### PR TITLE
Add TLSv1.2 packet labeling and detail decoding

### DIFF
--- a/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
+++ b/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
@@ -162,6 +162,228 @@ NSArray<PCPPNativeAddressDescriptor *> *MapAddresses(const pcpp::PcapLiveDevice 
     return addresses;
 }
 
+NSString *TLSVersionLabel(pcpp::SSLVersion version)
+{
+    switch (version.asEnum(true)) {
+        case pcpp::SSLVersion::SSL3:
+            return @"SSLv3.0";
+        case pcpp::SSLVersion::TLS1_0:
+            return @"TLSv1.0";
+        case pcpp::SSLVersion::TLS1_1:
+            return @"TLSv1.1";
+        case pcpp::SSLVersion::TLS1_2:
+            return @"TLSv1.2";
+        case pcpp::SSLVersion::TLS1_3:
+            return @"TLSv1.3";
+        case pcpp::SSLVersion::Unknown:
+        default:
+            return @"TLS";
+    }
+}
+
+pcpp::SSLVersion EffectiveTLSVersionForClientHello(pcpp::SSLClientHelloMessage *clientHelloMessage)
+{
+    if (auto *supportedVersions = clientHelloMessage->getExtensionOfType<pcpp::SSLSupportedVersionsExtension>()) {
+        std::optional<uint16_t> highestKnownVersion;
+        for (auto version : supportedVersions->getSupportedVersions()) {
+            if (version.asEnum(true) == pcpp::SSLVersion::Unknown) {
+                continue;
+            }
+
+            if (!highestKnownVersion.has_value() || version.asUInt() > highestKnownVersion.value()) {
+                highestKnownVersion = version.asUInt();
+            }
+        }
+
+        if (highestKnownVersion.has_value()) {
+            return pcpp::SSLVersion(highestKnownVersion.value());
+        }
+    }
+
+    return clientHelloMessage->getHandshakeVersion();
+}
+
+pcpp::SSLVersion EffectiveTLSVersion(pcpp::SSLLayer *sslLayer)
+{
+    if (auto *handshakeLayer = dynamic_cast<pcpp::SSLHandshakeLayer *>(sslLayer)) {
+        for (int index = 0; index < static_cast<int>(handshakeLayer->getHandshakeMessagesCount()); index += 1) {
+            auto *message = handshakeLayer->getHandshakeMessageAt(index);
+            if (auto *clientHelloMessage = dynamic_cast<pcpp::SSLClientHelloMessage *>(message)) {
+                return EffectiveTLSVersionForClientHello(clientHelloMessage);
+            }
+
+            if (auto *serverHelloMessage = dynamic_cast<pcpp::SSLServerHelloMessage *>(message)) {
+                return serverHelloMessage->getHandshakeVersion();
+            }
+        }
+    }
+
+    return sslLayer->getRecordVersion();
+}
+
+NSString *TLSLayerName(pcpp::SSLLayer *sslLayer)
+{
+    return TLSVersionLabel(EffectiveTLSVersion(sslLayer));
+}
+
+NSString *TLSVersionFieldValue(pcpp::SSLVersion version)
+{
+    return [NSString stringWithFormat:@"%@ (0x%04x)", TLSVersionLabel(version), version.asUInt()];
+}
+
+NSString *TLSRecordTypeName(pcpp::SSLRecordType recordType)
+{
+    switch (recordType) {
+        case pcpp::SSL_CHANGE_CIPHER_SPEC:
+            return @"Change Cipher Spec";
+        case pcpp::SSL_ALERT:
+            return @"Alert";
+        case pcpp::SSL_HANDSHAKE:
+            return @"Handshake";
+        case pcpp::SSL_APPLICATION_DATA:
+            return @"Application Data";
+        default:
+            return @"Unknown";
+    }
+}
+
+NSString *TLSRecordTypeFieldValue(pcpp::SSLRecordType recordType)
+{
+    return [NSString stringWithFormat:@"%@ (%u)", TLSRecordTypeName(recordType), static_cast<unsigned>(recordType)];
+}
+
+NSString *TLSHandshakeTypeName(pcpp::SSLHandshakeType handshakeType)
+{
+    switch (handshakeType) {
+        case pcpp::SSL_HELLO_REQUEST:
+            return @"Hello Request";
+        case pcpp::SSL_CLIENT_HELLO:
+            return @"Client Hello";
+        case pcpp::SSL_SERVER_HELLO:
+            return @"Server Hello";
+        case pcpp::SSL_NEW_SESSION_TICKET:
+            return @"New Session Ticket";
+        case pcpp::SSL_END_OF_EARLY_DATE:
+            return @"End Of Early Data";
+        case pcpp::SSL_ENCRYPTED_EXTENSIONS:
+            return @"Encrypted Extensions";
+        case pcpp::SSL_CERTIFICATE:
+            return @"Certificate";
+        case pcpp::SSL_SERVER_KEY_EXCHANGE:
+            return @"Server Key Exchange";
+        case pcpp::SSL_CERTIFICATE_REQUEST:
+            return @"Certificate Request";
+        case pcpp::SSL_SERVER_DONE:
+            return @"Server Hello Done";
+        case pcpp::SSL_CERTIFICATE_VERIFY:
+            return @"Certificate Verify";
+        case pcpp::SSL_CLIENT_KEY_EXCHANGE:
+            return @"Client Key Exchange";
+        case pcpp::SSL_FINISHED:
+            return @"Finished";
+        case pcpp::SSL_KEY_UPDATE:
+            return @"Key Update";
+        case pcpp::SSL_HANDSHAKE_UNKNOWN:
+        default:
+            return @"Unknown";
+    }
+}
+
+NSString *TLSHandshakeTypeFieldValue(pcpp::SSLHandshakeType handshakeType)
+{
+    return [NSString stringWithFormat:@"%@ (%u)", TLSHandshakeTypeName(handshakeType), static_cast<unsigned>(handshakeType)];
+}
+
+NSString *TLSSupportedVersionsSummary(pcpp::SSLSupportedVersionsExtension *supportedVersions)
+{
+    if (supportedVersions == nullptr) {
+        return nil;
+    }
+
+    NSMutableArray<NSString *> *versions = [NSMutableArray array];
+    for (auto version : supportedVersions->getSupportedVersions()) {
+        [versions addObject:TLSVersionLabel(version)];
+    }
+
+    if (versions.count == 0) {
+        return nil;
+    }
+
+    return [versions componentsJoinedByString:@", "];
+}
+
+NSString *TLSAlertLevelName(pcpp::SSLAlertLevel alertLevel)
+{
+    switch (alertLevel) {
+        case pcpp::SSL_ALERT_LEVEL_WARNING:
+            return @"Warning";
+        case pcpp::SSL_ALERT_LEVEL_FATAL:
+            return @"Fatal";
+        case pcpp::SSL_ALERT_LEVEL_ENCRYPTED:
+        default:
+            return @"Encrypted";
+    }
+}
+
+NSString *TLSAlertDescriptionName(pcpp::SSLAlertDescription alertDescription)
+{
+    switch (alertDescription) {
+        case pcpp::SSL_ALERT_CLOSE_NOTIFY:
+            return @"Close Notify";
+        case pcpp::SSL_ALERT_UNEXPECTED_MESSAGE:
+            return @"Unexpected Message";
+        case pcpp::SSL_ALERT_BAD_RECORD_MAC:
+            return @"Bad Record MAC";
+        case pcpp::SSL_ALERT_DECRYPTION_FAILED:
+            return @"Decryption Failed";
+        case pcpp::SSL_ALERT_RECORD_OVERFLOW:
+            return @"Record Overflow";
+        case pcpp::SSL_ALERT_DECOMPRESSION_FAILURE:
+            return @"Decompression Failure";
+        case pcpp::SSL_ALERT_HANDSHAKE_FAILURE:
+            return @"Handshake Failure";
+        case pcpp::SSL_ALERT_NO_CERTIFICATE:
+            return @"No Certificate";
+        case pcpp::SSL_ALERT_BAD_CERTIFICATE:
+            return @"Bad Certificate";
+        case pcpp::SSL_ALERT_UNSUPPORTED_CERTIFICATE:
+            return @"Unsupported Certificate";
+        case pcpp::SSL_ALERT_CERTIFICATE_REVOKED:
+            return @"Certificate Revoked";
+        case pcpp::SSL_ALERT_CERTIFICATE_EXPIRED:
+            return @"Certificate Expired";
+        case pcpp::SSL_ALERT_CERTIFICATE_UNKNOWN:
+            return @"Certificate Unknown";
+        case pcpp::SSL_ALERT_ILLEGAL_PARAMETER:
+            return @"Illegal Parameter";
+        case pcpp::SSL_ALERT_UNKNOWN_CA:
+            return @"Unknown CA";
+        case pcpp::SSL_ALERT_ACCESS_DENIED:
+            return @"Access Denied";
+        case pcpp::SSL_ALERT_DECODE_ERROR:
+            return @"Decode Error";
+        case pcpp::SSL_ALERT_DECRYPT_ERROR:
+            return @"Decrypt Error";
+        case pcpp::SSL_ALERT_EXPORT_RESTRICTION:
+            return @"Export Restriction";
+        case pcpp::SSL_ALERT_PROTOCOL_VERSION:
+            return @"Protocol Version";
+        case pcpp::SSL_ALERT_INSUFFICIENT_SECURITY:
+            return @"Insufficient Security";
+        case pcpp::SSL_ALERT_INTERNAL_ERROR:
+            return @"Internal Error";
+        case pcpp::SSL_ALERT_USER_CANCELLED:
+            return @"User Cancelled";
+        case pcpp::SSL_ALERT_NO_RENEGOTIATION:
+            return @"No Renegotiation";
+        case pcpp::SSL_ALERT_UNSUPPORTED_EXTENSION:
+            return @"Unsupported Extension";
+        case pcpp::SSL_ALERT_ENCRYPTED:
+        default:
+            return @"Encrypted";
+    }
+}
+
 PCPPNativeTransportHint MapTransportHint(const pcpp::Packet &packet)
 {
     if (packet.isPacketOfType(pcpp::HTTPRequest) || packet.isPacketOfType(pcpp::HTTPResponse)) {
@@ -203,7 +425,7 @@ PCPPNativeTransportHint MapTransportHint(const pcpp::Packet &packet)
     return PCPPNativeTransportHintUnknown;
 }
 
-NSString *LayerName(const pcpp::Layer &layer)
+NSString *LayerName(pcpp::Layer &layer)
 {
     switch (layer.getProtocol()) {
         case pcpp::Ethernet:
@@ -225,7 +447,7 @@ NSString *LayerName(const pcpp::Layer &layer)
         case pcpp::HTTPResponse:
             return @"HTTP Response";
         case pcpp::SSL:
-            return @"TLS";
+            return TLSLayerName(static_cast<pcpp::SSLLayer *>(&layer));
         case pcpp::GenericPayload:
             return @"Payload";
         default:
@@ -717,6 +939,26 @@ NSString *PayloadPreview(const uint8_t *bytes, size_t length, NSUInteger limit =
     return joined;
 }
 
+size_t TLSHandshakeDeclaredPayloadLength(const uint8_t *messageData, size_t messageLength)
+{
+    if (messageData == nullptr || messageLength < sizeof(pcpp::ssl_tls_handshake_layer)) {
+        return 0;
+    }
+
+    return (static_cast<size_t>(messageData[1]) << 16) |
+           (static_cast<size_t>(messageData[2]) << 8) |
+           static_cast<size_t>(messageData[3]);
+}
+
+NSString *TLSCipherSuiteFieldValue(uint16_t cipherSuiteID, pcpp::SSLCipherSuite *cipherSuite)
+{
+    if (cipherSuite == nullptr) {
+        return FormatHex16(cipherSuiteID);
+    }
+
+    return [NSString stringWithFormat:@"%@ (%@)", MakeNSString(cipherSuite->asString()), FormatHex16(cipherSuiteID)];
+}
+
 NSString *TCPFlagsSummary(const pcpp::tcphdr *header)
 {
     NSMutableArray<NSString *> *flags = [NSMutableArray array];
@@ -929,6 +1171,9 @@ private:
                 break;
             case pcpp::UDP:
                 appendUDP(static_cast<pcpp::UdpLayer *>(layer), offset, nodes);
+                break;
+            case pcpp::SSL:
+                appendTLS(static_cast<pcpp::SSLLayer *>(layer), offset, nodes);
                 break;
             case pcpp::GenericPayload:
                 appendPayload(static_cast<pcpp::PayloadLayer *>(layer), offset, nodes);
@@ -1160,6 +1405,245 @@ private:
                                        offset,
                                        udpLayer->getHeaderLen(),
                                        children)];
+    }
+
+    void appendTLS(pcpp::SSLLayer *sslLayer, NSUInteger offset, NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *nodes)
+    {
+        NSString *identifier = [NSString stringWithFormat:@"tls.%lu", static_cast<unsigned long>(offset)];
+        pcpp::SSLRecordType recordType = sslLayer->getRecordType();
+        uint16_t recordLength = ntohs(sslLayer->getRecordLayer()->length);
+        NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children = [NSMutableArray arrayWithArray:@[
+            MakeFieldNode([NSString stringWithFormat:@"%@.contentType", identifier],
+                          @"Content Type",
+                          TLSRecordTypeFieldValue(recordType),
+                          offset,
+                          0,
+                          1),
+            MakeFieldNode([NSString stringWithFormat:@"%@.version", identifier],
+                          @"Version",
+                          TLSVersionFieldValue(sslLayer->getRecordVersion()),
+                          offset,
+                          1,
+                          2),
+            MakeFieldNode([NSString stringWithFormat:@"%@.length", identifier],
+                          @"Length",
+                          [NSString stringWithFormat:@"%u bytes", recordLength],
+                          offset,
+                          3,
+                          2),
+        ]];
+
+        if (auto *handshakeLayer = dynamic_cast<pcpp::SSLHandshakeLayer *>(sslLayer)) {
+            appendTLSHandshake(handshakeLayer, offset, identifier, children);
+        } else if (auto *applicationDataLayer = dynamic_cast<pcpp::SSLApplicationDataLayer *>(sslLayer)) {
+            appendTLSApplicationData(applicationDataLayer, offset, identifier, children);
+        } else if (auto *alertLayer = dynamic_cast<pcpp::SSLAlertLayer *>(sslLayer)) {
+            appendTLSAlert(alertLayer, offset, identifier, children);
+        } else if (auto *changeCipherSpecLayer = dynamic_cast<pcpp::SSLChangeCipherSpecLayer *>(sslLayer)) {
+            appendTLSChangeCipherSpec(changeCipherSpecLayer, offset, identifier, children);
+        }
+
+        [nodes addObject:MakeLayerNode(identifier,
+                                       @"Transport Layer Security",
+                                       [NSString stringWithFormat:@"%@, %@", TLSLayerName(sslLayer), TLSRecordTypeName(recordType)],
+                                       offset,
+                                       sslLayer->getHeaderLen(),
+                                       children)];
+    }
+
+    void appendTLSHandshake(pcpp::SSLHandshakeLayer *handshakeLayer,
+                            NSUInteger offset,
+                            NSString *identifier,
+                            NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        // Decode the handshake records PcapPlusPlus exposes without attempting TLS decryption.
+        [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.handshake.count", identifier],
+                                                   @"Handshake Message Count",
+                                                   [NSString stringWithFormat:@"%zu", handshakeLayer->getHandshakeMessagesCount()])];
+
+        size_t messageRelativeOffset = sizeof(pcpp::ssl_tls_record_layer);
+        size_t layerLength = handshakeLayer->getHeaderLen();
+        for (int index = 0; index < static_cast<int>(handshakeLayer->getHandshakeMessagesCount()); index += 1) {
+            auto *message = handshakeLayer->getHandshakeMessageAt(index);
+            if (message == nullptr || messageRelativeOffset >= layerLength) {
+                break;
+            }
+
+            size_t messageLength = std::min(message->getMessageLength(), layerLength - messageRelativeOffset);
+            if (messageLength == 0) {
+                break;
+            }
+
+            NSUInteger messageOffset = offset + messageRelativeOffset;
+            const uint8_t *messageData = handshakeLayer->getData() + messageRelativeOffset;
+            NSString *messageIdentifier = [NSString stringWithFormat:@"%@.handshake.%d", identifier, index];
+            pcpp::SSLHandshakeType handshakeType = message->getHandshakeType();
+            NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *messageChildren = [NSMutableArray arrayWithArray:@[
+                MakeFieldNode([NSString stringWithFormat:@"%@.type", messageIdentifier],
+                              @"Handshake Type",
+                              TLSHandshakeTypeFieldValue(handshakeType),
+                              messageOffset,
+                              0,
+                              1),
+                MakeFieldNode([NSString stringWithFormat:@"%@.length", messageIdentifier],
+                              @"Length",
+                              [NSString stringWithFormat:@"%zu bytes", TLSHandshakeDeclaredPayloadLength(messageData, messageLength)],
+                              messageOffset,
+                              1,
+                              3),
+                MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.complete", messageIdentifier],
+                                       @"Complete",
+                                       message->isMessageComplete() ? @"Yes" : @"No"),
+            ]];
+
+            appendTLSHandshakeMessageMetadata(message, messageOffset, messageLength, messageIdentifier, messageChildren);
+            [children addObject:MakeDetailNode(messageIdentifier,
+                                               [NSString stringWithFormat:@"Handshake Protocol: %@", TLSHandshakeTypeName(handshakeType)],
+                                               MakeNSString(message->toString()),
+                                               @"field",
+                                               MakeByteRange(messageOffset, messageLength),
+                                               nil,
+                                               messageChildren)];
+            messageRelativeOffset += messageLength;
+        }
+    }
+
+    void appendTLSHandshakeMessageMetadata(pcpp::SSLHandshakeMessage *message,
+                                           NSUInteger messageOffset,
+                                           size_t messageLength,
+                                           NSString *messageIdentifier,
+                                           NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        if (auto *clientHelloMessage = dynamic_cast<pcpp::SSLClientHelloMessage *>(message)) {
+            if (messageLength >= sizeof(pcpp::ssl_tls_client_server_hello)) {
+                [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.handshakeVersion", messageIdentifier],
+                                                  @"Handshake Version",
+                                                  TLSVersionFieldValue(clientHelloMessage->getHandshakeVersion()),
+                                                  messageOffset,
+                                                  4,
+                                                  2)];
+            }
+            if (auto *sniExtension = clientHelloMessage->getExtensionOfType<pcpp::SSLServerNameIndicationExtension>()) {
+                NSString *hostName = NullableNSString(sniExtension->getHostName());
+                if (hostName != nil) {
+                    [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.sni", messageIdentifier],
+                                                               @"Server Name Indication",
+                                                               hostName)];
+                }
+            }
+            [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.cipherSuiteCount", messageIdentifier],
+                                                       @"Cipher Suites",
+                                                       [NSString stringWithFormat:@"%d", clientHelloMessage->getCipherSuiteCount()])];
+            [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.extensionCount", messageIdentifier],
+                                                       @"Extensions",
+                                                       [NSString stringWithFormat:@"%d", clientHelloMessage->getExtensionCount()])];
+            NSString *supportedVersions = TLSSupportedVersionsSummary(clientHelloMessage->getExtensionOfType<pcpp::SSLSupportedVersionsExtension>());
+            if (supportedVersions != nil) {
+                [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.supportedVersions", messageIdentifier],
+                                                           @"Supported Versions",
+                                                           supportedVersions)];
+            }
+            return;
+        }
+
+        if (auto *serverHelloMessage = dynamic_cast<pcpp::SSLServerHelloMessage *>(message)) {
+            if (messageLength >= sizeof(pcpp::ssl_tls_client_server_hello)) {
+                [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.handshakeVersion", messageIdentifier],
+                                                  @"Handshake Version",
+                                                  TLSVersionFieldValue(serverHelloMessage->getHandshakeVersion()),
+                                                  messageOffset,
+                                                  4,
+                                                  2)];
+            }
+
+            bool isValid = false;
+            uint16_t cipherSuiteID = serverHelloMessage->getCipherSuiteID(isValid);
+            if (isValid) {
+                [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.cipherSuite", messageIdentifier],
+                                                           @"Cipher Suite",
+                                                           TLSCipherSuiteFieldValue(cipherSuiteID, serverHelloMessage->getCipherSuite()))];
+            }
+            [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.extensionCount", messageIdentifier],
+                                                       @"Extensions",
+                                                       [NSString stringWithFormat:@"%d", serverHelloMessage->getExtensionCount()])];
+            NSString *supportedVersions = TLSSupportedVersionsSummary(serverHelloMessage->getExtensionOfType<pcpp::SSLSupportedVersionsExtension>());
+            if (supportedVersions != nil) {
+                [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.supportedVersions", messageIdentifier],
+                                                           @"Supported Versions",
+                                                           supportedVersions)];
+            }
+            return;
+        }
+
+        if (auto *certificateMessage = dynamic_cast<pcpp::SSLCertificateMessage *>(message)) {
+            [children addObject:MakeSyntheticFieldNode([NSString stringWithFormat:@"%@.certificateCount", messageIdentifier],
+                                                       @"Certificates",
+                                                       [NSString stringWithFormat:@"%d", certificateMessage->getNumOfCertificates()])];
+        }
+    }
+
+    void appendTLSApplicationData(pcpp::SSLApplicationDataLayer *applicationDataLayer,
+                                  NSUInteger offset,
+                                  NSString *identifier,
+                                  NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        size_t encryptedDataLength = applicationDataLayer->getEncryptedDataLen();
+        NSUInteger encryptedDataOffset = offset + sizeof(pcpp::ssl_tls_record_layer);
+        [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.encryptedData", identifier],
+                                          @"Encrypted Application Data",
+                                          [NSString stringWithFormat:@"%zu bytes", encryptedDataLength],
+                                          encryptedDataOffset,
+                                          0,
+                                          encryptedDataLength)];
+        [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.encryptedDataPreview", identifier],
+                                          @"Encrypted Data Preview",
+                                          PayloadPreview(applicationDataLayer->getEncryptedData(), encryptedDataLength),
+                                          encryptedDataOffset,
+                                          0,
+                                          encryptedDataLength)];
+    }
+
+    void appendTLSAlert(pcpp::SSLAlertLayer *alertLayer,
+                        NSUInteger offset,
+                        NSString *identifier,
+                        NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        if (alertLayer->getHeaderLen() > sizeof(pcpp::ssl_tls_record_layer)) {
+            pcpp::SSLAlertLevel alertLevel = alertLayer->getAlertLevel();
+            [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.alert.level", identifier],
+                                              @"Alert Level",
+                                              [NSString stringWithFormat:@"%@ (%u)", TLSAlertLevelName(alertLevel), static_cast<unsigned>(alertLevel)],
+                                              offset,
+                                              sizeof(pcpp::ssl_tls_record_layer),
+                                              1)];
+        }
+
+        if (alertLayer->getHeaderLen() > sizeof(pcpp::ssl_tls_record_layer) + 1) {
+            pcpp::SSLAlertDescription alertDescription = alertLayer->getAlertDescription();
+            [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.alert.description", identifier],
+                                              @"Alert Description",
+                                              [NSString stringWithFormat:@"%@ (%u)", TLSAlertDescriptionName(alertDescription), static_cast<unsigned>(alertDescription)],
+                                              offset,
+                                              sizeof(pcpp::ssl_tls_record_layer) + 1,
+                                              1)];
+        }
+    }
+
+    void appendTLSChangeCipherSpec(pcpp::SSLChangeCipherSpecLayer *changeCipherSpecLayer,
+                                   NSUInteger offset,
+                                   NSString *identifier,
+                                   NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        if (changeCipherSpecLayer->getHeaderLen() <= sizeof(pcpp::ssl_tls_record_layer)) {
+            return;
+        }
+
+        [children addObject:MakeFieldNode([NSString stringWithFormat:@"%@.changeCipherSpec", identifier],
+                                          @"Change Cipher Spec",
+                                          [NSString stringWithFormat:@"%u", changeCipherSpecLayer->getData()[sizeof(pcpp::ssl_tls_record_layer)]],
+                                          offset,
+                                          sizeof(pcpp::ssl_tls_record_layer),
+                                          1)];
     }
 
     void appendPayload(pcpp::PayloadLayer *payloadLayer, NSUInteger offset, NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *nodes)

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -124,6 +124,56 @@ struct InspectorPipelineTests {
         #expect(ipv6UDPChecksumStatus.value == "Illegal zero checksum")
     }
 
+    @Test func tlsClientHelloInspectionRendersVersionedSummaryAndDetail() async throws {
+        let fixtureURL = CoreFixtureCatalog.captureCategoryURL("tls").appendingPathComponent("SSL-ClientHello1.pcap")
+        let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: fixtureURL)
+        let packets = try await document.open()
+        let packet = try #require(packets.first { $0.transportHint == .tls })
+
+        #expect(packet.layers.contains { $0.name == "TLSv1.2" })
+
+        let inspection = try await document.inspectPacket(id: packet.id)
+        let tlsNode = try #require(inspection.detailNodes.first { $0.name == "Transport Layer Security" })
+        #expect(tlsNode.value?.contains("TLSv1.2") == true)
+        #expect(findNode(in: tlsNode.children, name: "Content Type")?.value?.contains("Handshake") == true)
+        #expect(findNode(in: tlsNode.children, name: "Version") != nil)
+        #expect(findNode(in: tlsNode.children, name: "Length") != nil)
+        #expect(findNode(in: tlsNode.children, name: "Handshake Protocol: Client Hello") != nil)
+        #expect(findNode(in: tlsNode.children, name: "Handshake Version")?.value?.contains("TLSv1.2") == true)
+        #expect(findNode(in: tlsNode.children, name: "Server Name Indication")?.value == "www.google.com")
+    }
+
+    @Test func tlsApplicationDataInspectionRendersRecordVersionsAndEncryptedData() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let captureURL = directory.appendingPathComponent("tls-application-data.pcap")
+        try writePCAP(
+            to: captureURL,
+            packets: [
+                makeIPv4TLSApplicationDataPacket(recordVersion: 0x0301),
+                makeIPv4TLSApplicationDataPacket(recordVersion: 0x0303),
+            ]
+        )
+
+        let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: captureURL)
+        let packets = try await document.open()
+        let firstPacket = try #require(packets.first)
+        let secondPacket = try #require(packets.dropFirst().first)
+
+        #expect(packets.map(\.transportHint) == [.tls, .tls])
+        #expect(firstPacket.layers.contains { $0.name == "TLSv1.0" })
+        #expect(secondPacket.layers.contains { $0.name == "TLSv1.2" })
+
+        let inspection = try await document.inspectPacket(id: secondPacket.id)
+        let tlsNode = try #require(inspection.detailNodes.first { $0.name == "Transport Layer Security" })
+        #expect(tlsNode.value == "TLSv1.2, Application Data")
+        #expect(findNode(in: tlsNode.children, name: "Content Type")?.value == "Application Data (23)")
+        #expect(findNode(in: tlsNode.children, name: "Version")?.value == "TLSv1.2 (0x0303)")
+        #expect(findNode(in: tlsNode.children, name: "Encrypted Application Data")?.value == "4 bytes")
+        #expect(findNode(in: tlsNode.children, name: "Encrypted Data Preview")?.value == "de ad be ef")
+    }
+
     @Test func tcpSynInspectionExpandsFlagsAndOptions() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -427,6 +477,36 @@ private func makeIPv4TCPPayloadPacket() -> Data {
     ])
 }
 
+private func makeIPv4TLSApplicationDataPacket(recordVersion: UInt16) -> Data {
+    let encryptedPayload: [UInt8] = [0xde, 0xad, 0xbe, 0xef]
+    let tlsRecordLength = 5 + encryptedPayload.count
+    let ipv4TotalLength = UInt16(20 + 20 + tlsRecordLength)
+    var packet = Data([
+        0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+        0x08, 0x00,
+        0x45, 0x00,
+    ])
+    packet.appendBigEndian(ipv4TotalLength)
+    packet.append(contentsOf: [
+        0x12, 0x37, 0x40, 0x00, 0x40, 0x06, 0x00, 0x00,
+        0xc0, 0xa8, 0x00, 0x01,
+        0xc0, 0xa8, 0x00, 0x02,
+    ])
+    packet.appendBigEndian(UInt16(54_321))
+    packet.appendBigEndian(UInt16(443))
+    packet.append(contentsOf: [
+        0x00, 0x00, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x01,
+        0x50, 0x18, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x17,
+    ])
+    packet.appendBigEndian(recordVersion)
+    packet.appendBigEndian(UInt16(encryptedPayload.count))
+    packet.append(contentsOf: encryptedPayload)
+    return packet
+}
+
 private func makeIPv4TCPSYNOptionsPacket() -> Data {
     Data([
         0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
@@ -496,10 +576,31 @@ private func findNode(in nodes: [PacketDetailNode], id: String) -> PacketDetailN
     return nil
 }
 
+private func findNode(in nodes: [PacketDetailNode], name: String) -> PacketDetailNode? {
+    for node in nodes {
+        if node.name == name {
+            return node
+        }
+
+        if let match = findNode(in: node.children, name: name) {
+            return match
+        }
+    }
+
+    return nil
+}
+
 private extension Data {
     mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
         var littleEndian = value.littleEndian
         Swift.withUnsafeBytes(of: &littleEndian) { buffer in
+            append(buffer.bindMemory(to: UInt8.self))
+        }
+    }
+
+    mutating func appendBigEndian<T: FixedWidthInteger>(_ value: T) {
+        var bigEndian = value.bigEndian
+        Swift.withUnsafeBytes(of: &bigEndian) { buffer in
             append(buffer.bindMemory(to: UInt8.self))
         }
     }

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -507,6 +507,15 @@ enum NetworkInspectorFormatters {
     }
 
     static func protocolLabel(for packet: PacketSummary) -> String {
+        if packet.transportHint == .tls {
+            return packet.layers.reversed()
+                .map(\.name)
+                .first { name in
+                    let uppercasedName = name.uppercased()
+                    return uppercasedName.hasPrefix("TLS") || uppercasedName.hasPrefix("SSL")
+                } ?? "TLS"
+        }
+
         if packet.transportHint != .unknown {
             return packet.transportHint.rawValue.uppercased()
         }

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -147,6 +147,19 @@ struct NetworkInspectorViewModelTests {
             transportHint: .udp,
             decodeStatus: PacketDecodeStatus(kind: .malformed, reason: "Bad length")
         )
+        let tls = makePacket(
+            packetNumber: 3,
+            source: .offline,
+            transportHint: .tls,
+            destinationPort: 443,
+            transportLayerName: "TLSv1.2"
+        )
+        let tlsFallback = makePacket(
+            packetNumber: 4,
+            source: .offline,
+            transportHint: .tls,
+            destinationPort: 443
+        )
 
         let healthyRow = PacketTableRow(packet: healthy)
         let malformedRow = PacketTableRow(packet: malformed)
@@ -157,8 +170,11 @@ struct NetworkInspectorViewModelTests {
         #expect(healthyRow.clientText == "Example")
         #expect(malformedRow.severity == .malformed)
         #expect(malformedRow.tags.map(\.label) == ["Malformed"])
+        #expect(PacketTableRow(packet: tls).protocolText == "TLSv1.2")
+        #expect(PacketTableRow(packet: tlsFallback).protocolText == "TLS")
 
         #expect(PacketDisplayFilter("protocol:http port:80").matches(healthy))
+        #expect(PacketDisplayFilter("protocol:TLSv1.2").matches(tls))
         #expect(PacketDisplayFilter("api.example.com").matches(healthy))
         #expect(PacketDisplayFilter("com.example.app").matches(healthy))
         #expect(PacketDisplayFilter("error:malformed").matches(malformed))
@@ -760,7 +776,8 @@ struct NetworkInspectorViewModelTests {
         decodeStatus: PacketDecodeStatus = PacketDecodeStatus(kind: .complete),
         sniDomainName: String? = nil,
         client: PacketClient? = nil,
-        transportDetailSummary: String? = nil
+        transportDetailSummary: String? = nil,
+        transportLayerName: String? = nil
     ) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,
@@ -778,7 +795,7 @@ struct NetworkInspectorViewModelTests {
             infoSummary: "Packet \(packetNumber)",
             layers: [
                 PacketLayer(name: "Ethernet"),
-                PacketLayer(name: transportHint.rawValue.uppercased(), detailSummary: transportDetailSummary),
+                PacketLayer(name: transportLayerName ?? transportHint.rawValue.uppercased(), detailSummary: transportDetailSummary),
             ],
             decodeStatus: decodeStatus,
             captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),


### PR DESCRIPTION
## Summary
- Add version-aware TLS labeling in the native bridge and surface `Transport Layer Security` detail nodes for handshake, application data, alert, and change-cipher-spec records.
- Prefer handshake versions and supported-versions data when available so TLS packets render as `TLSv1.0` through `TLSv1.3` instead of a generic `TLS` label.
- Extend inspector and formatter coverage with TLS ClientHello and TLS application-data tests.

## Testing
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme PcapPlusPlusCore -destination 'platform=macOS'`