### PR TITLE
Refactor live capture to disk-backed storage

### DIFF
--- a/PcapPlusPlusCore/Models/CoreProtocols.swift
+++ b/PcapPlusPlusCore/Models/CoreProtocols.swift
@@ -4,6 +4,23 @@ public typealias TCPViewerCompletion<Value> = (Result<Value, Error>) -> Void
 public typealias TCPViewerVoidCompletion = (Result<Void, Error>) -> Void
 public typealias PacketIngestEventHandler = (Result<PacketIngestEvent, Error>) -> Void
 
+#if DEBUG
+public struct LiveCaptureSessionDebugSnapshot: Equatable, Sendable {
+    public let pendingBatchCount: Int
+    public let activeRunPacketCount: UInt64
+
+    public static let empty = LiveCaptureSessionDebugSnapshot(
+        pendingBatchCount: 0,
+        activeRunPacketCount: 0
+    )
+
+    public init(pendingBatchCount: Int, activeRunPacketCount: UInt64) {
+        self.pendingBatchCount = pendingBatchCount
+        self.activeRunPacketCount = activeRunPacketCount
+    }
+}
+#endif
+
 public protocol CaptureInterfaceProviding {
     func listInterfaces(completion: @escaping TCPViewerCompletion<[CaptureInterfaceSummary]>)
 }
@@ -21,7 +38,18 @@ public protocol LiveCaptureSessionProviding: AnyObject {
     func stop(completion: @escaping TCPViewerVoidCompletion)
     func inspectPacket(id: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>)
     func healthSnapshot(completion: @escaping (CaptureHealthSnapshot) -> Void)
+    #if DEBUG
+    func debugMemorySnapshot() -> LiveCaptureSessionDebugSnapshot
+    #endif
 }
+
+#if DEBUG
+public extension LiveCaptureSessionProviding {
+    func debugMemorySnapshot() -> LiveCaptureSessionDebugSnapshot {
+        .empty
+    }
+}
+#endif
 
 public protocol OfflineCaptureDocumentProviding: AnyObject {
     var eventHandler: PacketIngestEventHandler? { get set }

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
@@ -447,6 +447,61 @@ enum NativeBridgeMapper {
     }
 }
 
+#if DEBUG
+struct NativeLivePacketDiskStoreSnapshot: Equatable {
+    let packetCount: Int
+    let backingFileSize: UInt64
+    let backingFileExists: Bool
+    let backingFilePath: String
+}
+
+final class NativeLivePacketDiskStoreTestHarness {
+    private let probe: PCPPNativeLivePacketStoreTestProbe
+
+    init() {
+        self.probe = PCPPNativeLivePacketStoreTestProbe()
+    }
+
+    var snapshot: NativeLivePacketDiskStoreSnapshot {
+        NativeLivePacketDiskStoreSnapshot(
+            packetCount: Int(probe.packetCount),
+            backingFileSize: UInt64(probe.backingFileSize),
+            backingFileExists: probe.backingFileExists,
+            backingFilePath: probe.backingFilePath
+        )
+    }
+
+    // Append synthetic packet bytes through the same native disk store used by live capture.
+    func appendPacket(
+        identifier: UInt64,
+        rawBytes: Data,
+        timestamp: Date,
+        linkLayerType: Int = 1,
+        originalLength: Int? = nil
+    ) throws {
+        try probe.appendPacket(
+            identifier: identifier,
+            rawBytes: rawBytes,
+            timestamp: timestamp,
+            linkLayerType: linkLayerType,
+            originalLength: originalLength ?? rawBytes.count
+        )
+    }
+
+    func inspectPacket(identifier: UInt64) throws -> PacketInspection {
+        try NativeBridgeMapper.packetInspection(probe.inspectPacket(identifier: identifier))
+    }
+
+    func offset(identifier: UInt64) throws -> UInt64 {
+        try probe.offset(identifier: identifier).uint64Value
+    }
+
+    func cleanup() {
+        probe.cleanup()
+    }
+}
+#endif
+
 extension CaptureOptions {
     func normalizedForLiveCapture() -> CaptureOptions {
         let normalizedFileWriting: CaptureFileWriting

--- a/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.h
+++ b/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.h
@@ -400,6 +400,33 @@ typedef BOOL (^PCPPNativeCancellationHandler)(void);
 
 @end
 
+#if DEBUG
+
+@interface PCPPNativeLivePacketStoreTestProbe : NSObject
+
+@property (nonatomic, readonly) NSUInteger packetCount;
+@property (nonatomic, readonly) unsigned long long backingFileSize;
+@property (nonatomic, readonly) BOOL backingFileExists;
+@property (nonatomic, copy, readonly) NSString *backingFilePath;
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (BOOL)appendPacketWithIdentifier:(unsigned long long)identifier
+                           rawBytes:(NSData *)rawBytes
+                          timestamp:(NSDate *)timestamp
+                      linkLayerType:(NSInteger)linkLayerType
+                     originalLength:(NSInteger)originalLength
+                              error:(NSError **)error NS_SWIFT_NAME(appendPacket(identifier:rawBytes:timestamp:linkLayerType:originalLength:));
+- (nullable PCPPNativePacketInspectionDescriptor *)inspectPacketWithIdentifier:(unsigned long long)identifier
+                                                                         error:(NSError **)error NS_SWIFT_NAME(inspectPacket(identifier:));
+- (nullable NSNumber *)offsetForPacketWithIdentifier:(unsigned long long)identifier
+                                               error:(NSError **)error NS_SWIFT_NAME(offset(identifier:));
+- (void)cleanup;
+
+@end
+
+#endif
+
 @interface PCPPNativeCore : NSObject
 
 - (NSArray<PCPPNativeInterfaceDescriptor *> *)discoverInterfacesAndReturnError:(NSError **)error;

--- a/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
+++ b/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
@@ -1412,6 +1412,8 @@ private:
         if (file_ == nullptr) {
             throw std::runtime_error("Failed to open the live capture backing store.");
         }
+
+        NSLog(@"[TCPViewer] 🗂️ Live capture temp packet store created: %@", MakeNSString(filePath_.string()));
     }
 
     uint64_t currentOffset()

--- a/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
+++ b/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
@@ -1258,6 +1258,194 @@ struct StoredPacket {
     std::string packetComment;
 };
 
+struct LivePacketDiskRecord {
+    unsigned long long identifier = 0;
+    uint64_t offset = 0;
+    int capturedLength = 0;
+    int originalLength = 0;
+    timespec timestamp{};
+    pcpp::LinkLayerType linkLayerType = pcpp::LINKTYPE_ETHERNET;
+};
+
+NSError *MakeFileError(TCPViewerNativeErrorCode code, const std::string &message)
+{
+    return MakeError(code, MakeNSString(message));
+}
+
+pcpp::LinkLayerType LinkLayerTypeFromInteger(NSInteger linkLayerType)
+{
+    if (pcpp::RawPacket::isLinkTypeValid(static_cast<int>(linkLayerType))) {
+        return static_cast<pcpp::LinkLayerType>(linkLayerType);
+    }
+
+    return pcpp::LINKTYPE_ETHERNET;
+}
+
+class LivePacketDiskStore {
+public:
+    LivePacketDiskStore()
+        : filePath_(makeTemporaryFilePath()) {}
+
+    ~LivePacketDiskStore()
+    {
+        clear();
+    }
+
+    void append(const pcpp::RawPacket &packet, unsigned long long identifier)
+    {
+        ensureFileOpen();
+
+        const auto offset = currentOffset();
+        const int capturedLength = packet.getRawDataLen();
+        if (capturedLength > 0) {
+            const auto bytesWritten = ::fwrite(packet.getRawData(), 1, static_cast<size_t>(capturedLength), file_);
+            if (bytesWritten != static_cast<size_t>(capturedLength)) {
+                throw std::runtime_error("Failed to write packet bytes into the live capture backing store.");
+            }
+        }
+
+        index_.push_back({
+            identifier,
+            offset,
+            capturedLength,
+            packet.getFrameLength(),
+            packet.getPacketTimeStamp(),
+            packet.getLinkLayerType(),
+        });
+    }
+
+    std::unique_ptr<pcpp::RawPacket> packet(unsigned long long identifier)
+    {
+        const auto *record = recordForIdentifier(identifier);
+        if (record == nullptr) {
+            throw std::out_of_range("TCP Viewer could not find that packet in the live capture backing store.");
+        }
+
+        flushPendingWrites();
+        if (::fseeko(file_, static_cast<off_t>(record->offset), SEEK_SET) != 0) {
+            throw std::runtime_error("Failed to seek to packet bytes in the live capture backing store.");
+        }
+
+        auto bytes = std::make_unique<uint8_t[]>(static_cast<size_t>(record->capturedLength));
+        if (record->capturedLength > 0) {
+            const auto bytesRead = ::fread(bytes.get(), 1, static_cast<size_t>(record->capturedLength), file_);
+            if (bytesRead != static_cast<size_t>(record->capturedLength)) {
+                throw std::runtime_error("Failed to read packet bytes from the live capture backing store.");
+            }
+        }
+
+        auto packet = std::make_unique<pcpp::RawPacket>();
+        if (!packet->setRawData(bytes.get(),
+                                record->capturedLength,
+                                record->timestamp,
+                                record->linkLayerType,
+                                record->originalLength)) {
+            throw std::runtime_error("Failed to rebuild a packet from the live capture backing store.");
+        }
+
+        bytes.release();
+        return packet;
+    }
+
+    uint64_t offset(unsigned long long identifier) const
+    {
+        const auto *record = recordForIdentifier(identifier);
+        if (record == nullptr) {
+            throw std::out_of_range("TCP Viewer could not find that packet in the live capture backing store.");
+        }
+
+        return record->offset;
+    }
+
+    size_t count() const
+    {
+        return index_.size();
+    }
+
+    uint64_t fileSize()
+    {
+        flushPendingWrites();
+        if (!std::filesystem::exists(filePath_)) {
+            return 0;
+        }
+
+        return static_cast<uint64_t>(std::filesystem::file_size(filePath_));
+    }
+
+    const std::filesystem::path &filePath() const
+    {
+        return filePath_;
+    }
+
+    bool fileExists() const
+    {
+        return std::filesystem::exists(filePath_);
+    }
+
+    void clear()
+    {
+        if (file_ != nullptr) {
+            ::fclose(file_);
+            file_ = nullptr;
+        }
+
+        std::error_code error;
+        std::filesystem::remove(filePath_, error);
+        index_.clear();
+    }
+
+private:
+    static std::filesystem::path makeTemporaryFilePath()
+    {
+        NSString *fileName = [NSString stringWithFormat:@"TCPViewerLiveCapture-%@.pktstore", NSUUID.UUID.UUIDString];
+        NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
+        return std::filesystem::path(MakeStdString(path));
+    }
+
+    void ensureFileOpen()
+    {
+        if (file_ != nullptr) {
+            return;
+        }
+
+        file_ = ::fopen(filePath_.string().c_str(), "w+b");
+        if (file_ == nullptr) {
+            throw std::runtime_error("Failed to open the live capture backing store.");
+        }
+    }
+
+    uint64_t currentOffset()
+    {
+        const off_t offset = ::ftello(file_);
+        if (offset < 0) {
+            throw std::runtime_error("Failed to determine the live capture backing store offset.");
+        }
+
+        return static_cast<uint64_t>(offset);
+    }
+
+    void flushPendingWrites()
+    {
+        if (file_ != nullptr && ::fflush(file_) != 0) {
+            throw std::runtime_error("Failed to flush the live capture backing store.");
+        }
+    }
+
+    const LivePacketDiskRecord *recordForIdentifier(unsigned long long identifier) const
+    {
+        if (identifier == 0 || identifier > index_.size()) {
+            return nullptr;
+        }
+
+        const auto &record = index_[static_cast<size_t>(identifier - 1)];
+        return record.identifier == identifier ? &record : nullptr;
+    }
+
+    std::filesystem::path filePath_;
+    FILE *file_ = nullptr;
+    std::vector<LivePacketDiskRecord> index_;
+};
+
 class CaptureFileWriter {
 public:
     CaptureFileWriter(const std::string &mode,
@@ -1400,7 +1588,7 @@ public:
     unsigned long long packetsReceived = 0;
     unsigned long long packetsDropped = 0;
     unsigned long long packetsDroppedByInterface = 0;
-    std::vector<StoredPacket> packets;
+    LivePacketDiskStore packetStore;
     NSString *statusMessage = @"Live capture is ready.";
     PCPPNativeLiveSessionPhase phase = PCPPNativeLiveSessionPhaseReady;
     CaptureFileWriter writer_;
@@ -1793,38 +1981,40 @@ PCPPNativeCaptureHealthDescriptor *MakeHealthDescriptor(const LiveCaptureState &
 
 static void OnLivePacketArrives(pcpp::RawPacket *rawPacket, pcpp::PcapLiveDevice *, void *userCookie)
 {
-    auto *session = (__bridge PCPPNativeLiveSession *)userCookie;
-    std::lock_guard<std::mutex> lock(session->_state->mutex);
+    @autoreleasepool {
+        auto *session = (__bridge PCPPNativeLiveSession *)userCookie;
+        std::lock_guard<std::mutex> lock(session->_state->mutex);
 
-    auto clonedPacket = std::unique_ptr<pcpp::RawPacket>(rawPacket->clone());
-    session->_state->packetsObserved += 1;
-    session->_state->packets.push_back({std::move(clonedPacket), ""});
+        try {
+            const unsigned long long packetIdentifier = session->_state->nextPacketIdentifier;
+            session->_state->packetsObserved += 1;
 
-    auto *summary = MakePacketSummary(*session->_state->packets.back().rawPacket,
-                                      session->_state->nextPacketIdentifier,
-                                      session->_state->interfaceIdentifier_,
-                                      session->_state->device == nullptr ? nil : MakeNSString(session->_state->device->getName()),
-                                      nil,
-                                      session->_state->sniReassembly.get());
-//    NSLog(@"TCPViewer captured live packet #%llu on %@ (%d/%d bytes, observed=%llu)",
-//          summary.packetNumber,
-//          summary.captureMetadata.interfaceName ?: session->_state->interfaceIdentifier_,
-//          rawPacket->getRawDataLen(),
-//          rawPacket->getFrameLength(),
-//          session->_state->packetsObserved);
-    session->_state->nextPacketIdentifier += 1;
+            auto *summary = MakePacketSummary(*rawPacket,
+                                              packetIdentifier,
+                                              session->_state->interfaceIdentifier_,
+                                              session->_state->device == nullptr ? nil : MakeNSString(session->_state->device->getName()),
+                                              nil,
+                                              session->_state->sniReassembly.get());
+            session->_state->packetStore.append(*rawPacket, packetIdentifier);
+            session->_state->nextPacketIdentifier += 1;
 
-    try {
-        session->_state->writer_.writePacket(*session->_state->packets.back().rawPacket, nil);
-    } catch (const std::exception &exception) {
-        if (session.errorHandler != nil) {
-            session.errorHandler(MakeError(TCPViewerNativeErrorCodeFileWriteFailed, MakeNSString(exception.what())));
+            try {
+                session->_state->writer_.writePacket(*rawPacket, nil);
+            } catch (const std::exception &exception) {
+                if (session.errorHandler != nil) {
+                    session.errorHandler(MakeError(TCPViewerNativeErrorCodeFileWriteFailed, MakeNSString(exception.what())));
+                }
+            }
+
+            session->_state->statusMessage = @"Capturing live packets.";
+            if (session.packetHandler != nil) {
+                session.packetHandler(@[summary]);
+            }
+        } catch (const std::exception &exception) {
+            if (session.errorHandler != nil) {
+                session.errorHandler(MakeError(TCPViewerNativeErrorCodeFileWriteFailed, MakeNSString(exception.what())));
+            }
         }
-    }
-
-    session->_state->statusMessage = @"Capturing live packets.";
-    if (session.packetHandler != nil) {
-        session.packetHandler(@[summary]);
     }
 }
 
@@ -1895,7 +2085,7 @@ static void OnLiveStatsUpdate(pcpp::IPcapDevice::PcapStats &stats, void *userCoo
         }
 
         if (_state->phase == PCPPNativeLiveSessionPhaseStopped) {
-            _state->packets.clear();
+            _state->packetStore.clear();
             _state->packetsObserved = 0;
             _state->packetsReceived = 0;
             _state->packetsDropped = 0;
@@ -2092,16 +2282,16 @@ static void OnLiveStatsUpdate(pcpp::IPcapDevice::PcapStats &stats, void *userCoo
 
     {
         std::lock_guard<std::mutex> lock(_state->mutex);
-        if (identifier == 0 || identifier > _state->packets.size()) {
+        try {
+            rawPacket = _state->packetStore.packet(identifier);
+            if (_state->device != nullptr) {
+                interfaceName = MakeNSString(_state->device->getName());
+            }
+        } catch (const std::exception &exception) {
             if (error != nullptr) {
-                *error = MakeError(TCPViewerNativeErrorCodeFileReadFailed, @"TCP Viewer could not find that packet in the live session.");
+                *error = MakeError(TCPViewerNativeErrorCodeFileReadFailed, MakeNSString(exception.what()));
             }
             return nil;
-        }
-
-        rawPacket = std::unique_ptr<pcpp::RawPacket>(_state->packets[identifier - 1].rawPacket->clone());
-        if (_state->device != nullptr) {
-            interfaceName = MakeNSString(_state->device->getName());
         }
     }
 
@@ -2115,6 +2305,159 @@ static void OnLiveStatsUpdate(pcpp::IPcapDevice::PcapStats &stats, void *userCoo
 }
 
 @end
+
+#if DEBUG
+
+@interface PCPPNativeLivePacketStoreTestProbe () {
+@private
+    std::unique_ptr<LivePacketDiskStore> _store;
+}
+
+@end
+
+@implementation PCPPNativeLivePacketStoreTestProbe
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    _store = std::make_unique<LivePacketDiskStore>();
+
+    return self;
+}
+
+- (NSUInteger)packetCount
+{
+    return _store == nullptr ? 0 : static_cast<NSUInteger>(_store->count());
+}
+
+- (unsigned long long)backingFileSize
+{
+    if (_store == nullptr) {
+        return 0;
+    }
+
+    try {
+        return _store->fileSize();
+    } catch (const std::exception &) {
+        return 0;
+    }
+}
+
+- (BOOL)backingFileExists
+{
+    return _store != nullptr && _store->fileExists();
+}
+
+- (NSString *)backingFilePath
+{
+    if (_store == nullptr) {
+        return @"";
+    }
+
+    return MakeNSString(_store->filePath().string());
+}
+
+- (BOOL)appendPacketWithIdentifier:(unsigned long long)identifier
+                           rawBytes:(NSData *)rawBytes
+                          timestamp:(NSDate *)timestamp
+                      linkLayerType:(NSInteger)linkLayerType
+                     originalLength:(NSInteger)originalLength
+                              error:(NSError **)error
+{
+    if (_store == nullptr) {
+        if (error != nullptr) {
+            *error = MakeError(TCPViewerNativeErrorCodeFileWriteFailed, @"The live packet backing store is not available.");
+        }
+        return NO;
+    }
+
+    timespec packetTimestamp{};
+    NSTimeInterval seconds = timestamp.timeIntervalSince1970;
+    packetTimestamp.tv_sec = static_cast<time_t>(seconds);
+    packetTimestamp.tv_nsec = static_cast<long>((seconds - static_cast<NSTimeInterval>(packetTimestamp.tv_sec)) * 1'000'000'000.0);
+
+    try {
+        auto bytes = std::make_unique<uint8_t[]>(static_cast<size_t>(rawBytes.length));
+        if (rawBytes.length > 0) {
+            std::memcpy(bytes.get(), rawBytes.bytes, static_cast<size_t>(rawBytes.length));
+        }
+
+        pcpp::RawPacket packet;
+        if (!packet.setRawData(bytes.get(),
+                               static_cast<int>(rawBytes.length),
+                               packetTimestamp,
+                               LinkLayerTypeFromInteger(linkLayerType),
+                               static_cast<int>(originalLength))) {
+            if (error != nullptr) {
+                *error = MakeError(TCPViewerNativeErrorCodeFileWriteFailed, @"The test packet bytes could not be prepared.");
+            }
+            return NO;
+        }
+
+        bytes.release();
+        _store->append(packet, identifier);
+        return YES;
+    } catch (const std::exception &exception) {
+        if (error != nullptr) {
+            *error = MakeFileError(TCPViewerNativeErrorCodeFileWriteFailed, exception.what());
+        }
+        return NO;
+    }
+}
+
+- (PCPPNativePacketInspectionDescriptor *)inspectPacketWithIdentifier:(unsigned long long)identifier error:(NSError **)error
+{
+    if (_store == nullptr) {
+        if (error != nullptr) {
+            *error = MakeError(TCPViewerNativeErrorCodeFileReadFailed, @"The live packet backing store is not available.");
+        }
+        return nil;
+    }
+
+    try {
+        auto packet = _store->packet(identifier);
+        return MakePacketInspection(*packet, identifier, nil, nil);
+    } catch (const std::exception &exception) {
+        if (error != nullptr) {
+            *error = MakeFileError(TCPViewerNativeErrorCodeFileReadFailed, exception.what());
+        }
+        return nil;
+    }
+}
+
+- (NSNumber *)offsetForPacketWithIdentifier:(unsigned long long)identifier error:(NSError **)error
+{
+    if (_store == nullptr) {
+        if (error != nullptr) {
+            *error = MakeError(TCPViewerNativeErrorCodeFileReadFailed, @"The live packet backing store is not available.");
+        }
+        return nil;
+    }
+
+    try {
+        return @(_store->offset(identifier));
+    } catch (const std::exception &exception) {
+        if (error != nullptr) {
+            *error = MakeFileError(TCPViewerNativeErrorCodeFileReadFailed, exception.what());
+        }
+        return nil;
+    }
+}
+
+- (void)cleanup
+{
+    if (_store != nullptr) {
+        _store->clear();
+    }
+}
+
+@end
+
+#endif
 
 namespace {
 
@@ -2401,48 +2744,50 @@ NSArray<PCPPNativePacketSummaryDescriptor *> *LoadPacketsFromURLIncrementally(Of
 
     try {
         while (true) {
-            if (cancellationCheck != nil && cancellationCheck()) {
-                wasCancelled = true;
-                break;
-            }
+            @autoreleasepool {
+                if (cancellationCheck != nil && cancellationCheck()) {
+                    wasCancelled = true;
+                    break;
+                }
 
-            pcpp::RawPacket rawPacket;
-            std::string packetComment;
-            bool didReadPacket = false;
+                pcpp::RawPacket rawPacket;
+                std::string packetComment;
+                bool didReadPacket = false;
 
-            if (auto *pcapngReader = dynamic_cast<pcpp::PcapNgFileReaderDevice *>(reader.get())) {
-                didReadPacket = pcapngReader->getNextPacket(rawPacket, packetComment);
-            } else {
-                didReadPacket = reader->getNextPacket(rawPacket);
-            }
+                if (auto *pcapngReader = dynamic_cast<pcpp::PcapNgFileReaderDevice *>(reader.get())) {
+                    didReadPacket = pcapngReader->getNextPacket(rawPacket, packetComment);
+                } else {
+                    didReadPacket = reader->getNextPacket(rawPacket);
+                }
 
-            if (!didReadPacket) {
-                break;
-            }
+                if (!didReadPacket) {
+                    break;
+                }
 
-            auto *summary = MakePacketSummary(rawPacket,
-                                              identifier,
-                                              nil,
-                                              nil,
-                                              NullableNSString(packetComment),
-                                              &sniReassembly);
-            {
-                std::lock_guard<std::mutex> lock(state.mutex);
-                state.packets.push_back({std::make_unique<pcpp::RawPacket>(rawPacket), packetComment});
-            }
+                auto *summary = MakePacketSummary(rawPacket,
+                                                  identifier,
+                                                  nil,
+                                                  nil,
+                                                  NullableNSString(packetComment),
+                                                  &sniReassembly);
+                {
+                    std::lock_guard<std::mutex> lock(state.mutex);
+                    state.packets.push_back({std::make_unique<pcpp::RawPacket>(rawPacket), packetComment});
+                }
 
-            [packets addObject:summary];
-            [pendingBatch addObject:summary];
-            processedBytes += static_cast<uint64_t>(rawPacket.getRawDataLen());
-            identifier += 1;
+                [packets addObject:summary];
+                [pendingBatch addObject:summary];
+                processedBytes += static_cast<uint64_t>(rawPacket.getRawDataLen());
+                identifier += 1;
 
-            if (pendingBatch.count >= effectiveBatchSize) {
-                flushPendingBatch();
-                emitProgress(@"loading",
-                             packets.count,
-                             processedBytes,
-                             false,
-                             [NSString stringWithFormat:@"Loaded %lu packets from %@…", (unsigned long)packets.count, fileName]);
+                if (pendingBatch.count >= effectiveBatchSize) {
+                    flushPendingBatch();
+                    emitProgress(@"loading",
+                                 packets.count,
+                                 processedBytes,
+                                 false,
+                                 [NSString stringWithFormat:@"Loaded %lu packets from %@…", (unsigned long)packets.count, fileName]);
+                }
             }
         }
     } catch (const std::exception &exception) {

--- a/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
+++ b/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
@@ -41,6 +41,12 @@ public final class NativeLiveCaptureSession: LiveCaptureSessionProviding, @unche
     public func healthSnapshot(completion: @escaping (CaptureHealthSnapshot) -> Void) {
         state.healthSnapshot(completion: completion)
     }
+
+    #if DEBUG
+    public func debugMemorySnapshot() -> LiveCaptureSessionDebugSnapshot {
+        state.debugMemorySnapshot()
+    }
+    #endif
 }
 
 struct LivePacketBatchBuffer<Element: Sendable>: Sendable {
@@ -53,6 +59,10 @@ struct LivePacketBatchBuffer<Element: Sendable>: Sendable {
 
     var isEmpty: Bool {
         pendingElements.isEmpty
+    }
+
+    var pendingCount: Int {
+        pendingElements.count
     }
 
     mutating func append(_ elements: [Element]) -> [Element]? {
@@ -76,6 +86,10 @@ struct LivePacketBatchBuffer<Element: Sendable>: Sendable {
         let elements = pendingElements
         pendingElements.removeAll(keepingCapacity: true)
         return elements
+    }
+
+    mutating func discardPending(releasingCapacity: Bool) {
+        pendingElements.removeAll(keepingCapacity: !releasingCapacity)
     }
 }
 
@@ -185,13 +199,24 @@ private final class NativeLiveCaptureSessionState: @unchecked Sendable {
         }
     }
 
+    #if DEBUG
+    func debugMemorySnapshot() -> LiveCaptureSessionDebugSnapshot {
+        queue.sync {
+            LiveCaptureSessionDebugSnapshot(
+                pendingBatchCount: packetBatchBuffer.pendingCount,
+                activeRunPacketCount: activeRunPacketCount
+            )
+        }
+    }
+    #endif
+
     private func startOnQueue() throws {
         cancelDurationStopWorkItem()
         if phase == .stopped || phase == .failed || phase == .ready {
             activeRunPacketCount = 0
             startedAt = Date()
             cancelPacketBatchFlushWorkItem()
-            _ = packetBatchBuffer.flush()
+            packetBatchBuffer.discardPending(releasingCapacity: true)
         }
 
         do {

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -54,6 +54,12 @@ struct InspectorPipelineTests {
         #expect(buffer.append([6]) == nil)
         #expect(buffer.flush() == [6])
         #expect(buffer.flush() == nil)
+
+        #expect(buffer.append([7, 8]) == nil)
+        #expect(buffer.pendingCount == 2)
+        buffer.discardPending(releasingCapacity: true)
+        #expect(buffer.isEmpty)
+        #expect(buffer.flush() == nil)
     }
 
     @Test func generatedCaptureInspectionCoversCoreProtocolsAndExactByteRanges() async throws {

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 @testable import PcapPlusPlusCore
@@ -286,6 +287,102 @@ struct InspectorPipelineTests {
             #expect(error.code == .offlineFileSaveFailed)
         }
     }
+
+    #if DEBUG
+    @Test func livePacketDiskStoreAppendsInspectsAndCleansUpLargeCounts() throws {
+        let harness = NativeLivePacketDiskStoreTestHarness()
+        let packet = makeIPv4UDPPayloadPacket()
+        let checkpoints = [10_000, 50_000, 100_000]
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        var lastCheckpoint = 0
+
+        for checkpoint in checkpoints {
+            for packetNumber in (lastCheckpoint + 1)...checkpoint {
+                try harness.appendPacket(
+                    identifier: UInt64(packetNumber),
+                    rawBytes: packet,
+                    timestamp: timestamp.addingTimeInterval(TimeInterval(packetNumber))
+                )
+            }
+
+            let snapshot = harness.snapshot
+            #expect(snapshot.packetCount == checkpoint)
+            #expect(snapshot.backingFileExists)
+            #expect(snapshot.backingFileSize == UInt64(packet.count * checkpoint))
+            #expect(try harness.offset(identifier: 1) == 0)
+            #expect(try harness.offset(identifier: UInt64(checkpoint)) == UInt64(packet.count * (checkpoint - 1)))
+            lastCheckpoint = checkpoint
+        }
+
+        for identifier in [UInt64(1), 50_000, 100_000] {
+            let inspection = try harness.inspectPacket(identifier: identifier)
+            #expect(inspection.packetID == identifier)
+            #expect(inspection.rawBytes == packet)
+            #expect(inspection.detailNodes.map(\.name).contains("UDP"))
+        }
+
+        do {
+            _ = try harness.inspectPacket(identifier: 100_001)
+            Issue.record("Expected a missing packet identifier to fail.")
+        } catch {
+            #expect(String(describing: error).contains("backing store"))
+        }
+
+        let backingFilePath = harness.snapshot.backingFilePath
+        #expect(FileManager.default.fileExists(atPath: backingFilePath))
+
+        harness.cleanup()
+
+        #expect(!FileManager.default.fileExists(atPath: backingFilePath))
+        #expect(harness.snapshot.packetCount == 0)
+        #expect(!harness.snapshot.backingFileExists)
+    }
+
+    @Test func livePacketDiskStoreRSSStressIsGated() throws {
+        guard ProcessInfo.processInfo.environment["TCPVIEWER_RUN_MEMORY_STRESS"] == "1" else {
+            return
+        }
+
+        let harness = NativeLivePacketDiskStoreTestHarness()
+        let packet = makePaddedPacket(base: makeIPv4UDPPayloadPacket(), byteCount: 2_048)
+        let timestamp = Date(timeIntervalSince1970: 1_700_100_000)
+        var samples: [(String, UInt64)] = [("before", residentMemoryBytes())]
+        var appended = 0
+
+        for checkpoint in [10_000, 50_000, 100_000] {
+            for packetNumber in (appended + 1)...checkpoint {
+                try harness.appendPacket(
+                    identifier: UInt64(packetNumber),
+                    rawBytes: packet,
+                    timestamp: timestamp.addingTimeInterval(TimeInterval(packetNumber))
+                )
+            }
+
+            appended = checkpoint
+            samples.append(("after \(checkpoint)", residentMemoryBytes()))
+        }
+
+        for identifier in [UInt64(1), 50_000, 100_000] {
+            let inspection = try harness.inspectPacket(identifier: identifier)
+            #expect(inspection.rawBytes.count == packet.count)
+        }
+        samples.append(("after inspections", residentMemoryBytes()))
+
+        let beforeCleanupPath = harness.snapshot.backingFilePath
+        harness.cleanup()
+        samples.append(("after cleanup", residentMemoryBytes()))
+
+        let capturedBytes = UInt64(packet.count * 100_000)
+        let growthAt100K = samples[3].1 > samples[0].1 ? samples[3].1 - samples[0].1 : 0
+        let growthAfterInspections = samples[4].1 > samples[0].1 ? samples[4].1 - samples[0].1 : 0
+        logMemorySamples(samples)
+
+        #expect(!FileManager.default.fileExists(atPath: beforeCleanupPath))
+        #expect(growthAt100K < 96 * 1_024 * 1_024)
+        #expect(growthAfterInspections < 112 * 1_024 * 1_024)
+        #expect(growthAt100K < capturedBytes / 2)
+    }
+    #endif
 }
 
 private struct LoadEventSnapshot: Sendable {
@@ -494,6 +591,37 @@ private func findNode(in nodes: [PacketDetailNode], id: String) -> PacketDetailN
     }
 
     return nil
+}
+
+private func makePaddedPacket(base: Data, byteCount: Int) -> Data {
+    var packet = base
+    if packet.count < byteCount {
+        packet.append(Data(repeating: 0, count: byteCount - packet.count))
+    }
+    return packet
+}
+
+private func residentMemoryBytes() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.stride / MemoryLayout<natural_t>.stride)
+    let result = withUnsafeMutablePointer(to: &info) { pointer in
+        pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundPointer in
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), reboundPointer, &count)
+        }
+    }
+
+    guard result == KERN_SUCCESS else {
+        return 0
+    }
+
+    return UInt64(info.resident_size)
+}
+
+private func logMemorySamples(_ samples: [(String, UInt64)]) {
+    let formatted = samples.map { label, bytes in
+        String(format: "%@: %.1f MB", label, Double(bytes) / 1_048_576.0)
+    }
+    print("TCPViewer RSS stress samples: \(formatted.joined(separator: ", "))")
 }
 
 private extension Data {

--- a/TCPViewer.xcodeproj/xcshareddata/xcschemes/TCPViewer.xcscheme
+++ b/TCPViewer.xcodeproj/xcshareddata/xcschemes/TCPViewer.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -56,6 +56,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BAAE975C2F9B815F00C52A7C"
+            BuildableName = "TCP Viewer.app"
+            BlueprintName = "TCPViewer"
+            ReferencedContainer = "container:TCPViewer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -80,15 +89,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BAAE975C2F9B815F00C52A7C"
-            BuildableName = "TCP Viewer.app"
-            BlueprintName = "TCPViewer"
-            ReferencedContainer = "container:TCPViewer.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -40,6 +40,16 @@ struct PacketIngestState: Sendable, Equatable {
         packets.count
     }
 
+    func packet(withID identifier: PacketSummary.ID?) -> PacketSummary? {
+        guard let identifier,
+              let packetIndex = packetIndexByID[identifier],
+              packets.indices.contains(packetIndex) else {
+            return nil
+        }
+
+        return packets[packetIndex]
+    }
+
     mutating func reset(source: CaptureSource? = nil, message: String) {
         self.source = source
         packets = []
@@ -364,22 +374,22 @@ struct PacketInspectionState: Sendable, Equatable {
 }
 
 struct PacketNavigationState: Sendable, Equatable {
-    var visiblePackets: [PacketSummary]
+    var visiblePacketIDs: [PacketSummary.ID]
     var jumpText: String
     var jumpErrorMessage: String?
     var statusMessage: String
 
     static let empty = PacketNavigationState(
-        visiblePackets: [],
+        visiblePacketIDs: [],
         jumpText: "",
         jumpErrorMessage: nil,
         statusMessage: "No packets available."
     )
 
     static func == (lhs: PacketNavigationState, rhs: PacketNavigationState) -> Bool {
-        lhs.visiblePackets.count == rhs.visiblePackets.count &&
-            lhs.visiblePackets.first?.id == rhs.visiblePackets.first?.id &&
-            lhs.visiblePackets.last?.id == rhs.visiblePackets.last?.id &&
+        lhs.visiblePacketIDs.count == rhs.visiblePacketIDs.count &&
+            lhs.visiblePacketIDs.first == rhs.visiblePacketIDs.first &&
+            lhs.visiblePacketIDs.last == rhs.visiblePacketIDs.last &&
             lhs.jumpText == rhs.jumpText &&
             lhs.jumpErrorMessage == rhs.jumpErrorMessage &&
             lhs.statusMessage == rhs.statusMessage
@@ -804,7 +814,7 @@ final class TCPViewerWorkspaceController {
             return
         }
 
-        guard let packet = snapshot.navigationState.visiblePackets.first(where: { $0.packetNumber == packetNumber }) else {
+        guard let packet = snapshot.packetIngestState.packets.first(where: { $0.packetNumber == packetNumber }) else {
             snapshot.navigationState.jumpErrorMessage = "Packet \(packetNumber) is not visible right now."
             return
         }
@@ -818,16 +828,16 @@ final class TCPViewerWorkspaceController {
             return
         }
 
-        selectPacket(snapshot.navigationState.visiblePackets[currentIndex - 1].id)
+        selectPacket(snapshot.navigationState.visiblePacketIDs[currentIndex - 1])
     }
 
     func selectNextPacket() {
         guard let currentIndex = selectedVisiblePacketIndex(),
-              currentIndex < snapshot.navigationState.visiblePackets.count - 1 else {
+              currentIndex < snapshot.navigationState.visiblePacketIDs.count - 1 else {
             return
         }
 
-        selectPacket(snapshot.navigationState.visiblePackets[currentIndex + 1].id)
+        selectPacket(snapshot.navigationState.visiblePacketIDs[currentIndex + 1])
     }
 
     func selectDetailNode(_ identifier: String?) {
@@ -1182,7 +1192,7 @@ final class TCPViewerWorkspaceController {
         let source = snapshot.packetIngestState.source
         snapshot.packetIngestState.reset(source: source, message: "Cleared.")
         snapshot.navigationState = PacketNavigationState(
-            visiblePackets: [],
+            visiblePacketIDs: [],
             jumpText: "",
             jumpErrorMessage: nil,
             statusMessage: "Cleared."
@@ -1741,20 +1751,20 @@ final class TCPViewerWorkspaceController {
         var shouldValidateSelection = true
 
         if case .append(let range) = mutation,
-           snapshot.navigationState.visiblePackets.count == range.lowerBound,
+           snapshot.navigationState.visiblePacketIDs.count == range.lowerBound,
            range.upperBound <= snapshot.packetIngestState.packets.count {
-            snapshot.navigationState.visiblePackets.append(
-                contentsOf: snapshot.packetIngestState.packets[range]
+            snapshot.navigationState.visiblePacketIDs.append(
+                contentsOf: snapshot.packetIngestState.packets[range].map(\.id)
             )
             shouldValidateSelection = false
         } else {
-            snapshot.navigationState.visiblePackets = snapshot.packetIngestState.packets
+            snapshot.navigationState.visiblePacketIDs = snapshot.packetIngestState.packets.map(\.id)
         }
         snapshot.navigationState.statusMessage = message
 
         if shouldValidateSelection,
            let selectedPacketID = snapshot.selectedPacketID,
-           !snapshot.navigationState.visiblePackets.contains(where: { $0.id == selectedPacketID }) {
+           !snapshot.navigationState.visiblePacketIDs.contains(selectedPacketID) {
             resetInspectionState()
         }
     }
@@ -1770,7 +1780,7 @@ final class TCPViewerWorkspaceController {
             return nil
         }
 
-        return snapshot.navigationState.visiblePackets.firstIndex(where: { $0.id == selectedPacketID })
+        return snapshot.navigationState.visiblePacketIDs.firstIndex(of: selectedPacketID)
     }
 
     private func scheduleInspection(for identifier: PacketSummary.ID?) {
@@ -1791,9 +1801,8 @@ final class TCPViewerWorkspaceController {
 
         let liveSession = self.liveSession
         let document = self.document
-        let visiblePackets = snapshot.navigationState.visiblePackets
-
-        guard let packet = visiblePackets.first(where: { $0.id == identifier }) else {
+        guard let packet = snapshot.packetIngestState.packet(withID: identifier),
+              snapshot.navigationState.visiblePacketIDs.contains(identifier) else {
             return
         }
 

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -562,6 +562,11 @@ final class TCPViewerWorkspaceController {
 
     private(set) var snapshot: TCPViewerWindowSnapshot {
         didSet {
+            guard snapshotUpdateDepth == 0 else {
+                snapshotNeedsNotification = true
+                return
+            }
+
             delegate?.tcpViewerWorkspaceControllerDidChange(self)
         }
     }
@@ -578,6 +583,8 @@ final class TCPViewerWorkspaceController {
     private var documentEventGeneration = 0
     private var inspectionGeneration = 0
     private var filterValidationGeneration = 0
+    private var snapshotUpdateDepth = 0
+    private var snapshotNeedsNotification = false
 
     init(
         services: TCPViewerServiceRegistry? = nil,
@@ -597,6 +604,20 @@ final class TCPViewerWorkspaceController {
 
     deinit {
         cancelControllerTasks()
+    }
+
+    // Coalesce related snapshot writes so AppKit renders one coherent state.
+    private func batchSnapshotUpdates(_ updates: () -> Void) {
+        snapshotUpdateDepth += 1
+        updates()
+        snapshotUpdateDepth -= 1
+
+        guard snapshotUpdateDepth == 0, snapshotNeedsNotification else {
+            return
+        }
+
+        snapshotNeedsNotification = false
+        delegate?.tcpViewerWorkspaceControllerDidChange(self)
     }
 
     static func prepareAllForApplicationTermination(completion: @escaping (Bool) -> Void) {
@@ -1270,10 +1291,6 @@ final class TCPViewerWorkspaceController {
     }
 
     func selectPacket(_ identifier: PacketSummary.ID?) {
-        snapshot.selectedPacketID = identifier
-        snapshot.inspectionState.selectedDetailNodeID = nil
-        snapshot.inspectionState.highlightedByteRange = nil
-        snapshot.navigationState.jumpErrorMessage = nil
         scheduleInspection(for: identifier)
     }
 
@@ -1799,7 +1816,6 @@ final class TCPViewerWorkspaceController {
     private func resetInspectionState() {
         inspectionGeneration += 1
         snapshot.inspectionState = .empty
-        snapshot.selectedPacketID = nil
     }
 
     private func selectedVisiblePacketIndex() -> Int? {
@@ -1813,26 +1829,35 @@ final class TCPViewerWorkspaceController {
     private func scheduleInspection(for identifier: PacketSummary.ID?) {
         inspectionGeneration += 1
         let generation = inspectionGeneration
+        var packetForInspection: PacketSummary?
 
-        guard let identifier else {
-            snapshot.inspectionState = .empty
-            return
+        batchSnapshotUpdates {
+            snapshot.navigationState.jumpErrorMessage = nil
+            guard let identifier,
+                  let packet = snapshot.packetIngestState.packet(withID: identifier),
+                  snapshot.navigationState.visiblePacketIDs.contains(identifier) else {
+                snapshot.inspectionState = .empty
+                return
+            }
+
+            packetForInspection = packet
+            snapshot.inspectionState = PacketInspectionState(
+                selectedPacketID: identifier,
+                inspection: nil,
+                selectedDetailNodeID: nil,
+                highlightedByteRange: nil,
+                isLoading: true,
+                statusMessage: "Inspecting packet \(identifier)..."
+            )
         }
 
-        snapshot.inspectionState.selectedPacketID = identifier
-        snapshot.inspectionState.inspection = nil
-        snapshot.inspectionState.selectedDetailNodeID = nil
-        snapshot.inspectionState.highlightedByteRange = nil
-        snapshot.inspectionState.isLoading = true
-        snapshot.inspectionState.statusMessage = "Inspecting packet \(identifier)..."
+        guard let packet = packetForInspection,
+              let identifier = snapshot.selectedPacketID else {
+            return
+        }
 
         let liveSession = self.liveSession
         let document = self.document
-        guard let packet = snapshot.packetIngestState.packet(withID: identifier),
-              snapshot.navigationState.visiblePacketIDs.contains(identifier) else {
-            return
-        }
-
         let completion: TCPViewerCompletion<PacketInspection> = { [weak self] result in
             DispatchQueue.main.async {
                 guard let self,
@@ -1843,15 +1868,19 @@ final class TCPViewerWorkspaceController {
 
                 switch result {
                 case .success(let inspection):
-                    self.snapshot.inspectionState.selectedPacketID = identifier
-                    self.snapshot.inspectionState.inspection = inspection
-                    self.snapshot.inspectionState.isLoading = false
-                    self.snapshot.inspectionState.statusMessage = "Inspecting packet \(inspection.packetNumber)."
+                    self.batchSnapshotUpdates {
+                        self.snapshot.inspectionState.selectedPacketID = identifier
+                        self.snapshot.inspectionState.inspection = inspection
+                        self.snapshot.inspectionState.isLoading = false
+                        self.snapshot.inspectionState.statusMessage = "Inspecting packet \(inspection.packetNumber)."
+                    }
                 case .failure(let error):
                     let tcpviewerError = self.tcpviewerError(from: error, defaultCode: .offlineFileOpenFailed)
-                    self.snapshot.inspectionState.inspection = nil
-                    self.snapshot.inspectionState.isLoading = false
-                    self.snapshot.inspectionState.statusMessage = tcpviewerError.message
+                    self.batchSnapshotUpdates {
+                        self.snapshot.inspectionState.inspection = nil
+                        self.snapshot.inspectionState.isLoading = false
+                        self.snapshot.inspectionState.statusMessage = tcpviewerError.message
+                    }
                 }
             }
         }

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -547,6 +547,16 @@ protocol TCPViewerWorkspaceControllerDelegate: AnyObject {
     func tcpViewerWorkspaceControllerDidChange(_ controller: TCPViewerWorkspaceController)
 }
 
+#if DEBUG
+struct TCPViewerWorkspaceMemoryDebugSnapshot: Equatable {
+    let ingestPacketCount: Int
+    let packetIndexCount: Int
+    let navigationVisibleIDCount: Int
+    let metadata: PacketMetadataEnrichmentDebugSnapshot
+    let liveSession: LiveCaptureSessionDebugSnapshot?
+}
+#endif
+
 final class TCPViewerWorkspaceController {
     weak var delegate: TCPViewerWorkspaceControllerDelegate?
 
@@ -1190,6 +1200,8 @@ final class TCPViewerWorkspaceController {
 
     func clearPackets() {
         let source = snapshot.packetIngestState.source
+        let shouldReleaseStoppedLiveSession = snapshot.sessionState.phase == .stopped ||
+            snapshot.sessionState.phase == .failed
         snapshot.packetIngestState.reset(source: source, message: "Cleared.")
         snapshot.navigationState = PacketNavigationState(
             visiblePacketIDs: [],
@@ -1201,7 +1213,22 @@ final class TCPViewerWorkspaceController {
         snapshot.documentState.packetCount = 0
         snapshot.sessionState.capturedPacketCount = 0
         services.packetMetadataEnricher.reset()
+        if shouldReleaseStoppedLiveSession {
+            releaseLiveSession()
+        }
     }
+
+    #if DEBUG
+    func debugMemorySnapshot() -> TCPViewerWorkspaceMemoryDebugSnapshot {
+        TCPViewerWorkspaceMemoryDebugSnapshot(
+            ingestPacketCount: snapshot.packetIngestState.packets.count,
+            packetIndexCount: snapshot.packetIngestState.packetIndexByID.count,
+            navigationVisibleIDCount: snapshot.navigationState.visiblePacketIDs.count,
+            metadata: services.packetMetadataEnricher.debugMemorySnapshot(),
+            liveSession: liveSession?.debugMemorySnapshot()
+        )
+    }
+    #endif
 
     func presentOpenCapturePanel() {
         let panel = NSOpenPanel()

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -123,7 +123,7 @@ struct PacketTag: Identifiable, Sendable, Hashable {
 
 struct PacketTableRow: Identifiable, Sendable, Hashable {
     let id: PacketSummary.ID
-    let packet: PacketSummary
+    let client: PacketClient?
     let numberText: String
     let timeText: String
     let sourceText: String
@@ -138,7 +138,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
 
     init(packet: PacketSummary) {
         self.id = packet.id
-        self.packet = packet
+        self.client = packet.client
         self.numberText = "\(packet.packetNumber)"
         self.timeText = NetworkInspectorFormatters.packetTime.string(from: packet.timestamp)
         self.sourceText = NetworkInspectorFormatters.endpointLabel(packet.endpoints.source)
@@ -339,7 +339,6 @@ struct NetworkInspectorSnapshot: Equatable {
     var displayFilter: PacketDisplayFilter
     var displayFilterChips: [PacketFilterChip]
     var packetRows: [PacketTableRow]
-    var packetRowIDs: [PacketSummary.ID]
     var packetTableGeneration: UInt64
     var packetTableUpdatePlan: PacketTableUpdatePlan
     var malformedPacketCount: Int
@@ -371,11 +370,12 @@ struct NetworkInspectorSnapshot: Equatable {
             displayFilter: packetTableContent.displayFilter,
             displayFilterChips: packetTableContent.displayFilterChips,
             packetRows: packetTableContent.rows,
-            packetRowIDs: packetTableContent.rowIDs,
             packetTableGeneration: packetTableContent.generation,
             packetTableUpdatePlan: packetTableContent.updatePlan,
             malformedPacketCount: packetTableContent.malformedPacketCount,
-            selectedPacket: packetTableContent.selectedPacket(id: base.selectedPacketID),
+            selectedPacket: packetTableContent.selectedRowIndex(id: base.selectedPacketID) == nil
+                ? nil
+                : base.packetIngestState.packet(withID: base.selectedPacketID),
             selectedPacketRowIndex: packetTableContent.selectedRowIndex(id: base.selectedPacketID)
         )
     }
@@ -429,22 +429,18 @@ struct PacketTableContent: Sendable {
     let displayFilter: PacketDisplayFilter
     let displayFilterChips: [PacketFilterChip]
     let rows: [PacketTableRow]
-    let rowIDs: [PacketSummary.ID]
     let generation: UInt64
     let updatePlan: PacketTableUpdatePlan
     let malformedPacketCount: Int
-    let visiblePacketsByID: [PacketSummary.ID: PacketSummary]
     let visiblePacketRowIndexByID: [PacketSummary.ID: Int]
 
     static let empty = PacketTableContent(
         displayFilter: PacketDisplayFilter(""),
         displayFilterChips: [],
         rows: [],
-        rowIDs: [],
         generation: 0,
         updatePlan: .none,
         malformedPacketCount: 0,
-        visiblePacketsByID: [:],
         visiblePacketRowIndexByID: [:]
     )
 
@@ -452,30 +448,18 @@ struct PacketTableContent: Sendable {
         displayFilter: PacketDisplayFilter,
         displayFilterChips: [PacketFilterChip],
         rows: [PacketTableRow],
-        rowIDs: [PacketSummary.ID],
         generation: UInt64,
         updatePlan: PacketTableUpdatePlan,
         malformedPacketCount: Int,
-        visiblePacketsByID: [PacketSummary.ID: PacketSummary],
         visiblePacketRowIndexByID: [PacketSummary.ID: Int]
     ) {
         self.displayFilter = displayFilter
         self.displayFilterChips = displayFilterChips
         self.rows = rows
-        self.rowIDs = rowIDs
         self.generation = generation
         self.updatePlan = updatePlan
         self.malformedPacketCount = malformedPacketCount
-        self.visiblePacketsByID = visiblePacketsByID
         self.visiblePacketRowIndexByID = visiblePacketRowIndexByID
-    }
-
-    func selectedPacket(id: PacketSummary.ID?) -> PacketSummary? {
-        guard let id else {
-            return nil
-        }
-
-        return visiblePacketsByID[id]
     }
 
     func selectedRowIndex(id: PacketSummary.ID?) -> Int? {

--- a/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
@@ -14,15 +14,65 @@ struct PacketMetadataUpdate {
     let client: PacketClient?
 }
 
+#if DEBUG
+struct PacketClientResolverDebugSnapshot: Equatable {
+    let socketKeyCount: Int
+    let localEndpointKeyCount: Int
+    let localPortKeyCount: Int
+    let pidClientCount: Int
+    let negativeLookupCount: Int
+    let processIdentityCacheCount: Int
+    let bundleIdentityCacheCount: Int
+
+    static let empty = PacketClientResolverDebugSnapshot(
+        socketKeyCount: 0,
+        localEndpointKeyCount: 0,
+        localPortKeyCount: 0,
+        pidClientCount: 0,
+        negativeLookupCount: 0,
+        processIdentityCacheCount: 0,
+        bundleIdentityCacheCount: 0
+    )
+}
+
+struct PacketMetadataEnrichmentDebugSnapshot: Equatable {
+    let flowCount: Int
+    let flowOrderCount: Int
+    let pendingPacketIDCount: Int
+    let clientResolver: PacketClientResolverDebugSnapshot
+
+    static let empty = PacketMetadataEnrichmentDebugSnapshot(
+        flowCount: 0,
+        flowOrderCount: 0,
+        pendingPacketIDCount: 0,
+        clientResolver: .empty
+    )
+}
+#endif
+
 protocol PacketMetadataEnriching: AnyObject {
     func reset()
     func enrich(_ packets: [PacketSummary], source: CaptureSource) -> PacketMetadataEnrichmentResult
+    #if DEBUG
+    func debugMemorySnapshot() -> PacketMetadataEnrichmentDebugSnapshot
+    #endif
 }
 
 protocol PacketClientResolving: AnyObject {
     func reset()
     func client(for packet: PacketSummary) -> PacketClient?
+    #if DEBUG
+    func debugMemorySnapshot() -> PacketClientResolverDebugSnapshot
+    #endif
 }
+
+#if DEBUG
+extension PacketClientResolving {
+    func debugMemorySnapshot() -> PacketClientResolverDebugSnapshot {
+        .empty
+    }
+}
+#endif
 
 final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
     private struct FlowMetadata {
@@ -53,10 +103,21 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
 
     // Reset flow and process caches when packet lineage changes.
     func reset() {
-        flowMetadataByStreamID.removeAll(keepingCapacity: true)
-        flowOrder.removeAll(keepingCapacity: true)
+        flowMetadataByStreamID.removeAll(keepingCapacity: false)
+        flowOrder.removeAll(keepingCapacity: false)
         clientResolver.reset()
     }
+
+    #if DEBUG
+    func debugMemorySnapshot() -> PacketMetadataEnrichmentDebugSnapshot {
+        PacketMetadataEnrichmentDebugSnapshot(
+            flowCount: flowMetadataByStreamID.count,
+            flowOrderCount: flowOrder.count,
+            pendingPacketIDCount: flowMetadataByStreamID.values.reduce(0) { $0 + $1.pendingPacketIDs.count },
+            clientResolver: clientResolver.debugMemorySnapshot()
+        )
+    }
+    #endif
 
     // Enrich the incoming batch and emit flow updates for packets already stored.
     func enrich(_ packets: [PacketSummary], source: CaptureSource) -> PacketMetadataEnrichmentResult {
@@ -152,6 +213,47 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
     }
 }
 
+struct MacOSBundleIdentity {
+    let displayName: String?
+    let bundleIdentifier: String?
+}
+
+struct MacOSProcessClientResolverEnvironment {
+    let processName: (pid_t) -> String
+    let processPath: (pid_t) -> String?
+    let bundleIdentity: (URL) -> MacOSBundleIdentity
+
+    static let live = MacOSProcessClientResolverEnvironment(
+        processName: { pid in
+            var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+            let length = proc_name(pid, &buffer, UInt32(buffer.count))
+            guard length > 0 else {
+                return "PID \(pid)"
+            }
+            return String(cString: buffer)
+        },
+        processPath: { pid in
+            var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+            let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+            guard length > 0 else {
+                return nil
+            }
+            return String(cString: buffer)
+        },
+        bundleIdentity: { bundleURL in
+            let bundle = Bundle(url: bundleURL)
+            let displayName = bundle.flatMap { bundle in
+                bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ??
+                    bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
+            }
+            return MacOSBundleIdentity(
+                displayName: displayName,
+                bundleIdentifier: bundle?.bundleIdentifier
+            )
+        }
+    )
+}
+
 final class MacOSPacketClientResolver: PacketClientResolving {
     fileprivate enum SocketTransport: Hashable {
         case tcp
@@ -197,31 +299,71 @@ final class MacOSPacketClientResolver: PacketClientResolving {
         }
     }
 
+    private struct ProcessIdentityCacheEntry {
+        let executablePath: String?
+        let client: PacketClient
+    }
+
     private let snapshotTTL: TimeInterval
     private let negativeTTL: TimeInterval
     private let maxNegativeLookups: Int
+    private let maxProcessIdentityCacheEntries: Int
+    private let maxBundleIdentityCacheEntries: Int
+    private let environment: MacOSProcessClientResolverEnvironment
     private var snapshotDate: Date?
     private var clientsBySocketKey: [SocketKey: PacketClient] = [:]
     private var clientsByLocalEndpointKey: [LocalEndpointKey: PacketClient] = [:]
     private var clientsByLocalPortKey: [LocalPortKey: PacketClient] = [:]
     private var clientsByPID: [pid_t: PacketClient] = [:]
     private var negativeLookups: [PacketLookupKey: Date] = [:]
+    private var processIdentityCacheByPID: [pid_t: ProcessIdentityCacheEntry] = [:]
+    private var processIdentityOrder: [pid_t] = []
+    private var bundleIdentityByPath: [String: MacOSBundleIdentity] = [:]
+    private var bundleIdentityOrder: [String] = []
 
-    init(snapshotTTL: TimeInterval = 0.5, negativeTTL: TimeInterval = 0.5, maxNegativeLookups: Int = 10_000) {
+    init(
+        snapshotTTL: TimeInterval = 0.5,
+        negativeTTL: TimeInterval = 0.5,
+        maxNegativeLookups: Int = 10_000,
+        maxProcessIdentityCacheEntries: Int = 2_048,
+        maxBundleIdentityCacheEntries: Int = 512,
+        environment: MacOSProcessClientResolverEnvironment = .live
+    ) {
         self.snapshotTTL = snapshotTTL
         self.negativeTTL = negativeTTL
         self.maxNegativeLookups = max(maxNegativeLookups, 1)
+        self.maxProcessIdentityCacheEntries = max(maxProcessIdentityCacheEntries, 1)
+        self.maxBundleIdentityCacheEntries = max(maxBundleIdentityCacheEntries, 1)
+        self.environment = environment
     }
 
     // Clear process snapshots between live capture sessions.
     func reset() {
         snapshotDate = nil
-        clientsBySocketKey.removeAll(keepingCapacity: true)
-        clientsByLocalEndpointKey.removeAll(keepingCapacity: true)
-        clientsByLocalPortKey.removeAll(keepingCapacity: true)
-        clientsByPID.removeAll(keepingCapacity: true)
-        negativeLookups.removeAll(keepingCapacity: true)
+        clientsBySocketKey.removeAll(keepingCapacity: false)
+        clientsByLocalEndpointKey.removeAll(keepingCapacity: false)
+        clientsByLocalPortKey.removeAll(keepingCapacity: false)
+        clientsByPID.removeAll(keepingCapacity: false)
+        negativeLookups.removeAll(keepingCapacity: false)
+        processIdentityCacheByPID.removeAll(keepingCapacity: false)
+        processIdentityOrder.removeAll(keepingCapacity: false)
+        bundleIdentityByPath.removeAll(keepingCapacity: false)
+        bundleIdentityOrder.removeAll(keepingCapacity: false)
     }
+
+    #if DEBUG
+    func debugMemorySnapshot() -> PacketClientResolverDebugSnapshot {
+        PacketClientResolverDebugSnapshot(
+            socketKeyCount: clientsBySocketKey.count,
+            localEndpointKeyCount: clientsByLocalEndpointKey.count,
+            localPortKeyCount: clientsByLocalPortKey.count,
+            pidClientCount: clientsByPID.count,
+            negativeLookupCount: negativeLookups.count,
+            processIdentityCacheCount: processIdentityCacheByPID.count,
+            bundleIdentityCacheCount: bundleIdentityByPath.count
+        )
+    }
+    #endif
 
     // Resolve a packet to the current macOS process that owns its local socket.
     func client(for packet: PacketSummary) -> PacketClient? {
@@ -376,16 +518,24 @@ final class MacOSPacketClientResolver: PacketClientResolving {
         clientsBySocketKey[SocketKey(transport: transport, local: local, remote: remote)] = client
     }
 
-    private func client(for pid: pid_t) -> PacketClient? {
-        if let client = clientsByPID[pid] {
+    func client(for pid: pid_t) -> PacketClient? {
+        let executablePath = environment.processPath(pid)
+        if let client = clientsByPID[pid],
+           let cachedIdentity = processIdentityCacheByPID[pid],
+           cachedIdentity.executablePath == executablePath {
             return client
         }
 
-        let name = processName(for: pid)
-        let executablePath = processPath(for: pid)
+        if let cachedIdentity = processIdentityCacheByPID[pid],
+           cachedIdentity.executablePath == executablePath {
+            clientsByPID[pid] = cachedIdentity.client
+            return cachedIdentity.client
+        }
+
+        let name = environment.processName(pid)
         let bundleURL = executablePath.flatMap(appBundleURL(for:))
-        let bundle = bundleURL.flatMap(Bundle.init(url:))
-        let displayName = bundleDisplayName(bundle) ??
+        let bundleIdentity = bundleURL.flatMap(cachedBundleIdentity(for:))
+        let displayName = bundleIdentity?.displayName ??
             executablePath.map { URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent } ??
             name
 
@@ -394,38 +544,40 @@ final class MacOSPacketClientResolver: PacketClientResolving {
             name: name,
             displayName: displayName,
             executablePath: executablePath,
-            bundleIdentifier: bundle?.bundleIdentifier,
+            bundleIdentifier: bundleIdentity?.bundleIdentifier,
             bundlePath: bundleURL?.path
         )
         clientsByPID[pid] = client
+        rememberProcessIdentity(pid: pid, executablePath: executablePath, client: client)
         return client
     }
 
-    private func processName(for pid: pid_t) -> String {
-        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
-        let length = proc_name(pid, &buffer, UInt32(buffer.count))
-        guard length > 0 else {
-            return "PID \(pid)"
+    private func rememberProcessIdentity(pid: pid_t, executablePath: String?, client: PacketClient) {
+        if processIdentityCacheByPID[pid] == nil {
+            processIdentityOrder.append(pid)
         }
-        return String(cString: buffer)
+
+        processIdentityCacheByPID[pid] = ProcessIdentityCacheEntry(executablePath: executablePath, client: client)
+        while processIdentityOrder.count > maxProcessIdentityCacheEntries {
+            let removedPID = processIdentityOrder.removeFirst()
+            processIdentityCacheByPID.removeValue(forKey: removedPID)
+        }
     }
 
-    private func processPath(for pid: pid_t) -> String? {
-        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
-        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
-        guard length > 0 else {
-            return nil
-        }
-        return String(cString: buffer)
-    }
-
-    private func bundleDisplayName(_ bundle: Bundle?) -> String? {
-        guard let bundle else {
-            return nil
+    private func cachedBundleIdentity(for bundleURL: URL) -> MacOSBundleIdentity {
+        let path = bundleURL.path
+        if let identity = bundleIdentityByPath[path] {
+            return identity
         }
 
-        return bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ??
-            bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
+        let identity = environment.bundleIdentity(bundleURL)
+        bundleIdentityByPath[path] = identity
+        bundleIdentityOrder.append(path)
+        while bundleIdentityOrder.count > maxBundleIdentityCacheEntries {
+            let removedPath = bundleIdentityOrder.removeFirst()
+            bundleIdentityByPath.removeValue(forKey: removedPath)
+        }
+        return identity
     }
 
     private func appBundleURL(for executablePath: String) -> URL? {

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -239,6 +239,26 @@ final class PacketSourceListService {
     private var domainBuckets: [PacketSourceDomainKey: PacketSourceListTreeBuilder.DomainBucket] = [:]
     private var domainOrder: [PacketSourceDomainKey] = []
 
+    func reset() {
+        packetRevision = nil
+        packetLineageRevision = nil
+        sourcePacketCount = 0
+        cachedSnapshot = .empty
+        appBuckets.removeAll(keepingCapacity: false)
+        appOrder.removeAll(keepingCapacity: false)
+        domainBuckets.removeAll(keepingCapacity: false)
+        domainOrder.removeAll(keepingCapacity: false)
+    }
+
+    #if DEBUG
+    func debugMemorySnapshot() -> PacketSourceListDebugSnapshot {
+        PacketSourceListDebugSnapshot(
+            appBucketCount: appBuckets.count,
+            domainBucketCount: domainBuckets.count
+        )
+    }
+    #endif
+
     // Keep the tree in sync with packet mutations, using append when packet lineage is unchanged.
     func snapshot(for ingestState: PacketIngestState) -> PacketSourceListSnapshot {
         guard packetRevision != ingestState.packetRevision else {
@@ -300,6 +320,13 @@ final class PacketSourceListService {
         return cachedSnapshot
     }
 }
+
+#if DEBUG
+struct PacketSourceListDebugSnapshot: Equatable {
+    let appBucketCount: Int
+    let domainBucketCount: Int
+}
+#endif
 
 enum PacketSourceListTreeBuilder {
     struct AppBucket: Equatable, Sendable {

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -276,7 +276,7 @@ final class PacketSourceListService {
                     appBuckets[clientIdentity.key] = PacketSourceListTreeBuilder.AppBucket(identity: clientIdentity)
                 }
 
-                appBuckets[clientIdentity.key]?.packetIDs.append(packet.id)
+                appBuckets[clientIdentity.key]?.packetCount += 1
             }
 
             let domainIdentity = PacketSourceListClassifier.domainIdentity(for: packet)
@@ -285,7 +285,7 @@ final class PacketSourceListService {
                 domainBuckets[domainIdentity.key] = PacketSourceListTreeBuilder.DomainBucket(identity: domainIdentity)
             }
 
-            domainBuckets[domainIdentity.key]?.packetIDs.append(packet.id)
+            domainBuckets[domainIdentity.key]?.packetCount += 1
         }
     }
 
@@ -304,12 +304,12 @@ final class PacketSourceListService {
 enum PacketSourceListTreeBuilder {
     struct AppBucket: Equatable, Sendable {
         let identity: PacketSourceClientIdentity
-        var packetIDs: [PacketSummary.ID] = []
+        var packetCount = 0
     }
 
     struct DomainBucket: Equatable, Sendable {
         let identity: PacketSourceDomainIdentity
-        var packetIDs: [PacketSummary.ID] = []
+        var packetCount = 0
     }
 
     static let favoritesGroupID = "group:favorites"
@@ -335,7 +335,7 @@ enum PacketSourceListTreeBuilder {
                 title: bucket.identity.displayName,
                 systemImageName: "app",
                 iconFilePath: bucket.identity.iconFilePath,
-                count: bucket.packetIDs.count,
+                count: bucket.packetCount,
                 kind: .app,
                 selection: .app(bucket.identity.key),
                 children: []
@@ -347,7 +347,7 @@ enum PacketSourceListTreeBuilder {
                 title: bucket.identity.displayName,
                 systemImageName: "network",
                 iconFilePath: nil,
-                count: bucket.packetIDs.count,
+                count: bucket.packetCount,
                 kind: .domain,
                 selection: .domain(bucket.identity.key),
                 children: []
@@ -400,7 +400,7 @@ enum PacketSourceListTreeBuilder {
                         title: "Apps",
                         systemImageName: "folder.fill",
                         iconFilePath: nil,
-                        count: appBuckets.reduce(0) { $0 + $1.packetIDs.count },
+                        count: appBuckets.reduce(0) { $0 + $1.packetCount },
                         kind: .folder,
                         selection: .apps,
                         children: appItems
@@ -410,7 +410,7 @@ enum PacketSourceListTreeBuilder {
                         title: "Domains",
                         systemImageName: "globe",
                         iconFilePath: nil,
-                        count: domainBuckets.reduce(0) { $0 + $1.packetIDs.count },
+                        count: domainBuckets.reduce(0) { $0 + $1.packetCount },
                         kind: .folder,
                         selection: .domains,
                         children: domainItems

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -57,6 +57,25 @@ private struct PacketTableContentCache {
     private var generation: UInt64 = 0
     private var cachedContent = PacketTableContent.empty
 
+    mutating func reset() {
+        packetRevision = nil
+        packetLineageRevision = nil
+        sourcePacketCount = 0
+        displayFilterText = nil
+        sourceListSelection = nil
+        generation &+= 1
+        cachedContent = .empty
+    }
+
+    #if DEBUG
+    var debugMemorySnapshot: PacketTableContentCacheDebugSnapshot {
+        PacketTableContentCacheDebugSnapshot(
+            rowCount: cachedContent.rows.count,
+            visiblePacketIndexCount: cachedContent.visiblePacketRowIndexByID.count
+        )
+    }
+    #endif
+
     mutating func content(
         for ingestState: PacketIngestState,
         displayFilterText: String,
@@ -213,6 +232,44 @@ private struct PacketTableContentCache {
         return content
     }
 }
+
+#if DEBUG
+struct PacketTableContentCacheDebugSnapshot: Equatable {
+    let rowCount: Int
+    let visiblePacketIndexCount: Int
+}
+
+struct NetworkInspectorMemoryDebugSnapshot: Equatable {
+    let ingestPacketCount: Int
+    let packetIndexCount: Int
+    let navigationVisibleIDCount: Int
+    let tableRowCount: Int
+    let tableVisiblePacketIndexCount: Int
+    let sourceListAppBucketCount: Int
+    let sourceListDomainBucketCount: Int
+    let metadata: PacketMetadataEnrichmentDebugSnapshot
+    let liveSession: LiveCaptureSessionDebugSnapshot?
+
+    var logDescription: String {
+        [
+            "ingestPackets=\(ingestPacketCount)",
+            "packetIndex=\(packetIndexCount)",
+            "navIDs=\(navigationVisibleIDCount)",
+            "tableRows=\(tableRowCount)",
+            "tableVisibleIndex=\(tableVisiblePacketIndexCount)",
+            "sourceApps=\(sourceListAppBucketCount)",
+            "sourceDomains=\(sourceListDomainBucketCount)",
+            "metadataFlows=\(metadata.flowCount)",
+            "metadataPendingIDs=\(metadata.pendingPacketIDCount)",
+            "resolverPIDClients=\(metadata.clientResolver.pidClientCount)",
+            "resolverProcessIdentities=\(metadata.clientResolver.processIdentityCacheCount)",
+            "resolverBundleIdentities=\(metadata.clientResolver.bundleIdentityCacheCount)",
+            "livePendingBatch=\(liveSession?.pendingBatchCount.description ?? "nil")",
+            "liveActiveRunPackets=\(liveSession?.activeRunPacketCount.description ?? "nil")",
+        ].joined(separator: ", ")
+    }
+}
+#endif
 
 protocol NetworkInspectorViewModelDelegate: AnyObject {
     func networkInspectorViewModelDidChange(_ viewModel: NetworkInspectorViewModel)
@@ -403,8 +460,16 @@ final class NetworkInspectorViewModel {
     }
 
     func clearPackets() {
+        #if DEBUG
+        logClearMemorySnapshot("before")
+        #endif
         controller.clearPackets()
+        packetTableContentCache.reset()
+        sourceListService.reset()
         rebuildSnapshot()
+        #if DEBUG
+        logClearMemorySnapshot("after")
+        #endif
     }
 
     func updateCaptureFilterText(_ text: String) {
@@ -574,6 +639,30 @@ final class NetworkInspectorViewModel {
 
         snapshot = updatedSnapshot
     }
+
+    #if DEBUG
+    func debugMemorySnapshot() -> NetworkInspectorMemoryDebugSnapshot {
+        let tableSnapshot = packetTableContentCache.debugMemorySnapshot
+        let sourceListSnapshot = sourceListService.debugMemorySnapshot()
+        let workspaceSnapshot = controller.debugMemorySnapshot()
+        return NetworkInspectorMemoryDebugSnapshot(
+            ingestPacketCount: workspaceSnapshot.ingestPacketCount,
+            packetIndexCount: workspaceSnapshot.packetIndexCount,
+            navigationVisibleIDCount: workspaceSnapshot.navigationVisibleIDCount,
+            tableRowCount: tableSnapshot.rowCount,
+            tableVisiblePacketIndexCount: tableSnapshot.visiblePacketIndexCount,
+            sourceListAppBucketCount: sourceListSnapshot.appBucketCount,
+            sourceListDomainBucketCount: sourceListSnapshot.domainBucketCount,
+            metadata: workspaceSnapshot.metadata,
+            liveSession: workspaceSnapshot.liveSession
+        )
+    }
+
+    private func logClearMemorySnapshot(_ phase: String) {
+        let snapshot = debugMemorySnapshot()
+        print("[TCPViewer] 🧹 Clear memory \(phase): \(snapshot.logDescription)")
+    }
+    #endif
 }
 
 extension NetworkInspectorViewModel: TCPViewerWorkspaceControllerDelegate {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -98,13 +98,9 @@ private struct PacketTableContentCache {
         sourceListSelection: PacketSourceListSelection
     ) -> PacketTableContent {
         var rows: [PacketTableRow] = []
-        var rowIDs: [PacketSummary.ID] = []
-        var visiblePacketsByID: [PacketSummary.ID: PacketSummary] = [:]
         var visiblePacketRowIndexByID: [PacketSummary.ID: Int] = [:]
         var malformedPacketCount = 0
         rows.reserveCapacity(ingestState.packets.count)
-        rowIDs.reserveCapacity(ingestState.packets.count)
-        visiblePacketsByID.reserveCapacity(ingestState.packets.count)
         visiblePacketRowIndexByID.reserveCapacity(ingestState.packets.count)
 
         for packet in ingestState.packets {
@@ -119,8 +115,6 @@ private struct PacketTableContentCache {
 
             let rowIndex = rows.count
             rows.append(PacketTableRow(packet: packet))
-            rowIDs.append(packet.id)
-            visiblePacketsByID[packet.id] = packet
             visiblePacketRowIndexByID[packet.id] = rowIndex
         }
 
@@ -130,11 +124,9 @@ private struct PacketTableContentCache {
             displayFilter: displayFilter,
             displayFilterChips: displayFilter.chips,
             rows: rows,
-            rowIDs: rowIDs,
             generation: generation,
             updatePlan: updatePlan,
             malformedPacketCount: malformedPacketCount,
-            visiblePacketsByID: visiblePacketsByID,
             visiblePacketRowIndexByID: visiblePacketRowIndexByID
         )
         return store(
@@ -162,15 +154,11 @@ private struct PacketTableContentCache {
         }
 
         var rows = cachedContent.rows
-        var rowIDs = cachedContent.rowIDs
-        var visiblePacketsByID = cachedContent.visiblePacketsByID
         var visiblePacketRowIndexByID = cachedContent.visiblePacketRowIndexByID
         var malformedPacketCount = cachedContent.malformedPacketCount
         let appendStartIndex = rows.count
 
         rows.reserveCapacity(rows.count + newPackets.count)
-        rowIDs.reserveCapacity(rowIDs.count + newPackets.count)
-        visiblePacketsByID.reserveCapacity(visiblePacketsByID.count + newPackets.count)
         visiblePacketRowIndexByID.reserveCapacity(visiblePacketRowIndexByID.count + newPackets.count)
 
         for packet in newPackets {
@@ -185,8 +173,6 @@ private struct PacketTableContentCache {
 
             let rowIndex = rows.count
             rows.append(PacketTableRow(packet: packet))
-            rowIDs.append(packet.id)
-            visiblePacketsByID[packet.id] = packet
             visiblePacketRowIndexByID[packet.id] = rowIndex
         }
 
@@ -199,11 +185,9 @@ private struct PacketTableContentCache {
             displayFilter: displayFilter,
             displayFilterChips: displayFilter.chips,
             rows: rows,
-            rowIDs: rowIDs,
             generation: generation,
             updatePlan: didAppendVisibleRows ? .append(appendStartIndex..<rows.count) : .none,
             malformedPacketCount: malformedPacketCount,
-            visiblePacketsByID: visiblePacketsByID,
             visiblePacketRowIndexByID: visiblePacketRowIndexByID
         )
         return store(

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -42,9 +42,16 @@ final class PacketInspectorPanelViewModel {
         packetTableContent: .empty
     ))
 
-    // Extract inspector-only state so the controller can render without touching root state.
-    func render(snapshot: NetworkInspectorSnapshot) {
-        state = PacketInspectorRenderState(snapshot: snapshot)
+    // Extract inspector-only state and report whether the inspector actually changed.
+    @discardableResult
+    func render(snapshot: NetworkInspectorSnapshot) -> Bool {
+        let nextState = PacketInspectorRenderState(snapshot: snapshot)
+        guard nextState != state else {
+            return false
+        }
+
+        state = nextState
+        return true
     }
 }
 
@@ -74,7 +81,11 @@ final class PacketInspectorViewController: NSViewController {
     }
 
     func render(snapshot: NetworkInspectorSnapshot) {
-        viewModel.render(snapshot: snapshot)
+        let didChange = viewModel.render(snapshot: snapshot)
+        guard didChange || currentContentView == nil else {
+            return
+        }
+
         let state = viewModel.state
         logSelectedPacketRender(state: state)
         tabControl.selectedSegment = PacketInspectorTab.allCases.firstIndex(of: state.inspectorTab) ?? 0

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -57,6 +57,7 @@ final class PacketInspectorViewController: NSViewController {
     private var currentContentView: NSView?
     private var hexView: PacketHexFiendView?
     private var rawOutlineView: PacketRawOutlineView?
+    private var renderLogCount = 0
 
     override func loadView() {
         view = NSView()
@@ -75,8 +76,18 @@ final class PacketInspectorViewController: NSViewController {
     func render(snapshot: NetworkInspectorSnapshot) {
         viewModel.render(snapshot: snapshot)
         let state = viewModel.state
+        logSelectedPacketRender(state: state)
         tabControl.selectedSegment = PacketInspectorTab.allCases.firstIndex(of: state.inspectorTab) ?? 0
         renderContent(state: state)
+    }
+
+    // Log every inspector render so row-selection reload behavior is easy to count in Console.
+    private func logSelectedPacketRender(state: PacketInspectorRenderState) {
+        renderLogCount += 1
+        let selectedID = state.selectedPacketID.map(String.init) ?? "nil"
+        let packetNumber = state.selectedPacket.map { "#\($0.packetNumber)" } ?? "none"
+        let inspectionID = state.inspection?.packetID.description ?? "nil"
+        print("[TCPViewer] 🧪 Inspector render \(renderLogCount): selectedPacketID=\(selectedID), packet=\(packetNumber), tab=\(state.inspectorTab.title), loading=\(state.isLoading), inspectionPacketID=\(inspectionID)")
     }
 
     private func setupHeader() {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -46,12 +46,32 @@ final class PacketInspectorPanelViewModel {
     @discardableResult
     func render(snapshot: NetworkInspectorSnapshot) -> Bool {
         let nextState = PacketInspectorRenderState(snapshot: snapshot)
+        guard !shouldDeferPendingInspection(nextState) else {
+            return false
+        }
+
         guard nextState != state else {
             return false
         }
 
         state = nextState
         return true
+    }
+
+    private func shouldDeferPendingInspection(_ state: PacketInspectorRenderState) -> Bool {
+        guard let selectedPacketID = state.selectedPacketID else {
+            return false
+        }
+
+        if state.isLoading {
+            return true
+        }
+
+        if let inspection = state.inspection, inspection.packetID != selectedPacketID {
+            return true
+        }
+
+        return false
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -256,7 +256,7 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
         if let cell = cell as? PacketProtocolCell {
             cell.configure(protocolText: packetRow.protocolText, severity: packetRow.severity)
         } else if let cell = cell as? PacketClientCell {
-            cell.configure(client: packetRow.packet.client)
+            cell.configure(client: packetRow.client)
         } else if let cell = cell as? PacketTextCell {
             cell.configure(style: textStyle(for: column, in: packetRow))
         }

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -609,7 +609,7 @@ struct WindowControllerTests {
 
         #expect(controller.snapshot.selectedPacketID == firstPacket.id)
         #expect(controller.snapshot.inspectionState.inspection?.packetID == firstPacket.id)
-        #expect(controller.snapshot.navigationState.visiblePackets.map(\.packetNumber) == [1, 2])
+        #expect(controller.snapshot.navigationState.visiblePacketIDs == [firstPacket.id, secondPacket.id])
 
         await tearDown(controller)
     }
@@ -751,7 +751,7 @@ struct WindowControllerTests {
 
         #expect(controller.snapshot.packetIngestState.totalPacketCount == 0)
         #expect(controller.snapshot.documentState.packetCount == 0)
-        #expect(controller.snapshot.navigationState.visiblePackets.isEmpty)
+        #expect(controller.snapshot.navigationState.visiblePacketIDs.isEmpty)
         #expect(controller.snapshot.selectedPacketID == nil)
         #expect(controller.snapshot.inspectionState.inspection == nil)
         #expect(controller.snapshot.inspectionState.highlightedByteRange == nil)

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -333,6 +333,72 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.packetTableUpdatePlan == .append(1..<3))
     }
 
+    @Test func liveModelKeepsLargePacketNavigationAndSourceListShapeCompact() async {
+        let liveSession = InspectorFakeLiveSession()
+        let clientResolver = InspectorFakePacketClientResolver(defaultClient: nil)
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(
+                core: InspectorFakeCore(
+                    interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                    liveSession: liveSession
+                ),
+                packetMetadataEnricher: PacketMetadataEnrichmentService(clientResolver: clientResolver)
+            ),
+            userDefaults: isolatedDefaults()
+        )
+        var lastCheckpoint: UInt64 = 0
+
+        await viewModel.performInitialLoadIfNeeded()
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+
+        for checkpoint in [UInt64(10_000), 50_000, 100_000] {
+            let batch = makeLivePacketBatch(from: lastCheckpoint + 1, through: checkpoint)
+            liveSession.send(.packetBatch(batch, disposition: .append))
+
+            await waitUntil(timeoutNanoseconds: 15_000_000_000) {
+                viewModel.snapshot.totalPacketCount == Int(checkpoint) &&
+                    viewModel.snapshot.visiblePacketCount == Int(checkpoint) &&
+                    viewModel.snapshot.base.navigationState.visiblePacketIDs.count == Int(checkpoint)
+            }
+
+            #expect(viewModel.snapshot.packetRows.first?.id == 1)
+            #expect(viewModel.snapshot.packetRows.last?.id == checkpoint)
+            #expect(viewModel.snapshot.base.navigationState.visiblePacketIDs.first == 1)
+            #expect(viewModel.snapshot.base.navigationState.visiblePacketIDs.last == checkpoint)
+            #expect(viewModel.snapshot.sourceListSnapshot.item(for: .domains)?.count == Int(checkpoint))
+            #expect(viewModel.snapshot.sourceListSnapshot.item(for: .domain(.ipAddresses))?.count == Int(checkpoint))
+            #expect(viewModel.snapshot.sourceListSnapshot.item(for: .apps)?.count == 0)
+            lastCheckpoint = checkpoint
+        }
+
+        let navigationLabels = Set(Mirror(reflecting: viewModel.snapshot.base.navigationState).children.compactMap(\.label))
+        #expect(navigationLabels.contains("visiblePacketIDs"))
+        #expect(!navigationLabels.contains("visiblePackets"))
+
+        let selectedPacket = makePacket(packetNumber: 50_000, source: .live, transportHint: .tcp, streamID: nil)
+        liveSession.inspections[selectedPacket.id] = makeInspection(for: selectedPacket)
+        viewModel.selectPacket(selectedPacket.id)
+
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.snapshot.base.inspectionState.inspection?.packetID == selectedPacket.id
+        }
+
+        #expect(viewModel.snapshot.selectedPacket?.id == selectedPacket.id)
+        #expect(viewModel.snapshot.selectedPacketRowIndex == 49_999)
+
+        viewModel.updateDisplayFilterText("protocol:tcp")
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.snapshot.visiblePacketCount == 50_000
+        }
+
+        #expect(viewModel.snapshot.packetRows.count == 50_000)
+        #expect(viewModel.snapshot.packetRows.first?.id == 2)
+        #expect(viewModel.snapshot.packetRows.last?.id == 100_000)
+        #expect(viewModel.snapshot.base.navigationState.visiblePacketIDs.count == 100_000)
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .domain(.ipAddresses))?.count == 100_000)
+    }
+
     @Test func metadataEnrichmentBackfillsSNIAndCachesLiveClient() async {
         let client = makeClient()
         let clientResolver = InspectorFakePacketClientResolver(defaultClient: client)
@@ -787,11 +853,22 @@ struct NetworkInspectorViewModelTests {
         )
     }
 
+    private func makeLivePacketBatch(from start: UInt64, through end: UInt64) -> [PacketSummary] {
+        (start...end).map { packetNumber in
+            makePacket(
+                packetNumber: packetNumber,
+                source: .live,
+                transportHint: packetNumber.isMultiple(of: 2) ? .tcp : .udp,
+                streamID: nil
+            )
+        }
+    }
+
     private func makeInspection(for packet: PacketSummary) -> PacketInspection {
         PacketInspection(
             packetID: packet.id,
             packetNumber: packet.packetNumber,
-            rawBytes: Data(repeating: UInt8(packet.packetNumber), count: 16),
+            rawBytes: Data(repeating: UInt8(packet.packetNumber % 256), count: 16),
             detailNodes: [
                 PacketDetailNode(id: "frame", name: "Frame", value: "Packet \(packet.packetNumber)", kind: .layer)
             ],

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -231,6 +231,45 @@ struct NetworkInspectorViewModelTests {
         """)
     }
 
+    @Test func inspectorPanelSkipsRenderForUnchangedSelectionDuringLiveAppends() {
+        let selectedPacket = makePacket(packetNumber: 1, source: .live, transportHint: .tcp, streamID: nil)
+        let appendedPacket = makePacket(packetNumber: 2, source: .live, transportHint: .udp, streamID: nil)
+        let inspection = makeInspection(for: selectedPacket)
+        let panelViewModel = PacketInspectorPanelViewModel()
+        let firstSnapshot = makeInspectorSnapshot(
+            packets: [selectedPacket],
+            selectedPacketID: selectedPacket.id,
+            inspection: inspection,
+            generation: 1,
+            updatePlan: .reload
+        )
+        let appendSnapshot = makeInspectorSnapshot(
+            packets: [selectedPacket, appendedPacket],
+            selectedPacketID: selectedPacket.id,
+            inspection: inspection,
+            generation: 2,
+            updatePlan: .append(1..<2)
+        )
+        let updatedSelectedPacket = makePacket(
+            packetNumber: selectedPacket.packetNumber,
+            source: .live,
+            transportHint: .tcp,
+            streamID: nil,
+            sniDomainName: "selected.example.com"
+        )
+        let selectedMetadataSnapshot = makeInspectorSnapshot(
+            packets: [updatedSelectedPacket, appendedPacket],
+            selectedPacketID: selectedPacket.id,
+            inspection: inspection,
+            generation: 3,
+            updatePlan: .reload
+        )
+
+        #expect(panelViewModel.render(snapshot: firstSnapshot))
+        #expect(!panelViewModel.render(snapshot: appendSnapshot))
+        #expect(panelViewModel.render(snapshot: selectedMetadataSnapshot))
+    }
+
     @Test func statusStripKeepsCancelAvailableDuringZeroPacketLoad() {
         var base = TCPViewerWindowSnapshot.foundation
         base.loadState = PacketLoadState(progress: PacketLoadProgress(
@@ -397,6 +436,33 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.packetRows.last?.id == 100_000)
         #expect(viewModel.snapshot.base.navigationState.visiblePacketIDs.count == 100_000)
         #expect(viewModel.snapshot.sourceListSnapshot.item(for: .domain(.ipAddresses))?.count == 100_000)
+
+        await viewModel.stopLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .stopped, message: "Live capture stopped."))
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.snapshot.base.sessionState.phase == .stopped
+        }
+
+        #if DEBUG
+        let beforeClear = viewModel.debugMemorySnapshot()
+        #expect(beforeClear.ingestPacketCount == 100_000)
+        #expect(beforeClear.tableRowCount == 50_000)
+        #expect(beforeClear.navigationVisibleIDCount == 100_000)
+        #expect(beforeClear.sourceListDomainBucketCount == 1)
+        #expect(beforeClear.metadata.flowCount > 0)
+
+        viewModel.clearPackets()
+        let afterClear = viewModel.debugMemorySnapshot()
+        #expect(afterClear.ingestPacketCount == 0)
+        #expect(afterClear.packetIndexCount == 0)
+        #expect(afterClear.tableRowCount == 0)
+        #expect(afterClear.tableVisiblePacketIndexCount == 0)
+        #expect(afterClear.navigationVisibleIDCount == 0)
+        #expect(afterClear.sourceListAppBucketCount == 0)
+        #expect(afterClear.sourceListDomainBucketCount == 0)
+        #expect(afterClear.metadata == .empty)
+        #expect(afterClear.liveSession == nil)
+        #endif
     }
 
     @Test func metadataEnrichmentBackfillsSNIAndCachesLiveClient() async {
@@ -513,6 +579,51 @@ struct NetworkInspectorViewModelTests {
 
         #expect(result.packets.first?.client == nil)
         #expect(clientResolver.clientLookupCount == 0)
+    }
+
+    @Test func macOSPacketClientResolverCachesProcessAndBundleIdentityForRepeatedPIDPath() {
+        var processNameLookupCount = 0
+        var processPathLookupCount = 0
+        var bundleIdentityLookupCount = 0
+        let executablePath = "/Applications/Example.app/Contents/MacOS/Example"
+        let environment = MacOSProcessClientResolverEnvironment(
+            processName: { pid in
+                processNameLookupCount += 1
+                return "Process \(pid)"
+            },
+            processPath: { _ in
+                processPathLookupCount += 1
+                return executablePath
+            },
+            bundleIdentity: { _ in
+                bundleIdentityLookupCount += 1
+                return MacOSBundleIdentity(
+                    displayName: "Example",
+                    bundleIdentifier: "com.example.app"
+                )
+            }
+        )
+        let resolver = MacOSPacketClientResolver(
+            snapshotTTL: 0,
+            maxProcessIdentityCacheEntries: 4,
+            maxBundleIdentityCacheEntries: 4,
+            environment: environment
+        )
+
+        let first = resolver.client(for: 123)
+        let second = resolver.client(for: 123)
+
+        #expect(first?.displayName == "Example")
+        #expect(second?.bundleIdentifier == "com.example.app")
+        #expect(processNameLookupCount == 1)
+        #expect(processPathLookupCount == 2)
+        #expect(bundleIdentityLookupCount == 1)
+        #if DEBUG
+        #expect(resolver.debugMemorySnapshot().processIdentityCacheCount == 1)
+        #expect(resolver.debugMemorySnapshot().bundleIdentityCacheCount == 1)
+        resolver.reset()
+        #expect(resolver.debugMemorySnapshot() == .empty)
+        #endif
     }
 
     @Test func metadataEnrichmentExpiresIdleFlowBeforeReusingStreamID() {
@@ -816,6 +927,50 @@ struct NetworkInspectorViewModelTests {
         )
     }
 
+    private func makeInspectorSnapshot(
+        packets: [PacketSummary],
+        selectedPacketID: PacketSummary.ID?,
+        inspection: PacketInspection?,
+        generation: UInt64,
+        updatePlan: PacketTableUpdatePlan
+    ) -> NetworkInspectorSnapshot {
+        var base = TCPViewerWindowSnapshot.foundation
+        base.packetIngestState.replace(with: packets, source: .live)
+        base.inspectionState = PacketInspectionState(
+            selectedPacketID: selectedPacketID,
+            inspection: inspection,
+            selectedDetailNodeID: nil,
+            highlightedByteRange: nil,
+            isLoading: false,
+            statusMessage: "Packet loaded."
+        )
+        let rows = packets.map(PacketTableRow.init(packet:))
+        let visibleIndex = Dictionary(uniqueKeysWithValues: rows.enumerated().map { index, row in
+            (row.id, index)
+        })
+        let tableContent = PacketTableContent(
+            displayFilter: PacketDisplayFilter(""),
+            displayFilterChips: [],
+            rows: rows,
+            generation: generation,
+            updatePlan: updatePlan,
+            malformedPacketCount: 0,
+            visiblePacketRowIndexByID: visibleIndex
+        )
+        return NetworkInspectorSnapshot.make(
+            base: base,
+            selectedSidebar: .liveCapture,
+            selectedSourceListSelection: .allPackets,
+            sourceListSnapshot: .empty,
+            sourceListFilterText: "",
+            workspaceMode: .packets,
+            inspectorTab: .summary,
+            isInspectorVisible: true,
+            displayFilterText: "",
+            packetTableContent: tableContent
+        )
+    }
+
     private func makePacket(
         packetNumber: UInt64,
         source: CaptureSource,
@@ -859,7 +1014,7 @@ struct NetworkInspectorViewModelTests {
                 packetNumber: packetNumber,
                 source: .live,
                 transportHint: packetNumber.isMultiple(of: 2) ? .tcp : .udp,
-                streamID: nil
+                streamID: UInt32((packetNumber % 4_096) + 1)
             )
         }
     }

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -270,6 +270,48 @@ struct NetworkInspectorViewModelTests {
         #expect(panelViewModel.render(snapshot: selectedMetadataSnapshot))
     }
 
+    @Test func inspectorPanelDefersPendingSelectionUntilInspectionMatches() {
+        let firstPacket = makePacket(packetNumber: 5, source: .live, transportHint: .tcp, streamID: nil)
+        let nextPacket = makePacket(packetNumber: 15, source: .live, transportHint: .tcp, streamID: nil)
+        let firstInspection = makeInspection(for: firstPacket)
+        let nextInspection = makeInspection(for: nextPacket)
+        let panelViewModel = PacketInspectorPanelViewModel()
+        let firstSnapshot = makeInspectorSnapshot(
+            packets: [firstPacket, nextPacket],
+            selectedPacketID: firstPacket.id,
+            inspection: firstInspection,
+            generation: 1,
+            updatePlan: .reload
+        )
+        let staleInspectionSnapshot = makeInspectorSnapshot(
+            packets: [firstPacket, nextPacket],
+            selectedPacketID: nextPacket.id,
+            inspection: firstInspection,
+            generation: 2,
+            updatePlan: .reload
+        )
+        let loadingSnapshot = makeInspectorSnapshot(
+            packets: [firstPacket, nextPacket],
+            selectedPacketID: nextPacket.id,
+            inspection: nil,
+            generation: 3,
+            updatePlan: .reload,
+            isLoading: true
+        )
+        let resolvedSnapshot = makeInspectorSnapshot(
+            packets: [firstPacket, nextPacket],
+            selectedPacketID: nextPacket.id,
+            inspection: nextInspection,
+            generation: 4,
+            updatePlan: .reload
+        )
+
+        #expect(panelViewModel.render(snapshot: firstSnapshot))
+        #expect(!panelViewModel.render(snapshot: staleInspectionSnapshot))
+        #expect(!panelViewModel.render(snapshot: loadingSnapshot))
+        #expect(panelViewModel.render(snapshot: resolvedSnapshot))
+    }
+
     @Test func statusStripKeepsCancelAvailableDuringZeroPacketLoad() {
         var base = TCPViewerWindowSnapshot.foundation
         base.loadState = PacketLoadState(progress: PacketLoadProgress(
@@ -932,7 +974,8 @@ struct NetworkInspectorViewModelTests {
         selectedPacketID: PacketSummary.ID?,
         inspection: PacketInspection?,
         generation: UInt64,
-        updatePlan: PacketTableUpdatePlan
+        updatePlan: PacketTableUpdatePlan,
+        isLoading: Bool = false
     ) -> NetworkInspectorSnapshot {
         var base = TCPViewerWindowSnapshot.foundation
         base.packetIngestState.replace(with: packets, source: .live)
@@ -941,7 +984,7 @@ struct NetworkInspectorViewModelTests {
             inspection: inspection,
             selectedDetailNodeID: nil,
             highlightedByteRange: nil,
-            isLoading: false,
+            isLoading: isLoading,
             statusMessage: "Packet loaded."
         )
         let rows = packets.map(PacketTableRow.init(packet:))

--- a/scripts/bootstrap-pcapplusplus.sh
+++ b/scripts/bootstrap-pcapplusplus.sh
@@ -14,6 +14,29 @@ BUILD_DIR="$BUILD_ROOT/pcapplusplus-${CONFIGURATION_NAME}-$(printf '%s' "$ARCHIT
 STAMP_FILE="$INSTALL_ROOT/.tcpviewer-build-stamp"
 CURRENT_STAMP_CONTENT="tag=$PINNED_TAG;commit=$PINNED_COMMIT;config=$CONFIGURATION_NAME;archs=$ARCHITECTURES"
 
+cache_value() {
+  KEY="$1"
+  CACHE_FILE="$2"
+  awk -F= -v key="$KEY:INTERNAL" '$1 == key { print $2; exit }' "$CACHE_FILE"
+}
+
+reset_mismatched_cmake_cache() {
+  CACHE_FILE="$BUILD_DIR/CMakeCache.txt"
+
+  if [ ! -f "$CACHE_FILE" ]; then
+    return
+  fi
+
+  CACHE_SOURCE_DIR="$(cache_value CMAKE_HOME_DIRECTORY "$CACHE_FILE")"
+  CACHE_BUILD_DIR="$(cache_value CMAKE_CACHEFILE_DIR "$CACHE_FILE")"
+
+  # CMake caches are tied to absolute source/build paths, so copied caches must be discarded.
+  if [ "$CACHE_SOURCE_DIR" != "$SOURCE_DIR" ] || [ "$CACHE_BUILD_DIR" != "$BUILD_DIR" ]; then
+    echo "warning: removing stale PcapPlusPlus CMake cache for a different checkout." >&2
+    rm -rf "$BUILD_DIR"
+  fi
+}
+
 if ! command -v git >/dev/null 2>&1; then
   echo "error: git is required to prepare vendored PcapPlusPlus." >&2
   exit 1
@@ -59,6 +82,7 @@ if git -C "$SOURCE_DIR" rev-parse --verify --quiet "$PINNED_TAG^{commit}" >/dev/
 fi
 
 mkdir -p "$BUILD_DIR" "$INSTALL_ROOT"
+reset_mismatched_cmake_cache
 
 if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$CURRENT_STAMP_CONTENT" ] \
   && [ -f "$INSTALL_ROOT/lib/libPcap++.a" ] \


### PR DESCRIPTION
## Summary
- Move live capture packet retention to a private disk-backed store with compact in-memory indexes.
- Reduce Swift-side duplication by tracking visible packet IDs, not full packet copies, across navigation and table models.
- Add debug-only test harnesses plus large-scale coverage for append/read/inspect behavior, cleanup, and RSS growth.

## Testing
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme PcapPlusPlusCore -destination 'platform=macOS'`
- Gated RSS stress validation passed with `TCPVIEWER_RUN_MEMORY_STRESS=1` on the PcapPlusPlusCore test bundle