### PR TITLE
Add interface history and source list deletion

### DIFF
--- a/TCPViewer/App/Settings/AppConfiguration.swift
+++ b/TCPViewer/App/Settings/AppConfiguration.swift
@@ -44,9 +44,11 @@ final class AppConfiguration: NSObject {
     }
 
     private let defaults: UserDefaults
+    let interfaceSelectionHistory: InterfaceSelectionHistoryStore
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        self.interfaceSelectionHistory = InterfaceSelectionHistoryStore(defaults: defaults)
         super.init()
         registerDefaults()
     }
@@ -119,6 +121,7 @@ final class AppConfiguration: NSObject {
         defaults.removeObject(forKey: Key.packetFontSize)
         defaults.removeObject(forKey: Key.usesMonospacedPacketFont)
         defaults.removeObject(forKey: Key.appearanceTheme)
+        interfaceSelectionHistory.clear()
         registerDefaults()
         notifyChange()
     }

--- a/TCPViewer/App/Settings/InterfaceSelectionHistoryStore.swift
+++ b/TCPViewer/App/Settings/InterfaceSelectionHistoryStore.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+final class InterfaceSelectionHistoryStore {
+    static let storageKey = "TCPViewer.settings.interfaceSelection.lastUsedInterfaceIDs"
+    static let defaultMaximumInterfaceCount = 5
+
+    private static let legacyStorageKey = "TCPViewer.lastUsedInterfaceIDs"
+
+    private let defaults: UserDefaults
+    private let maximumInterfaceCount: Int
+
+    init(
+        defaults: UserDefaults = .standard,
+        maximumInterfaceCount: Int = InterfaceSelectionHistoryStore.defaultMaximumInterfaceCount
+    ) {
+        self.defaults = defaults
+        self.maximumInterfaceCount = max(1, maximumInterfaceCount)
+    }
+
+    var lastUsedInterfaceIDs: [String] {
+        sanitizedHistory(from: storedInterfaceIDs())
+    }
+
+    @discardableResult
+    func recordInterfaceUsage(_ interfaceID: String) -> [String] {
+        let normalizedID = interfaceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedID.isEmpty else {
+            return lastUsedInterfaceIDs
+        }
+
+        return replaceHistory(with: [normalizedID] + lastUsedInterfaceIDs)
+    }
+
+    @discardableResult
+    func replaceHistory(with interfaceIDs: [String]) -> [String] {
+        let history = sanitizedHistory(from: interfaceIDs)
+        defaults.set(history, forKey: Self.storageKey)
+        defaults.removeObject(forKey: Self.legacyStorageKey)
+        return history
+    }
+
+    func clear() {
+        defaults.removeObject(forKey: Self.storageKey)
+        defaults.removeObject(forKey: Self.legacyStorageKey)
+    }
+
+    private func storedInterfaceIDs() -> [String] {
+        if let ids = defaults.stringArray(forKey: Self.storageKey) {
+            return ids
+        }
+
+        return defaults.stringArray(forKey: Self.legacyStorageKey) ?? []
+    }
+
+    private func sanitizedHistory(from interfaceIDs: [String]) -> [String] {
+        var seen = Set<String>()
+        var history: [String] = []
+
+        for interfaceID in interfaceIDs {
+            let normalizedID = interfaceID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedID.isEmpty, seen.insert(normalizedID).inserted else {
+                continue
+            }
+
+            history.append(normalizedID)
+            if history.count == maximumInterfaceCount {
+                break
+            }
+        }
+
+        return history
+    }
+}

--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -100,6 +100,7 @@ final class TCPViewerToolbarDataSource: NSObject {
         interfacePopup.target = self
         interfacePopup.action = #selector(interfaceChanged(_:))
         interfacePopup.controlSize = .regular
+        interfacePopup.menu?.autoenablesItems = false
 
         captureButton.target = self
         captureButton.action = #selector(captureButtonPressed(_:))
@@ -138,25 +139,81 @@ final class TCPViewerToolbarDataSource: NSObject {
 
     private func renderInterfacePopup() {
         interfacePopup.removeAllItems()
+        interfacePopup.menu?.autoenablesItems = false
         if viewModel.interfaces.isEmpty {
             interfacePopup.addItem(withTitle: "No Interfaces")
             interfacePopup.isEnabled = false
             return
         }
 
-        for interface in viewModel.interfaces {
-            let title = interface.friendlyName ?? interface.displayName
-            interfacePopup.addItem(withTitle: title)
-            interfacePopup.lastItem?.representedObject = interface.id
-            interfacePopup.lastItem?.isEnabled = interface.isSelectable && !viewModel.isCaptureLocked
+        let recentInterfaces = viewModel.lastUsedInterfaceIDs.compactMap { identifier in
+            viewModel.interfaces.first { $0.id == identifier }
+        }
+        let recentInterfaceIDs = Set(recentInterfaces.map(\.id))
+        let remainingInterfaces = viewModel.interfaces.filter { !recentInterfaceIDs.contains($0.id) }
+
+        if !recentInterfaces.isEmpty {
+            addInterfaceGroupHeader("Last used")
+            recentInterfaces.forEach(addInterfaceItem)
+            if !remainingInterfaces.isEmpty {
+                interfacePopup.menu?.addItem(.separator())
+            }
         }
 
-        if let selectedID = viewModel.selectedInterfaceID,
-           let index = viewModel.interfaces.firstIndex(where: { $0.id == selectedID }) {
-            interfacePopup.selectItem(at: index)
+        remainingInterfaces.forEach(addInterfaceItem)
+        if !selectInterfaceItem(with: viewModel.selectedInterfaceID) {
+            selectFirstInterfaceItem()
         }
-
         interfacePopup.isEnabled = !viewModel.isCaptureLocked
+    }
+
+    private func addInterfaceGroupHeader(_ title: String) {
+        // Add a disabled group label so recent interfaces read separately from the full inventory.
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.attributedTitle = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold),
+                .foregroundColor: NSColor.disabledControlTextColor,
+            ]
+        )
+        item.isEnabled = false
+        interfacePopup.menu?.addItem(item)
+    }
+
+    private func addInterfaceItem(_ interface: CaptureInterfaceSummary) {
+        // Keep each menu item self-identifying so selection does not depend on grouped menu indexes.
+        let item = NSMenuItem(title: interface.friendlyName ?? interface.displayName, action: nil, keyEquivalent: "")
+        item.representedObject = interface.id
+        item.isEnabled = interface.isSelectable && !viewModel.isCaptureLocked
+        interfacePopup.menu?.addItem(item)
+    }
+
+    @discardableResult
+    private func selectInterfaceItem(with identifier: String?) -> Bool {
+        // Select by represented identifier because recent grouping changes visible row order.
+        guard let identifier, let menu = interfacePopup.menu else {
+            return false
+        }
+
+        for (index, item) in menu.items.enumerated() where item.representedObject as? String == identifier {
+            interfacePopup.selectItem(at: index)
+            return true
+        }
+
+        return false
+    }
+
+    private func selectFirstInterfaceItem() {
+        // Avoid leaving the disabled group header as the visible popup title when no selection exists.
+        guard let menu = interfacePopup.menu else {
+            return
+        }
+
+        for (index, item) in menu.items.enumerated() where item.representedObject is String {
+            interfacePopup.selectItem(at: index)
+            return
+        }
     }
 
     private func renderCaptureButton() {
@@ -180,6 +237,9 @@ final class TCPViewerToolbarDataSource: NSObject {
 
     @objc private func interfaceChanged(_ sender: NSPopUpButton) {
         guard let identifier = sender.selectedItem?.representedObject as? String else {
+            if !selectInterfaceItem(with: viewModel.selectedInterfaceID) {
+                selectFirstInterfaceItem()
+            }
             return
         }
 
@@ -259,6 +319,7 @@ private final class TCPViewerToolbarViewModel {
     private(set) var selectedInterfaceTitle = "Interface"
     private(set) var interfaces: [CaptureInterfaceSummary] = []
     private(set) var selectedInterfaceID: String?
+    private(set) var lastUsedInterfaceIDs: [String] = []
     private(set) var isCaptureLocked = false
     private(set) var captureButtonTitle = "Start"
     private(set) var captureButtonImageName = "play.fill"
@@ -276,6 +337,7 @@ private final class TCPViewerToolbarViewModel {
     func render(snapshot: NetworkInspectorSnapshot, viewModel: NetworkInspectorViewModel) {
         interfaces = snapshot.base.sessionState.interfaceInventory
         selectedInterfaceID = snapshot.base.sessionState.selectedInterfaceID
+        lastUsedInterfaceIDs = snapshot.base.sessionState.lastUsedInterfaceIDs
         selectedInterfaceTitle = viewModel.selectedInterfaceTitle()
         isCaptureLocked = snapshot.isCaptureLocked
         captureButtonTitle = viewModel.captureButtonTitle()

--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -10,7 +10,10 @@ final class TCPViewerWindowController: NSWindowController {
     private var helperSheetWindow: NSWindow?
 
     init(services: TCPViewerServiceRegistry, configuration: AppConfiguration, initialURL: URL? = nil) {
-        let viewModel = NetworkInspectorViewModel(services: services)
+        let viewModel = NetworkInspectorViewModel(
+            services: services,
+            interfaceHistoryStore: configuration.interfaceSelectionHistory
+        )
         self.rootViewController = TCPViewerRootViewController(viewModel: viewModel, configuration: configuration)
         let window = NSWindow(contentViewController: rootViewController)
         window.title = initialURL?.lastPathComponent ?? "TCP Viewer"

--- a/TCPViewer/Core/AppKitUIUtilities.swift
+++ b/TCPViewer/Core/AppKitUIUtilities.swift
@@ -30,7 +30,8 @@ enum TCPViewerUI {
         title: String,
         imageName: String,
         message: String,
-        placement: PlaceholderPlacement = .center
+        placement: PlaceholderPlacement = .center,
+        iconTitleSpacing: CGFloat = 10
     ) -> NSView {
         let imageView = NSImageView(image: image(imageName) ?? NSImage())
         imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 42, weight: .regular)
@@ -47,6 +48,7 @@ enum TCPViewerUI {
         stack.orientation = .vertical
         stack.alignment = .centerX
         stack.spacing = 10
+        stack.setCustomSpacing(iconTitleSpacing, after: imageView)
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         let container = NSView()

--- a/TCPViewer/Core/TCPViewerUserDataDirectory.swift
+++ b/TCPViewer/Core/TCPViewerUserDataDirectory.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+final class TCPViewerUserDataDirectory {
+    static let shared = TCPViewerUserDataDirectory()
+
+    private static let appFolderName = "TCPViewer"
+    private static let settingsFolderName = "settings"
+
+    private let fileManager: FileManager
+    private let applicationSupportBaseURL: URL
+
+    init(fileManager: FileManager = .default, applicationSupportBaseURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.applicationSupportBaseURL = applicationSupportBaseURL ?? Self.defaultApplicationSupportBaseURL(fileManager: fileManager)
+    }
+
+    var appDirectoryURL: URL {
+        applicationSupportBaseURL.appendingPathComponent(Self.appFolderName, isDirectory: true)
+    }
+
+    var settingsDirectoryURL: URL {
+        appDirectoryURL.appendingPathComponent(Self.settingsFolderName, isDirectory: true)
+    }
+
+    func settingsFileURL(named fileName: String) -> URL {
+        settingsDirectoryURL.appendingPathComponent(fileName)
+    }
+
+    @discardableResult
+    func createSettingsDirectoryIfNeeded() throws -> URL {
+        try fileManager.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)
+        return settingsDirectoryURL
+    }
+
+    private static func defaultApplicationSupportBaseURL(fileManager: FileManager) -> URL {
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+    }
+}

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -97,6 +97,30 @@ struct PacketIngestState: Sendable, Equatable {
         }
     }
 
+    mutating func delete(packetIDs: Set<PacketSummary.ID>, message: String? = nil) {
+        guard !packetIDs.isEmpty else {
+            lastMutation = .none
+            return
+        }
+
+        let originalCount = packets.count
+        packets.removeAll { packetIDs.contains($0.id) }
+        guard packets.count != originalCount else {
+            lastMutation = .none
+            return
+        }
+
+        rebuildPacketIndex()
+        packetRevision &+= 1
+        packetLineageRevision &+= 1
+        lastMutation = .replace
+        lastBatchCount = 0
+        recalculateCounters()
+        if let message {
+            statusMessage = message
+        }
+    }
+
     mutating func applyMetadataUpdates(_ updates: [PacketMetadataUpdate]) {
         var didUpdate = false
         for update in updates {
@@ -1236,6 +1260,29 @@ final class TCPViewerWorkspaceController {
         services.packetMetadataEnricher.reset()
         if shouldReleaseStoppedLiveSession {
             releaseLiveSession()
+        }
+    }
+
+    func deletePackets(_ packetIDs: Set<PacketSummary.ID>) {
+        guard !packetIDs.isEmpty else {
+            return
+        }
+
+        batchSnapshotUpdates {
+            let source = snapshot.packetIngestState.source
+            snapshot.packetIngestState.delete(packetIDs: packetIDs, message: "Deleted \(packetIDs.count) packet(s).")
+            synchronizeVisiblePackets(message: snapshot.packetIngestState.statusMessage)
+
+            switch source {
+            case .some(.live):
+                snapshot.sessionState.capturedPacketCount = snapshot.packetIngestState.totalPacketCount
+            case .some(.offline):
+                snapshot.documentState.packetCount = snapshot.packetIngestState.totalPacketCount
+            case nil:
+                break
+            case .some:
+                break
+            }
         }
     }
 

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -256,6 +256,7 @@ struct CaptureSessionState: Sendable, Equatable {
     var phase: Phase
     var interfaceInventory: [CaptureInterfaceSummary]
     var selectedInterfaceID: String?
+    var lastUsedInterfaceIDs: [String]
     var options: CaptureOptions
     var health: CaptureHealthSnapshot
     var capturedPacketCount: Int
@@ -266,6 +267,7 @@ struct CaptureSessionState: Sendable, Equatable {
         phase: .idle,
         interfaceInventory: [],
         selectedInterfaceID: nil,
+        lastUsedInterfaceIDs: [],
         options: CaptureOptions.defaults(),
         health: .empty,
         capturedPacketCount: 0,
@@ -598,6 +600,7 @@ final class TCPViewerWorkspaceController {
     let services: TCPViewerServiceRegistry
     private let backgroundCoordinator: TCPViewerBackgroundCoordinator
     private let preferences: TCPViewerPreferences
+    private let interfaceHistoryStore: InterfaceSelectionHistoryStore
 
     private var hasPerformedInitialLoad = false
     private var liveSession: (any LiveCaptureSessionProviding)?
@@ -614,14 +617,17 @@ final class TCPViewerWorkspaceController {
         services: TCPViewerServiceRegistry? = nil,
         backgroundCoordinator: TCPViewerBackgroundCoordinator? = nil,
         snapshot: TCPViewerWindowSnapshot? = nil,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        interfaceHistoryStore: InterfaceSelectionHistoryStore? = nil
     ) {
         self.services = services ?? .foundation
         self.backgroundCoordinator = backgroundCoordinator ?? TCPViewerBackgroundCoordinator()
         self.preferences = TCPViewerPreferences(defaults: userDefaults)
+        self.interfaceHistoryStore = interfaceHistoryStore ?? InterfaceSelectionHistoryStore(defaults: userDefaults)
         var resolvedSnapshot = snapshot ?? .foundation
         resolvedSnapshot.filterState.captureFilterText = preferences.captureFilterText
         resolvedSnapshot.filterState.recentCaptureFilters = preferences.recentCaptureFilters
+        resolvedSnapshot.sessionState.lastUsedInterfaceIDs = self.interfaceHistoryStore.lastUsedInterfaceIDs
         self.snapshot = resolvedSnapshot
         TCPViewerWorkspaceControllerRegistry.shared.register(self)
     }
@@ -1458,6 +1464,16 @@ final class TCPViewerWorkspaceController {
         preferences.persistRecentCaptureFilters(recents)
     }
 
+    private func persistLastUsedInterface(_ interfaceID: String) {
+        // Promote the started interface while preserving a short, unique MRU list.
+        let normalizedID = interfaceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedID.isEmpty else {
+            return
+        }
+
+        snapshot.sessionState.lastUsedInterfaceIDs = interfaceHistoryStore.recordInterfaceUsage(normalizedID)
+    }
+
     private func makeAndStartLiveSession(
         interface: CaptureInterfaceSummary,
         options: CaptureOptions,
@@ -1521,7 +1537,9 @@ final class TCPViewerWorkspaceController {
                     return
                 }
 
-                if case .failure(let error) = result {
+                if case .success = result {
+                    self.persistLastUsedInterface(interface.id)
+                } else if case .failure(let error) = result {
                     let tcpviewerError = self.tcpviewerError(from: error, defaultCode: .liveSessionStartFailed)
                     self.snapshot.sessionState.phase = .failed
                     self.snapshot.sessionState.lastError = tcpviewerError

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -64,6 +64,13 @@ enum NetworkInspectorSidebarSelection: Hashable, Sendable {
     case view(NetworkInspectorWorkspaceMode)
 }
 
+private extension String {
+    var tcpviewerTrimmedNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
 enum PacketInspectorTab: String, CaseIterable, Identifiable, Sendable, Hashable {
     case summary
     case detail
@@ -124,6 +131,9 @@ struct PacketTag: Identifiable, Sendable, Hashable {
 struct PacketTableRow: Identifiable, Sendable, Hashable {
     let id: PacketSummary.ID
     let client: PacketClient?
+    let sourceAddress: String?
+    let destinationAddress: String?
+    let sniDomainName: String?
     let numberText: String
     let timeText: String
     let sourceText: String
@@ -139,6 +149,9 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
     init(packet: PacketSummary) {
         self.id = packet.id
         self.client = packet.client
+        self.sourceAddress = packet.endpoints.source.address
+        self.destinationAddress = packet.endpoints.destination.address
+        self.sniDomainName = packet.sniDomainName
         self.numberText = "\(packet.packetNumber)"
         self.timeText = NetworkInspectorFormatters.packetTime.string(from: packet.timestamp)
         self.sourceText = NetworkInspectorFormatters.endpointLabel(packet.endpoints.source)
@@ -154,6 +167,52 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
 
     var tagText: String {
         tags.map(\.label).joined(separator: " | ")
+    }
+
+    var canPinDomain: Bool {
+        sniDomainName?.tcpviewerTrimmedNonEmpty != nil
+    }
+
+    var canPinClient: Bool {
+        client != nil
+    }
+
+    func ipAddress(for clickedColumn: PacketTableColumnRole) -> String? {
+        switch clickedColumn {
+        case .source:
+            return sourceAddress ?? destinationAddress
+        case .destination:
+            return destinationAddress ?? sourceAddress
+        default:
+            return destinationAddress ?? sourceAddress
+        }
+    }
+
+    func text(for column: PacketTableColumnRole) -> String {
+        switch column {
+        case .number:
+            numberText
+        case .time:
+            timeText
+        case .source:
+            sourceText
+        case .destination:
+            destinationText
+        case .domain:
+            domainText
+        case .client:
+            clientText
+        case .protocol:
+            protocolText
+        case .length:
+            lengthText
+        case .summary:
+            summaryText
+        case .tags:
+            tagText
+        case .unknown:
+            ""
+        }
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+enum PacketTableColumnRole: String, Equatable, Sendable {
+    case number
+    case time
+    case source
+    case destination
+    case domain
+    case client
+    case `protocol`
+    case length
+    case summary
+    case tags
+    case unknown
+
+    init(columnIdentifier: String?) {
+        guard let columnIdentifier else {
+            self = .unknown
+            return
+        }
+
+        self = PacketTableColumnRole(rawValue: columnIdentifier) ?? .unknown
+    }
+}
+
+struct PacketTableMenuState: Equatable {
+    let targetRows: [Int]
+    let clickedColumn: PacketTableColumnRole
+    let copyRowEnabled: Bool
+    let copyCellEnabled: Bool
+    let pinDomainEnabled: Bool
+    let pinIPEnabled: Bool
+    let pinClientEnabled: Bool
+    let saveEnabled: Bool
+    let deleteEnabled: Bool
+}
+
+enum PacketTableMenuLogic {
+    static func state(
+        rows: [PacketTableRow],
+        selectedRowIndexes: IndexSet,
+        clickedRowIndex: Int?,
+        clickedColumnIdentifier: String?
+    ) -> PacketTableMenuState {
+        let targetIndexes = targetRowIndexes(
+            rowCount: rows.count,
+            selectedRowIndexes: selectedRowIndexes,
+            clickedRowIndex: clickedRowIndex
+        )
+        let targetRows = targetIndexes.compactMap { rows.indices.contains($0) ? rows[$0] : nil }
+        let clickedColumn = PacketTableColumnRole(columnIdentifier: clickedColumnIdentifier)
+        let singleRow = targetRows.count == 1 ? targetRows[0] : nil
+
+        return PacketTableMenuState(
+            targetRows: targetIndexes,
+            clickedColumn: clickedColumn,
+            copyRowEnabled: !targetRows.isEmpty,
+            copyCellEnabled: !targetRows.isEmpty && clickedColumn != .unknown,
+            pinDomainEnabled: singleRow?.canPinDomain == true,
+            pinIPEnabled: singleRow?.ipAddress(for: clickedColumn) != nil,
+            pinClientEnabled: singleRow?.canPinClient == true,
+            saveEnabled: !targetRows.isEmpty,
+            deleteEnabled: !targetRows.isEmpty
+        )
+    }
+
+    private static func targetRowIndexes(
+        rowCount: Int,
+        selectedRowIndexes: IndexSet,
+        clickedRowIndex: Int?
+    ) -> [Int] {
+        if let clickedRowIndex, clickedRowIndex >= 0, clickedRowIndex < rowCount {
+            if selectedRowIndexes.contains(clickedRowIndex) {
+                return selectedRowIndexes.filter { $0 >= 0 && $0 < rowCount }
+            }
+
+            return [clickedRowIndex]
+        }
+
+        return selectedRowIndexes.filter { $0 >= 0 && $0 < rowCount }
+    }
+}
+
+enum PacketTableCopyFormatter {
+    static let columnOrder: [PacketTableColumnRole] = [
+        .number,
+        .time,
+        .source,
+        .destination,
+        .domain,
+        .client,
+        .protocol,
+        .length,
+        .summary,
+        .tags,
+    ]
+
+    static func csvRows(_ rows: [PacketTableRow]) -> String {
+        rows
+            .map { row in
+                columnOrder.map { csvEscaped(row.text(for: $0)) }.joined(separator: ",")
+            }
+            .joined(separator: "\n")
+    }
+
+    static func csvCells(_ rows: [PacketTableRow], column: PacketTableColumnRole) -> String {
+        rows
+            .map { csvEscaped($0.text(for: column)) }
+            .joined(separator: "\n")
+    }
+
+    private static func csvEscaped(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r") else {
+            return value
+        }
+
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
@@ -85,6 +85,20 @@ final class PacketPinService {
         cachedPins
     }
 
+    func deletePin(id: PacketPinID) throws {
+        guard let index = cachedPins.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let removedPin = cachedPins.remove(at: index)
+        do {
+            try persist()
+        } catch {
+            cachedPins.insert(removedPin, at: index)
+            throw error
+        }
+    }
+
     // Create or reuse a stable pin for the selected packet criteria.
     @discardableResult
     func upsertPin(

--- a/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
@@ -1,0 +1,216 @@
+import Foundation
+import PcapPlusPlusCore
+
+struct PacketPinID: RawRepresentable, Codable, Hashable, Sendable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+enum PacketPinKind: String, Codable, Hashable, Sendable {
+    case domain
+    case ip
+    case client
+}
+
+struct PacketPin: Identifiable, Codable, Hashable, Sendable {
+    let id: PacketPinID
+    let kind: PacketPinKind
+    let title: String
+    let createdAt: Date
+    let domain: String?
+    let ipAddress: String?
+    let clientKey: String?
+    let clientDisplayName: String?
+    let clientIconFilePath: String?
+}
+
+enum PacketPinCreationKind: Equatable, Sendable {
+    case domain
+    case ip
+    case client
+}
+
+enum PacketPinCreationError: Error, Equatable {
+    case missingDomain
+    case missingIPAddress
+    case missingClient
+}
+
+enum PacketPinMatcher {
+    static func matches(_ packet: PacketSummary, pin: PacketPin) -> Bool {
+        switch pin.kind {
+        case .domain:
+            return normalizedDomain(packet.sniDomainName) == pin.domain
+        case .ip:
+            return packet.endpoints.source.address == pin.ipAddress ||
+                packet.endpoints.destination.address == pin.ipAddress
+        case .client:
+            return PacketSourceListClassifier.clientIdentity(for: packet)?.key.rawValue == pin.clientKey
+        }
+    }
+
+    static func normalizedDomain(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        return trimmed.lowercased()
+    }
+}
+
+final class PacketPinService {
+    private let storageURL: URL
+    private let fileManager: FileManager
+    private let userDataDirectory: TCPViewerUserDataDirectory
+    private let usesUserDataDirectoryStorage: Bool
+    private var cachedPins: [PacketPin]
+
+    init(
+        storageURL: URL? = nil,
+        fileManager: FileManager = .default,
+        userDataDirectory: TCPViewerUserDataDirectory = .shared
+    ) {
+        self.userDataDirectory = userDataDirectory
+        self.usesUserDataDirectoryStorage = storageURL == nil
+        self.storageURL = storageURL ?? PacketPinService.defaultStorageURL(userDataDirectory: userDataDirectory)
+        self.fileManager = fileManager
+        self.cachedPins = (try? Self.loadPins(from: self.storageURL, fileManager: fileManager)) ?? []
+    }
+
+    func pins() -> [PacketPin] {
+        cachedPins
+    }
+
+    // Create or reuse a stable pin for the selected packet criteria.
+    @discardableResult
+    func upsertPin(
+        from packet: PacketSummary,
+        kind: PacketPinCreationKind,
+        clickedColumn: PacketTableColumnRole,
+        now: Date = Date()
+    ) throws -> PacketPin {
+        let pin = try makePin(from: packet, kind: kind, clickedColumn: clickedColumn, now: now)
+        if let existingIndex = cachedPins.firstIndex(where: { $0.id == pin.id }) {
+            return cachedPins[existingIndex]
+        }
+
+        cachedPins.append(pin)
+        try persist()
+        return pin
+    }
+
+    func matchingPackets(in packets: [PacketSummary], for selection: PacketSourceListSelection) -> [PacketSummary] {
+        switch selection {
+        case .pinned:
+            return packets.filter { packet in
+                cachedPins.contains { pin in PacketPinMatcher.matches(packet, pin: pin) }
+            }
+        case .pinnedItem(let pinID):
+            guard let pin = cachedPins.first(where: { $0.id == pinID }) else {
+                return []
+            }
+            return packets.filter { PacketPinMatcher.matches($0, pin: pin) }
+        default:
+            return []
+        }
+    }
+
+    private func makePin(
+        from packet: PacketSummary,
+        kind: PacketPinCreationKind,
+        clickedColumn: PacketTableColumnRole,
+        now: Date
+    ) throws -> PacketPin {
+        switch kind {
+        case .domain:
+            guard let domain = PacketPinMatcher.normalizedDomain(packet.sniDomainName) else {
+                throw PacketPinCreationError.missingDomain
+            }
+
+            return PacketPin(
+                id: PacketPinID(rawValue: "domain:\(domain)"),
+                kind: .domain,
+                title: packet.sniDomainName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? domain,
+                createdAt: now,
+                domain: domain,
+                ipAddress: nil,
+                clientKey: nil,
+                clientDisplayName: nil,
+                clientIconFilePath: nil
+            )
+        case .ip:
+            guard let ipAddress = Self.ipAddress(from: packet, clickedColumn: clickedColumn) else {
+                throw PacketPinCreationError.missingIPAddress
+            }
+
+            return PacketPin(
+                id: PacketPinID(rawValue: "ip:\(ipAddress)"),
+                kind: .ip,
+                title: ipAddress,
+                createdAt: now,
+                domain: nil,
+                ipAddress: ipAddress,
+                clientKey: nil,
+                clientDisplayName: nil,
+                clientIconFilePath: nil
+            )
+        case .client:
+            guard let identity = PacketSourceListClassifier.clientIdentity(for: packet) else {
+                throw PacketPinCreationError.missingClient
+            }
+
+            return PacketPin(
+                id: PacketPinID(rawValue: "client:\(identity.key.rawValue)"),
+                kind: .client,
+                title: identity.displayName,
+                createdAt: now,
+                domain: nil,
+                ipAddress: nil,
+                clientKey: identity.key.rawValue,
+                clientDisplayName: identity.displayName,
+                clientIconFilePath: identity.iconFilePath
+            )
+        }
+    }
+
+    private static func ipAddress(from packet: PacketSummary, clickedColumn: PacketTableColumnRole) -> String? {
+        switch clickedColumn {
+        case .source:
+            return packet.endpoints.source.address ?? packet.endpoints.destination.address
+        case .destination:
+            return packet.endpoints.destination.address ?? packet.endpoints.source.address
+        default:
+            return packet.endpoints.destination.address ?? packet.endpoints.source.address
+        }
+    }
+
+    private func persist() throws {
+        if usesUserDataDirectoryStorage {
+            try userDataDirectory.createSettingsDirectoryIfNeeded()
+        } else {
+            try fileManager.createDirectory(at: storageURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(cachedPins).write(to: storageURL, options: .atomic)
+    }
+
+    private static func loadPins(from url: URL, fileManager: FileManager) throws -> [PacketPin] {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([PacketPin].self, from: Data(contentsOf: url))
+    }
+
+    private static func defaultStorageURL(userDataDirectory: TCPViewerUserDataDirectory) -> URL {
+        userDataDirectory.settingsFileURL(named: "PinnedPackets.json")
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -12,6 +12,10 @@ struct PacketSourceDomainKey: Hashable, Sendable {
     static let ipAddresses = PacketSourceDomainKey(rawValue: "ip-addresses", isMissingDomain: true)
 }
 
+struct PacketSourceIPAddressKey: Hashable, Sendable {
+    let rawValue: String
+}
+
 enum PacketSourceListSelection: Hashable, Sendable {
     case allPackets
     case pinned
@@ -21,6 +25,7 @@ enum PacketSourceListSelection: Hashable, Sendable {
     case app(PacketSourceClientKey)
     case domains
     case domain(PacketSourceDomainKey)
+    case ipAddress(PacketSourceIPAddressKey)
 }
 
 enum PacketSourceListItemKind: Hashable, Sendable {
@@ -62,6 +67,7 @@ struct PacketSourceListSnapshot: Equatable, Sendable {
         roots: PacketSourceListTreeBuilder.makeRoots(
             appBuckets: [],
             domainBuckets: [],
+            ipAddressBuckets: [],
             pinnedBuckets: [],
             savedPacketCount: 0
         )
@@ -153,6 +159,40 @@ struct PacketSourceDomainIdentity: Hashable, Sendable {
     let displayName: String
 }
 
+struct PacketSourceIPAddressIdentity: Hashable, Sendable {
+    let key: PacketSourceIPAddressKey
+    let displayName: String
+}
+
+enum PacketSourceListDeletionAction: Equatable, Sendable {
+    case none
+    case deletePin(PacketPinID)
+    case deletePackets(PacketSourceListSelection)
+
+    var isEnabled: Bool {
+        self != .none
+    }
+}
+
+enum PacketSourceListDeletionPolicy {
+    static func action(for item: PacketSourceListItem?) -> PacketSourceListDeletionAction {
+        guard let selection = item?.selection else {
+            return .none
+        }
+
+        switch selection {
+        case .pinnedItem(let pinID):
+            return .deletePin(pinID)
+        case .app, .ipAddress:
+            return .deletePackets(selection)
+        case .domain(let key) where !key.isMissingDomain:
+            return .deletePackets(selection)
+        default:
+            return .none
+        }
+    }
+}
+
 enum PacketSourceListClassifier {
     static func clientIdentity(for packet: PacketSummary) -> PacketSourceClientIdentity? {
         guard let client = packet.client else {
@@ -204,6 +244,32 @@ enum PacketSourceListClassifier {
         )
     }
 
+    static func ipAddressIdentities(for packet: PacketSummary) -> [PacketSourceIPAddressIdentity] {
+        guard domainIdentity(for: packet).key.isMissingDomain else {
+            return []
+        }
+
+        var seenKeys = Set<PacketSourceIPAddressKey>()
+        return [
+            trimmed(packet.endpoints.destination.address),
+            trimmed(packet.endpoints.source.address),
+        ].compactMap { address in
+            guard let address else {
+                return nil
+            }
+
+            let key = PacketSourceIPAddressKey(rawValue: address.lowercased())
+            guard seenKeys.insert(key).inserted else {
+                return nil
+            }
+
+            return PacketSourceIPAddressIdentity(
+                key: key,
+                displayName: address
+            )
+        }
+    }
+
     static func matches(_ packet: PacketSummary, selection: PacketSourceListSelection) -> Bool {
         switch selection {
         case .allPackets:
@@ -218,6 +284,8 @@ enum PacketSourceListClassifier {
             return true
         case .domain(let key):
             return domainIdentity(for: packet).key == key
+        case .ipAddress(let key):
+            return ipAddressIdentities(for: packet).contains { $0.key == key }
         }
     }
 
@@ -244,6 +312,8 @@ final class PacketSourceListService {
     private var appOrder: [PacketSourceClientKey] = []
     private var domainBuckets: [PacketSourceDomainKey: PacketSourceListTreeBuilder.DomainBucket] = [:]
     private var domainOrder: [PacketSourceDomainKey] = []
+    private var ipAddressBuckets: [PacketSourceIPAddressKey: PacketSourceListTreeBuilder.IPAddressBucket] = [:]
+    private var ipAddressOrder: [PacketSourceIPAddressKey] = []
     private var pinnedItems: [PacketPin] = []
     private var savedPacketCount = 0
 
@@ -256,6 +326,8 @@ final class PacketSourceListService {
         appOrder.removeAll(keepingCapacity: false)
         domainBuckets.removeAll(keepingCapacity: false)
         domainOrder.removeAll(keepingCapacity: false)
+        ipAddressBuckets.removeAll(keepingCapacity: false)
+        ipAddressOrder.removeAll(keepingCapacity: false)
         pinnedItems = []
         savedPacketCount = 0
     }
@@ -298,6 +370,8 @@ final class PacketSourceListService {
         appOrder = []
         domainBuckets = [:]
         domainOrder = []
+        ipAddressBuckets = [:]
+        ipAddressOrder = []
         appendPackets(ingestState.packets)
         return storeSnapshot(for: ingestState)
     }
@@ -325,6 +399,15 @@ final class PacketSourceListService {
             }
 
             domainBuckets[domainIdentity.key]?.packetCount += 1
+
+            for ipAddressIdentity in PacketSourceListClassifier.ipAddressIdentities(for: packet) {
+                if ipAddressBuckets[ipAddressIdentity.key] == nil {
+                    ipAddressOrder.append(ipAddressIdentity.key)
+                    ipAddressBuckets[ipAddressIdentity.key] = PacketSourceListTreeBuilder.IPAddressBucket(identity: ipAddressIdentity)
+                }
+
+                ipAddressBuckets[ipAddressIdentity.key]?.packetCount += 1
+            }
         }
     }
 
@@ -335,6 +418,7 @@ final class PacketSourceListService {
         cachedSnapshot = PacketSourceListTreeBuilder.makeSnapshot(
             appBuckets: appOrder.compactMap { appBuckets[$0] },
             domainBuckets: domainOrder.compactMap { domainBuckets[$0] },
+            ipAddressBuckets: ipAddressOrder.compactMap { ipAddressBuckets[$0] },
             pinnedBuckets: pinnedItems.map { pin in
                 PacketSourceListTreeBuilder.PinnedBucket(
                     pin: pin,
@@ -369,6 +453,11 @@ enum PacketSourceListTreeBuilder {
         var packetCount = 0
     }
 
+    struct IPAddressBucket: Equatable, Sendable {
+        let identity: PacketSourceIPAddressIdentity
+        var packetCount = 0
+    }
+
     struct PinnedBucket: Equatable, Sendable {
         let pin: PacketPin
         var packetCount = 0
@@ -391,6 +480,7 @@ enum PacketSourceListTreeBuilder {
     static func makeSnapshot(
         appBuckets: [AppBucket],
         domainBuckets: [DomainBucket],
+        ipAddressBuckets: [IPAddressBucket] = [],
         pinnedBuckets: [PinnedBucket] = [],
         savedPacketCount: Int = 0
     ) -> PacketSourceListSnapshot {
@@ -398,6 +488,7 @@ enum PacketSourceListTreeBuilder {
             roots: makeRoots(
                 appBuckets: appBuckets,
                 domainBuckets: domainBuckets,
+                ipAddressBuckets: ipAddressBuckets,
                 pinnedBuckets: pinnedBuckets,
                 savedPacketCount: savedPacketCount
             )
@@ -407,6 +498,7 @@ enum PacketSourceListTreeBuilder {
     static func makeRoots(
         appBuckets: [AppBucket],
         domainBuckets: [DomainBucket],
+        ipAddressBuckets: [IPAddressBucket] = [],
         pinnedBuckets: [PinnedBucket] = [],
         savedPacketCount: Int = 0
     ) -> [PacketSourceListItem] {
@@ -422,6 +514,18 @@ enum PacketSourceListTreeBuilder {
                 children: []
             )
         }
+        let ipAddressItems = ipAddressBuckets.map { bucket in
+            PacketSourceListItem(
+                id: "ip:\(bucket.identity.key.rawValue)",
+                title: bucket.identity.displayName,
+                systemImageName: "network",
+                iconFilePath: nil,
+                count: bucket.packetCount,
+                kind: .domain,
+                selection: .ipAddress(bucket.identity.key),
+                children: []
+            )
+        }
         let domainItems = domainBuckets.map { bucket in
             PacketSourceListItem(
                 id: "domain:\(bucket.identity.key.rawValue)",
@@ -431,7 +535,7 @@ enum PacketSourceListTreeBuilder {
                 count: bucket.packetCount,
                 kind: .domain,
                 selection: .domain(bucket.identity.key),
-                children: []
+                children: bucket.identity.key.isMissingDomain ? ipAddressItems : []
             )
         }
         let pinnedItems = pinnedBuckets.map { bucket in

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -15,6 +15,7 @@ struct PacketSourceDomainKey: Hashable, Sendable {
 enum PacketSourceListSelection: Hashable, Sendable {
     case allPackets
     case pinned
+    case pinnedItem(PacketPinID)
     case saved
     case apps
     case app(PacketSourceClientKey)
@@ -28,6 +29,7 @@ enum PacketSourceListItemKind: Hashable, Sendable {
     case folder
     case app
     case domain
+    case pin
 }
 
 struct PacketSourceListItem: Identifiable, Equatable, Sendable {
@@ -56,10 +58,14 @@ struct PacketSourceListItem: Identifiable, Equatable, Sendable {
 struct PacketSourceListSnapshot: Equatable, Sendable {
     let roots: [PacketSourceListItem]
 
-    static let empty = PacketSourceListSnapshot(roots: PacketSourceListTreeBuilder.makeRoots(
-        appBuckets: [],
-        domainBuckets: []
-    ))
+    static let empty = PacketSourceListSnapshot(
+        roots: PacketSourceListTreeBuilder.makeRoots(
+            appBuckets: [],
+            domainBuckets: [],
+            pinnedBuckets: [],
+            savedPacketCount: 0
+        )
+    )
 
     // Return a display-only filtered tree while preserving ancestors for matching children.
     func filtered(matching filterText: String) -> PacketSourceListSnapshot {
@@ -202,7 +208,7 @@ enum PacketSourceListClassifier {
         switch selection {
         case .allPackets:
             return true
-        case .pinned, .saved:
+        case .pinned, .pinnedItem, .saved:
             return false
         case .apps:
             return clientIdentity(for: packet) != nil
@@ -238,6 +244,8 @@ final class PacketSourceListService {
     private var appOrder: [PacketSourceClientKey] = []
     private var domainBuckets: [PacketSourceDomainKey: PacketSourceListTreeBuilder.DomainBucket] = [:]
     private var domainOrder: [PacketSourceDomainKey] = []
+    private var pinnedItems: [PacketPin] = []
+    private var savedPacketCount = 0
 
     func reset() {
         packetRevision = nil
@@ -248,6 +256,8 @@ final class PacketSourceListService {
         appOrder.removeAll(keepingCapacity: false)
         domainBuckets.removeAll(keepingCapacity: false)
         domainOrder.removeAll(keepingCapacity: false)
+        pinnedItems = []
+        savedPacketCount = 0
     }
 
     #if DEBUG
@@ -260,10 +270,19 @@ final class PacketSourceListService {
     #endif
 
     // Keep the tree in sync with packet mutations, using append when packet lineage is unchanged.
-    func snapshot(for ingestState: PacketIngestState) -> PacketSourceListSnapshot {
-        guard packetRevision != ingestState.packetRevision else {
+    func snapshot(
+        for ingestState: PacketIngestState,
+        pinnedItems: [PacketPin] = [],
+        savedPacketCount: Int = 0
+    ) -> PacketSourceListSnapshot {
+        guard packetRevision != ingestState.packetRevision ||
+                self.pinnedItems != pinnedItems ||
+                self.savedPacketCount != savedPacketCount else {
             return cachedSnapshot
         }
+
+        self.pinnedItems = pinnedItems
+        self.savedPacketCount = savedPacketCount
 
         if packetLineageRevision == ingestState.packetLineageRevision,
            sourcePacketCount <= ingestState.packets.count,
@@ -315,7 +334,18 @@ final class PacketSourceListService {
         sourcePacketCount = ingestState.packets.count
         cachedSnapshot = PacketSourceListTreeBuilder.makeSnapshot(
             appBuckets: appOrder.compactMap { appBuckets[$0] },
-            domainBuckets: domainOrder.compactMap { domainBuckets[$0] }
+            domainBuckets: domainOrder.compactMap { domainBuckets[$0] },
+            pinnedBuckets: pinnedItems.map { pin in
+                PacketSourceListTreeBuilder.PinnedBucket(
+                    pin: pin,
+                    packetCount: ingestState.packets.reduce(into: 0) { count, packet in
+                        if PacketPinMatcher.matches(packet, pin: pin) {
+                            count += 1
+                        }
+                    }
+                )
+            },
+            savedPacketCount: savedPacketCount
         )
         return cachedSnapshot
     }
@@ -339,23 +369,47 @@ enum PacketSourceListTreeBuilder {
         var packetCount = 0
     }
 
+    struct PinnedBucket: Equatable, Sendable {
+        let pin: PacketPin
+        var packetCount = 0
+    }
+
     static let favoritesGroupID = "group:favorites"
     static let allGroupID = "group:all"
+    static let pinnedFolderID = "favorite:pinned"
     static let appsFolderID = "folder:apps"
     static let domainsFolderID = "folder:domains"
 
     static let defaultExpandedItemIDs: Set<String> = [
         favoritesGroupID,
         allGroupID,
+        pinnedFolderID,
         appsFolderID,
         domainsFolderID,
     ]
 
-    static func makeSnapshot(appBuckets: [AppBucket], domainBuckets: [DomainBucket]) -> PacketSourceListSnapshot {
-        PacketSourceListSnapshot(roots: makeRoots(appBuckets: appBuckets, domainBuckets: domainBuckets))
+    static func makeSnapshot(
+        appBuckets: [AppBucket],
+        domainBuckets: [DomainBucket],
+        pinnedBuckets: [PinnedBucket] = [],
+        savedPacketCount: Int = 0
+    ) -> PacketSourceListSnapshot {
+        PacketSourceListSnapshot(
+            roots: makeRoots(
+                appBuckets: appBuckets,
+                domainBuckets: domainBuckets,
+                pinnedBuckets: pinnedBuckets,
+                savedPacketCount: savedPacketCount
+            )
+        )
     }
 
-    static func makeRoots(appBuckets: [AppBucket], domainBuckets: [DomainBucket]) -> [PacketSourceListItem] {
+    static func makeRoots(
+        appBuckets: [AppBucket],
+        domainBuckets: [DomainBucket],
+        pinnedBuckets: [PinnedBucket] = [],
+        savedPacketCount: Int = 0
+    ) -> [PacketSourceListItem] {
         let appItems = appBuckets.map { bucket in
             PacketSourceListItem(
                 id: "app:\(bucket.identity.key.rawValue)",
@@ -380,6 +434,18 @@ enum PacketSourceListTreeBuilder {
                 children: []
             )
         }
+        let pinnedItems = pinnedBuckets.map { bucket in
+            PacketSourceListItem(
+                id: "pin:\(bucket.pin.id.rawValue)",
+                title: bucket.pin.title,
+                systemImageName: systemImageName(for: bucket.pin),
+                iconFilePath: bucket.pin.clientIconFilePath,
+                count: bucket.packetCount,
+                kind: .pin,
+                selection: .pinnedItem(bucket.pin.id),
+                children: []
+            )
+        }
 
         return [
             PacketSourceListItem(
@@ -392,21 +458,21 @@ enum PacketSourceListTreeBuilder {
                 selection: nil,
                 children: [
                     PacketSourceListItem(
-                        id: "favorite:pinned",
+                        id: pinnedFolderID,
                         title: "Pinned",
                         systemImageName: "pin.fill",
                         iconFilePath: nil,
-                        count: nil,
-                        kind: .favorite,
+                        count: pinnedBuckets.reduce(0) { $0 + $1.packetCount },
+                        kind: .folder,
                         selection: .pinned,
-                        children: []
+                        children: pinnedItems
                     ),
                     PacketSourceListItem(
                         id: "favorite:saved",
                         title: "Saved",
                         systemImageName: "tray.and.arrow.down",
                         iconFilePath: nil,
-                        count: nil,
+                        count: savedPacketCount,
                         kind: .favorite,
                         selection: .saved,
                         children: []
@@ -445,5 +511,16 @@ enum PacketSourceListTreeBuilder {
                 ]
             ),
         ]
+    }
+
+    private static func systemImageName(for pin: PacketPin) -> String {
+        switch pin.kind {
+        case .domain:
+            return "globe"
+        case .ip:
+            return "network"
+        case .client:
+            return "app"
+        }
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
@@ -1,0 +1,95 @@
+import Foundation
+import PcapPlusPlusCore
+
+struct SavedPacketRecord: Identifiable, Codable, Hashable, Sendable {
+    let id: String
+    var savedAt: Date
+    var packet: PacketSummary
+}
+
+final class SavedPacketService {
+    private let storageURL: URL
+    private let fileManager: FileManager
+    private let userDataDirectory: TCPViewerUserDataDirectory
+    private let usesUserDataDirectoryStorage: Bool
+    private var cachedRecords: [SavedPacketRecord]
+
+    init(
+        storageURL: URL? = nil,
+        fileManager: FileManager = .default,
+        userDataDirectory: TCPViewerUserDataDirectory = .shared
+    ) {
+        self.userDataDirectory = userDataDirectory
+        self.usesUserDataDirectoryStorage = storageURL == nil
+        self.storageURL = storageURL ?? SavedPacketService.defaultStorageURL(userDataDirectory: userDataDirectory)
+        self.fileManager = fileManager
+        self.cachedRecords = (try? Self.loadRecords(from: self.storageURL, fileManager: fileManager)) ?? []
+    }
+
+    func records() -> [SavedPacketRecord] {
+        cachedRecords
+    }
+
+    func packets() -> [PacketSummary] {
+        cachedRecords.map(\.packet)
+    }
+
+    // Persist selected packet summaries without storing raw packet bytes.
+    @discardableResult
+    func save(_ packets: [PacketSummary], now: Date = Date()) throws -> [SavedPacketRecord] {
+        guard !packets.isEmpty else {
+            return []
+        }
+
+        var savedRecords: [SavedPacketRecord] = []
+        for packet in packets {
+            if let index = cachedRecords.firstIndex(where: { $0.packet.id == packet.id }) {
+                cachedRecords[index].savedAt = now
+                cachedRecords[index].packet = packet
+                savedRecords.append(cachedRecords[index])
+            } else {
+                let record = SavedPacketRecord(id: UUID().uuidString, savedAt: now, packet: packet)
+                cachedRecords.append(record)
+                savedRecords.append(record)
+            }
+        }
+
+        try persist()
+        return savedRecords
+    }
+
+    func deletePacketIDs(_ packetIDs: Set<PacketSummary.ID>) throws {
+        guard !packetIDs.isEmpty else {
+            return
+        }
+
+        cachedRecords.removeAll { packetIDs.contains($0.packet.id) }
+        try persist()
+    }
+
+    private func persist() throws {
+        if usesUserDataDirectoryStorage {
+            try userDataDirectory.createSettingsDirectoryIfNeeded()
+        } else {
+            try fileManager.createDirectory(at: storageURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(cachedRecords).write(to: storageURL, options: .atomic)
+    }
+
+    private static func loadRecords(from url: URL, fileManager: FileManager) throws -> [SavedPacketRecord] {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([SavedPacketRecord].self, from: Data(contentsOf: url))
+    }
+
+    private static func defaultStorageURL(userDataDirectory: TCPViewerUserDataDirectory) -> URL {
+        userDataDirectory.settingsFileURL(named: "SavedPackets.json")
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -396,12 +396,14 @@ final class NetworkInspectorViewModel {
     init(
         services: TCPViewerServiceRegistry,
         userDefaults: UserDefaults = .standard,
+        interfaceHistoryStore: InterfaceSelectionHistoryStore? = nil,
         pinService: PacketPinService = PacketPinService(),
         savedPacketService: SavedPacketService = SavedPacketService()
     ) {
         self.controller = TCPViewerWorkspaceController(
             services: services,
-            userDefaults: userDefaults
+            userDefaults: userDefaults,
+            interfaceHistoryStore: interfaceHistoryStore
         )
         self.preferences = NetworkInspectorPreferences(defaults: userDefaults)
         self.pinService = pinService
@@ -535,6 +537,17 @@ final class NetworkInspectorViewModel {
         rebuildSnapshot()
     }
 
+    func deleteSourceListItem(_ action: PacketSourceListDeletionAction) {
+        switch action {
+        case .none:
+            return
+        case .deletePin(let pinID):
+            deletePin(pinID)
+        case .deletePackets(let selection):
+            deletePackets(packetIDs(matching: selection))
+        }
+    }
+
     func updateSourceListFilterText(_ text: String) {
         sourceListFilterText = text
         rebuildSnapshot()
@@ -616,6 +629,23 @@ final class NetworkInspectorViewModel {
             controller.selectPacket(nextSelectionID)
         }
         rebuildSnapshot()
+    }
+
+    private func deletePin(_ pinID: PacketPinID) {
+        guard (try? pinService.deletePin(id: pinID)) != nil else {
+            return
+        }
+
+        if selectedSourceListSelection == .pinnedItem(pinID) {
+            selectedSourceListSelection = .pinned
+        }
+        rebuildSnapshot()
+    }
+
+    private func packetIDs(matching selection: PacketSourceListSelection) -> [PacketSummary.ID] {
+        controller.snapshot.packetIngestState.packets.compactMap { packet in
+            PacketSourceListClassifier.matches(packet, selection: selection) ? packet.id : nil
+        }
     }
 
     func updateCaptureFilterText(_ text: String) {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -54,6 +54,8 @@ private struct PacketTableContentCache {
     private var sourcePacketCount = 0
     private var displayFilterText: String?
     private var sourceListSelection: PacketSourceListSelection?
+    private var pinnedItems: [PacketPin] = []
+    private var savedRecords: [SavedPacketRecord] = []
     private var generation: UInt64 = 0
     private var cachedContent = PacketTableContent.empty
 
@@ -63,6 +65,8 @@ private struct PacketTableContentCache {
         sourcePacketCount = 0
         displayFilterText = nil
         sourceListSelection = nil
+        pinnedItems = []
+        savedRecords = []
         generation &+= 1
         cachedContent = .empty
     }
@@ -79,17 +83,26 @@ private struct PacketTableContentCache {
     mutating func content(
         for ingestState: PacketIngestState,
         displayFilterText: String,
-        sourceListSelection: PacketSourceListSelection
+        sourceListSelection: PacketSourceListSelection,
+        pinnedItems: [PacketPin],
+        savedRecords: [SavedPacketRecord]
     ) -> PacketTableContent {
-        guard packetRevision != ingestState.packetRevision ||
-                self.displayFilterText != displayFilterText ||
-                self.sourceListSelection != sourceListSelection else {
+        guard shouldRebuildContent(
+            ingestState: ingestState,
+            displayFilterText: displayFilterText,
+            sourceListSelection: sourceListSelection,
+            pinnedItems: pinnedItems,
+            savedRecords: savedRecords
+        ) else {
             return cachedContent
         }
 
         let displayFilter = PacketDisplayFilter(displayFilterText)
-        if self.displayFilterText == displayFilterText,
+        if sourceListSelection != .saved,
+           self.displayFilterText == displayFilterText,
            self.sourceListSelection == sourceListSelection,
+           self.pinnedItems == pinnedItems,
+           self.savedRecords == savedRecords,
            packetLineageRevision == ingestState.packetLineageRevision,
            sourcePacketCount <= ingestState.packets.count,
            case .append = ingestState.lastMutation {
@@ -98,7 +111,9 @@ private struct PacketTableContentCache {
                 ingestState: ingestState,
                 displayFilter: displayFilter,
                 displayFilterText: displayFilterText,
-                sourceListSelection: sourceListSelection
+                sourceListSelection: sourceListSelection,
+                pinnedItems: pinnedItems,
+                savedRecords: savedRecords
             )
         }
 
@@ -106,28 +121,53 @@ private struct PacketTableContentCache {
             from: ingestState,
             displayFilter: displayFilter,
             displayFilterText: displayFilterText,
-            sourceListSelection: sourceListSelection
+            sourceListSelection: sourceListSelection,
+            pinnedItems: pinnedItems,
+            savedRecords: savedRecords
         )
+    }
+
+    private func shouldRebuildContent(
+        ingestState: PacketIngestState,
+        displayFilterText: String,
+        sourceListSelection: PacketSourceListSelection,
+        pinnedItems: [PacketPin],
+        savedRecords: [SavedPacketRecord]
+    ) -> Bool {
+        let dependsOnIngestPackets = sourceListSelection != .saved
+        return (dependsOnIngestPackets && packetRevision != ingestState.packetRevision) ||
+            self.displayFilterText != displayFilterText ||
+            self.sourceListSelection != sourceListSelection ||
+            self.pinnedItems != pinnedItems ||
+            self.savedRecords != savedRecords
     }
 
     private mutating func rebuildContent(
         from ingestState: PacketIngestState,
         displayFilter: PacketDisplayFilter,
         displayFilterText: String,
-        sourceListSelection: PacketSourceListSelection
+        sourceListSelection: PacketSourceListSelection,
+        pinnedItems: [PacketPin],
+        savedRecords: [SavedPacketRecord]
     ) -> PacketTableContent {
         var rows: [PacketTableRow] = []
         var visiblePacketRowIndexByID: [PacketSummary.ID: Int] = [:]
         var malformedPacketCount = 0
-        rows.reserveCapacity(ingestState.packets.count)
-        visiblePacketRowIndexByID.reserveCapacity(ingestState.packets.count)
+        let sourcePackets = packets(
+            from: ingestState,
+            sourceListSelection: sourceListSelection,
+            pinnedItems: pinnedItems,
+            savedRecords: savedRecords
+        )
+        rows.reserveCapacity(sourcePackets.count)
+        visiblePacketRowIndexByID.reserveCapacity(sourcePackets.count)
 
-        for packet in ingestState.packets {
+        for packet in sourcePackets {
             if NetworkInspectorFormatters.severity(for: packet) == .malformed {
                 malformedPacketCount += 1
             }
 
-            guard PacketSourceListClassifier.matches(packet, selection: sourceListSelection),
+            guard matches(packet, selection: sourceListSelection, pinnedItems: pinnedItems),
                   displayFilter.isEmpty || displayFilter.matches(packet) else {
                 continue
             }
@@ -152,7 +192,9 @@ private struct PacketTableContentCache {
             content,
             ingestState: ingestState,
             displayFilterText: displayFilterText,
-            sourceListSelection: sourceListSelection
+            sourceListSelection: sourceListSelection,
+            pinnedItems: pinnedItems,
+            savedRecords: savedRecords
         )
     }
 
@@ -161,14 +203,18 @@ private struct PacketTableContentCache {
         ingestState: PacketIngestState,
         displayFilter: PacketDisplayFilter,
         displayFilterText: String,
-        sourceListSelection: PacketSourceListSelection
+        sourceListSelection: PacketSourceListSelection,
+        pinnedItems: [PacketPin],
+        savedRecords: [SavedPacketRecord]
     ) -> PacketTableContent {
         guard !newPackets.isEmpty else {
             return store(
                 cachedContent,
                 ingestState: ingestState,
                 displayFilterText: displayFilterText,
-                sourceListSelection: sourceListSelection
+                sourceListSelection: sourceListSelection,
+                pinnedItems: pinnedItems,
+                savedRecords: savedRecords
             )
         }
 
@@ -185,7 +231,7 @@ private struct PacketTableContentCache {
                 malformedPacketCount += 1
             }
 
-            guard PacketSourceListClassifier.matches(packet, selection: sourceListSelection),
+            guard matches(packet, selection: sourceListSelection, pinnedItems: pinnedItems),
                   displayFilter.isEmpty || displayFilter.matches(packet) else {
                 continue
             }
@@ -213,7 +259,9 @@ private struct PacketTableContentCache {
             content,
             ingestState: ingestState,
             displayFilterText: displayFilterText,
-            sourceListSelection: sourceListSelection
+            sourceListSelection: sourceListSelection,
+            pinnedItems: pinnedItems,
+            savedRecords: savedRecords
         )
     }
 
@@ -221,15 +269,55 @@ private struct PacketTableContentCache {
         _ content: PacketTableContent,
         ingestState: PacketIngestState,
         displayFilterText: String,
-        sourceListSelection: PacketSourceListSelection
+        sourceListSelection: PacketSourceListSelection,
+        pinnedItems: [PacketPin],
+        savedRecords: [SavedPacketRecord]
     ) -> PacketTableContent {
         packetRevision = ingestState.packetRevision
         packetLineageRevision = ingestState.packetLineageRevision
         sourcePacketCount = ingestState.packets.count
         self.displayFilterText = displayFilterText
         self.sourceListSelection = sourceListSelection
+        self.pinnedItems = pinnedItems
+        self.savedRecords = savedRecords
         cachedContent = content
         return content
+    }
+
+    private func packets(
+        from ingestState: PacketIngestState,
+        sourceListSelection: PacketSourceListSelection,
+        pinnedItems: [PacketPin],
+        savedRecords: [SavedPacketRecord]
+    ) -> [PacketSummary] {
+        switch sourceListSelection {
+        case .saved:
+            return savedRecords.map(\.packet)
+        case .pinned, .pinnedItem:
+            return ingestState.packets.filter { matches($0, selection: sourceListSelection, pinnedItems: pinnedItems) }
+        default:
+            return ingestState.packets
+        }
+    }
+
+    private func matches(
+        _ packet: PacketSummary,
+        selection: PacketSourceListSelection,
+        pinnedItems: [PacketPin]
+    ) -> Bool {
+        switch selection {
+        case .pinned:
+            return pinnedItems.contains { PacketPinMatcher.matches(packet, pin: $0) }
+        case .pinnedItem(let pinID):
+            guard let pin = pinnedItems.first(where: { $0.id == pinID }) else {
+                return false
+            }
+            return PacketPinMatcher.matches(packet, pin: pin)
+        case .saved:
+            return true
+        default:
+            return PacketSourceListClassifier.matches(packet, selection: selection)
+        }
     }
 }
 
@@ -287,6 +375,8 @@ final class NetworkInspectorViewModel {
     private let controller: TCPViewerWorkspaceController
     private let preferences: NetworkInspectorPreferences
     private let sourceListService = PacketSourceListService()
+    private let pinService: PacketPinService
+    private let savedPacketService: SavedPacketService
     private var packetTableContentCache = PacketTableContentCache()
     private var hasPerformedInitialLoad = false
 
@@ -303,19 +393,32 @@ final class NetworkInspectorViewModel {
         self.init(services: .foundation, userDefaults: userDefaults)
     }
 
-    init(services: TCPViewerServiceRegistry, userDefaults: UserDefaults = .standard) {
+    init(
+        services: TCPViewerServiceRegistry,
+        userDefaults: UserDefaults = .standard,
+        pinService: PacketPinService = PacketPinService(),
+        savedPacketService: SavedPacketService = SavedPacketService()
+    ) {
         self.controller = TCPViewerWorkspaceController(
             services: services,
             userDefaults: userDefaults
         )
         self.preferences = NetworkInspectorPreferences(defaults: userDefaults)
+        self.pinService = pinService
+        self.savedPacketService = savedPacketService
         self.isInspectorVisible = preferences.isInspectorVisible
         self.displayFilterText = preferences.displayFilterText
-        let sourceListSnapshot = sourceListService.snapshot(for: controller.snapshot.packetIngestState)
+        let sourceListSnapshot = sourceListService.snapshot(
+            for: controller.snapshot.packetIngestState,
+            pinnedItems: pinService.pins(),
+            savedPacketCount: savedPacketService.records().count
+        )
         let packetTableContent = packetTableContentCache.content(
             for: controller.snapshot.packetIngestState,
             displayFilterText: displayFilterText,
-            sourceListSelection: selectedSourceListSelection
+            sourceListSelection: selectedSourceListSelection,
+            pinnedItems: pinService.pins(),
+            savedRecords: savedPacketService.records()
         )
         self.snapshot = NetworkInspectorSnapshot.make(
             base: controller.snapshot,
@@ -472,6 +575,49 @@ final class NetworkInspectorViewModel {
         #endif
     }
 
+    func pinPacket(_ identifier: PacketSummary.ID, kind: PacketPinCreationKind, clickedColumn: PacketTableColumnRole) {
+        guard let packet = packet(withID: identifier),
+              let pin = try? pinService.upsertPin(from: packet, kind: kind, clickedColumn: clickedColumn) else {
+            return
+        }
+
+        selectedSourceListSelection = .pinnedItem(pin.id)
+        workspaceMode = .packets
+        rebuildSnapshot()
+    }
+
+    func savePackets(_ identifiers: [PacketSummary.ID]) {
+        let packets = packets(withIDs: identifiers)
+        guard !packets.isEmpty, (try? savedPacketService.save(packets)) != nil else {
+            return
+        }
+
+        rebuildSnapshot()
+    }
+
+    func deletePackets(_ identifiers: [PacketSummary.ID]) {
+        let packetIDs = Set(identifiers)
+        guard !packetIDs.isEmpty else {
+            return
+        }
+
+        let nextSelectionID = nextVisiblePacketIDAfterDeleting(packetIDs)
+        if selectedSourceListSelection == .saved {
+            guard (try? savedPacketService.deletePacketIDs(packetIDs)) != nil else {
+                return
+            }
+        } else {
+            controller.deletePackets(packetIDs)
+            packetTableContentCache.reset()
+        }
+
+        if let nextSelectionID,
+           controller.snapshot.packetIngestState.packet(withID: nextSelectionID) != nil {
+            controller.selectPacket(nextSelectionID)
+        }
+        rebuildSnapshot()
+    }
+
     func updateCaptureFilterText(_ text: String) {
         controller.updateCaptureFilterText(text)
         rebuildSnapshot()
@@ -611,7 +757,13 @@ final class NetworkInspectorViewModel {
     }
 
     private func rebuildSnapshot() {
-        let sourceListSnapshot = sourceListService.snapshot(for: controller.snapshot.packetIngestState)
+        let pinnedItems = pinService.pins()
+        let savedRecords = savedPacketService.records()
+        let sourceListSnapshot = sourceListService.snapshot(
+            for: controller.snapshot.packetIngestState,
+            pinnedItems: pinnedItems,
+            savedPacketCount: savedRecords.count
+        )
         if !sourceListSnapshot.contains(selection: selectedSourceListSelection) {
             selectedSourceListSelection = .allPackets
         }
@@ -619,7 +771,9 @@ final class NetworkInspectorViewModel {
         let packetTableContent = packetTableContentCache.content(
             for: controller.snapshot.packetIngestState,
             displayFilterText: displayFilterText,
-            sourceListSelection: selectedSourceListSelection
+            sourceListSelection: selectedSourceListSelection,
+            pinnedItems: pinnedItems,
+            savedRecords: savedRecords
         )
         let updatedSnapshot = NetworkInspectorSnapshot.make(
             base: controller.snapshot,
@@ -638,6 +792,41 @@ final class NetworkInspectorViewModel {
         }
 
         snapshot = updatedSnapshot
+    }
+
+    private func packet(withID identifier: PacketSummary.ID) -> PacketSummary? {
+        controller.snapshot.packetIngestState.packet(withID: identifier) ??
+            savedPacketService.records().first { $0.packet.id == identifier }?.packet
+    }
+
+    private func packets(withIDs identifiers: [PacketSummary.ID]) -> [PacketSummary] {
+        var packetsByID: [PacketSummary.ID: PacketSummary] = [:]
+        for packet in controller.snapshot.packetIngestState.packets {
+            packetsByID[packet.id] = packet
+        }
+        for record in savedPacketService.records() {
+            packetsByID[record.packet.id] = record.packet
+        }
+
+        return identifiers.compactMap { packetsByID[$0] }
+    }
+
+    private func nextVisiblePacketIDAfterDeleting(_ packetIDs: Set<PacketSummary.ID>) -> PacketSummary.ID? {
+        // Prefer the row after the deleted range, then fall back to the previous remaining row.
+        let rows = snapshot.packetRows
+        let deletedIndexes = rows.indices.filter { packetIDs.contains(rows[$0].id) }
+        guard let lastDeletedIndex = deletedIndexes.last else {
+            return nil
+        }
+
+        let nextIndex = lastDeletedIndex + 1
+        if rows.indices.contains(nextIndex) {
+            return rows[nextIndex].id
+        }
+
+        return rows.indices.reversed()
+            .first { $0 < lastDeletedIndex && !packetIDs.contains(rows[$0].id) }
+            .map { rows[$0].id }
     }
 
     #if DEBUG

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -3,6 +3,14 @@ import PcapPlusPlusCore
 
 protocol PacketTableViewControllerDelegate: AnyObject {
     func packetTableViewController(_ controller: PacketTableViewController, didSelectPacket identifier: PacketSummary.ID?)
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        didRequestPin kind: PacketPinCreationKind,
+        packetID: PacketSummary.ID,
+        clickedColumn: PacketTableColumnRole
+    )
+    func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
+    func packetTableViewController(_ controller: PacketTableViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
 }
 
 enum PacketTableSelectionSyncAction: Equatable {
@@ -16,8 +24,9 @@ enum PacketTableSelectionSyncPlanner {
         rows: [PacketTableRow],
         selectedPacketID: PacketSummary.ID?,
         selectedRowIndex: Int?,
-        tableSelectedRow: Int
+        tableSelectedRowIndexes: IndexSet
     ) -> PacketTableSelectionSyncAction {
+        let tableSelectedRow = tableSelectedRowIndexes.first ?? -1
         let visualSelectedID = rows.indices.contains(tableSelectedRow) ? rows[tableSelectedRow].id : nil
 
         guard let selectedPacketID,
@@ -31,6 +40,38 @@ enum PacketTableSelectionSyncPlanner {
         }
 
         return .select(selectedRowIndex)
+    }
+}
+
+fileprivate protocol PacketTableKeyboardActionHandling: AnyObject {
+    func packetTableViewDidRequestCopyRowsFromKeyboard(_ tableView: PacketTableView)
+    func packetTableViewDidRequestDeleteFromKeyboard(_ tableView: PacketTableView)
+}
+
+fileprivate final class PacketTableView: NSTableView {
+    weak var keyboardActionHandler: PacketTableKeyboardActionHandling?
+
+    @objc func copy(_ sender: Any?) {
+        keyboardActionHandler?.packetTableViewDidRequestCopyRowsFromKeyboard(self)
+    }
+
+    @objc func delete(_ sender: Any?) {
+        keyboardActionHandler?.packetTableViewDidRequestDeleteFromKeyboard(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags.contains(.command), event.charactersIgnoringModifiers?.lowercased() == "c" {
+            copy(nil)
+            return
+        }
+
+        if event.keyCode == 51 || event.keyCode == 117 {
+            delete(nil)
+            return
+        }
+
+        super.keyDown(with: event)
     }
 }
 
@@ -59,11 +100,13 @@ final class PacketTableViewController: NSViewController {
     weak var delegate: PacketTableViewControllerDelegate?
 
     private let configuration: AppConfiguration
-    private let tableView = NSTableView()
+    private let tableView = PacketTableView()
     private let scrollView = NSScrollView()
     private let viewModel = PacketTableViewModel()
     private var selectionCallbackSuppressionDepth = 0
     private var lastAppliedSelectedPacketID: PacketSummary.ID?
+    private var clickedRowIndex: Int?
+    private var clickedColumnIdentifier: String?
 
     private var rows: [PacketTableRow] {
         viewModel.rows
@@ -133,15 +176,18 @@ final class PacketTableViewController: NSViewController {
     private func setupTable() {
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.keyboardActionHandler = self
         tableView.usesAlternatingRowBackgroundColors = true
         tableView.allowsEmptySelection = true
-        tableView.allowsMultipleSelection = false
+        tableView.allowsMultipleSelection = true
         tableView.rowHeight = configuration.packetRowHeight
         tableView.intercellSpacing = NSSize(width: 0, height: 0)
         tableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
         tableView.selectionHighlightStyle = .regular
         tableView.style = .fullWidth
         tableView.focusRingType = .none
+        tableView.menu = NSMenu()
+        tableView.menu?.delegate = self
         
         addColumn("number", title: " No.", width: 68, minWidth: 52, cell: PacketTextCell())
         addColumn("time", title: " Time", width: 112, minWidth: 96, cell: PacketTextCell())
@@ -207,7 +253,7 @@ final class PacketTableViewController: NSViewController {
             rows: rows,
             selectedPacketID: viewModel.selectedPacketID,
             selectedRowIndex: viewModel.selectedRowIndex,
-            tableSelectedRow: tableView.selectedRow
+            tableSelectedRowIndexes: tableView.selectedRowIndexes
         )
 
         switch action {
@@ -223,30 +269,7 @@ final class PacketTableViewController: NSViewController {
     }
 
     private func text(for column: String, in row: PacketTableRow) -> String {
-        switch column {
-        case "number":
-            row.numberText
-        case "time":
-            row.timeText
-        case "source":
-            row.sourceText
-        case "destination":
-            row.destinationText
-        case "domain":
-            row.domainText
-        case "client":
-            row.clientText
-        case "protocol":
-            row.protocolText
-        case "length":
-            row.lengthText
-        case "summary":
-            row.summaryText
-        case "tags":
-            row.tagText
-        default:
-            ""
-        }
+        row.text(for: PacketTableColumnRole(columnIdentifier: column))
     }
 
     private func textStyle(for column: String, in row: PacketTableRow) -> PacketTextCell.Style {
@@ -261,6 +284,111 @@ final class PacketTableViewController: NSViewController {
         return .primary
     }
 
+    private func updateClickedPositionFromCurrentEvent() {
+        guard let event = NSApp.currentEvent else {
+            clickedRowIndex = nil
+            clickedColumnIdentifier = nil
+            return
+        }
+
+        let point = tableView.convert(event.locationInWindow, from: nil)
+        let row = tableView.row(at: point)
+        let column = tableView.column(at: point)
+        clickedRowIndex = rows.indices.contains(row) ? row : nil
+        clickedColumnIdentifier = tableView.tableColumns.indices.contains(column)
+            ? tableView.tableColumns[column].identifier.rawValue
+            : nil
+    }
+
+    private func menuState() -> PacketTableMenuState {
+        PacketTableMenuLogic.state(
+            rows: rows,
+            selectedRowIndexes: tableView.selectedRowIndexes,
+            clickedRowIndex: clickedRowIndex,
+            clickedColumnIdentifier: clickedColumnIdentifier
+        )
+    }
+
+    private func targetRows() -> [PacketTableRow] {
+        menuState().targetRows.compactMap { rows.indices.contains($0) ? rows[$0] : nil }
+    }
+
+    private func targetPacketIDs() -> [PacketSummary.ID] {
+        targetRows().map(\.id)
+    }
+
+    private func writeToPasteboard(_ value: String) {
+        guard !value.isEmpty else {
+            return
+        }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+
+    @objc private func copyRowsFromMenu(_ sender: Any?) {
+        copyTargetRows()
+    }
+
+    @objc private func copyCellFromMenu(_ sender: Any?) {
+        let state = menuState()
+        let rows = state.targetRows.compactMap { self.rows.indices.contains($0) ? self.rows[$0] : nil }
+        writeToPasteboard(PacketTableCopyFormatter.csvCells(rows, column: state.clickedColumn))
+    }
+
+    @objc private func pinDomainFromMenu(_ sender: Any?) {
+        requestPin(.domain)
+    }
+
+    @objc private func pinIPFromMenu(_ sender: Any?) {
+        requestPin(.ip)
+    }
+
+    @objc private func pinClientFromMenu(_ sender: Any?) {
+        requestPin(.client)
+    }
+
+    @objc private func saveRowsFromMenu(_ sender: Any?) {
+        let identifiers = targetPacketIDs()
+        guard !identifiers.isEmpty else {
+            return
+        }
+
+        delegate?.packetTableViewController(self, didRequestSavePackets: identifiers)
+    }
+
+    @objc private func deleteRowsFromMenu(_ sender: Any?) {
+        deleteTargetRows()
+    }
+
+    private func copyTargetRows() {
+        writeToPasteboard(PacketTableCopyFormatter.csvRows(targetRows()))
+    }
+
+    private func deleteTargetRows() {
+        let identifiers = targetPacketIDs()
+        guard !identifiers.isEmpty else {
+            return
+        }
+
+        delegate?.packetTableViewController(self, didRequestDeletePackets: identifiers)
+    }
+
+    private func requestPin(_ kind: PacketPinCreationKind) {
+        let state = menuState()
+        guard state.targetRows.count == 1,
+              let rowIndex = state.targetRows.first,
+              rows.indices.contains(rowIndex) else {
+            return
+        }
+
+        delegate?.packetTableViewController(
+            self,
+            didRequestPin: kind,
+            packetID: rows[rowIndex].id,
+            clickedColumn: state.clickedColumn
+        )
+    }
 }
 
 extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate {
@@ -296,7 +424,7 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
             return
         }
 
-        let selectedRow = tableView.selectedRow
+        let selectedRow = tableView.selectedRowIndexes.first ?? -1
         let selectedID = rows.indices.contains(selectedRow) ? rows[selectedRow].id : nil
         guard selectedID != lastAppliedSelectedPacketID else {
             return
@@ -304,6 +432,73 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
 
         lastAppliedSelectedPacketID = selectedID
         delegate?.packetTableViewController(self, didSelectPacket: selectedID)
+    }
+}
+
+extension PacketTableViewController: NSMenuDelegate {
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        updateClickedPositionFromCurrentEvent()
+        let state = menuState()
+
+        menu.removeAllItems()
+        let copyRowItem = NSMenuItem(title: "Copy Row", action: #selector(copyRowsFromMenu(_:)), keyEquivalent: "c")
+        copyRowItem.target = self
+        copyRowItem.isEnabled = state.copyRowEnabled
+        menu.addItem(copyRowItem)
+
+        let copyCellItem = NSMenuItem(title: "Copy Cell", action: #selector(copyCellFromMenu(_:)), keyEquivalent: "")
+        copyCellItem.target = self
+        copyCellItem.isEnabled = state.copyCellEnabled
+        menu.addItem(copyCellItem)
+
+        menu.addItem(.separator())
+
+        let pinItem = NSMenuItem(title: "Pin", action: nil, keyEquivalent: "")
+        let pinSubmenu = NSMenu(title: "Pin")
+        let pinDomainItem = NSMenuItem(title: "Domain", action: #selector(pinDomainFromMenu(_:)), keyEquivalent: "")
+        pinDomainItem.target = self
+        pinDomainItem.isEnabled = state.pinDomainEnabled
+        pinSubmenu.addItem(pinDomainItem)
+
+        let pinIPItem = NSMenuItem(title: "IP", action: #selector(pinIPFromMenu(_:)), keyEquivalent: "")
+        pinIPItem.target = self
+        pinIPItem.isEnabled = state.pinIPEnabled
+        pinSubmenu.addItem(pinIPItem)
+
+        let pinClientItem = NSMenuItem(title: "Client", action: #selector(pinClientFromMenu(_:)), keyEquivalent: "")
+        pinClientItem.target = self
+        pinClientItem.isEnabled = state.pinClientEnabled
+        pinSubmenu.addItem(pinClientItem)
+
+        pinItem.submenu = pinSubmenu
+        pinItem.isEnabled = state.pinDomainEnabled || state.pinIPEnabled || state.pinClientEnabled
+        menu.addItem(pinItem)
+
+        let saveItem = NSMenuItem(title: "Save", action: #selector(saveRowsFromMenu(_:)), keyEquivalent: "")
+        saveItem.target = self
+        saveItem.isEnabled = state.saveEnabled
+        menu.addItem(saveItem)
+
+        menu.addItem(.separator())
+
+        let deleteItem = NSMenuItem(title: "Delete", action: #selector(deleteRowsFromMenu(_:)), keyEquivalent: "\u{8}")
+        deleteItem.target = self
+        deleteItem.isEnabled = state.deleteEnabled
+        menu.addItem(deleteItem)
+    }
+}
+
+extension PacketTableViewController: PacketTableKeyboardActionHandling {
+    fileprivate func packetTableViewDidRequestCopyRowsFromKeyboard(_ tableView: PacketTableView) {
+        clickedRowIndex = nil
+        clickedColumnIdentifier = nil
+        copyTargetRows()
+    }
+
+    fileprivate func packetTableViewDidRequestDeleteFromKeyboard(_ tableView: PacketTableView) {
+        clickedRowIndex = nil
+        clickedColumnIdentifier = nil
+        deleteTargetRows()
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -115,7 +115,12 @@ final class PacketWorkspaceViewController: NSViewController {
         }
 
         placeholderView?.removeFromSuperview()
-        let placeholder = TCPViewerUI.placeholder(title: title, imageName: imageName, message: message)
+        let placeholder = TCPViewerUI.placeholder(
+            title: title,
+            imageName: imageName,
+            message: message,
+            iconTitleSpacing: 18
+        )
         TCPViewerUI.pin(placeholder, to: contentContainer)
         placeholderView = placeholder
     }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -3,6 +3,14 @@ import PcapPlusPlusCore
 
 protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didSelectPacket identifier: PacketSummary.ID?)
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestPin kind: PacketPinCreationKind,
+        packetID: PacketSummary.ID,
+        clickedColumn: PacketTableColumnRole
+    )
+    func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
+    func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
 }
 
 final class PacketWorkspaceViewModel {
@@ -25,11 +33,15 @@ final class PacketWorkspaceViewModel {
         switch snapshot.selectedSourceListSelection {
         case .pinned:
             emptyTitle = "Pinned Packets"
-            emptyMessage = "Pinning packets is coming soon."
+            emptyMessage = "Pinned matches will appear here as packets arrive."
+            emptyImageName = "pin.fill"
+        case .pinnedItem:
+            emptyTitle = "Pinned Packets"
+            emptyMessage = "No packets match this pinned item yet."
             emptyImageName = "pin.fill"
         case .saved:
             emptyTitle = "Saved Packets"
-            emptyMessage = "Saving packets is coming soon."
+            emptyMessage = "Saved packets appear here after using the packet table menu."
             emptyImageName = "tray.and.arrow.down"
         default:
             emptyTitle = snapshot.totalPacketCount == 0 ? "No Packets" : "No Matching Packets"
@@ -121,5 +133,27 @@ final class PacketWorkspaceViewController: NSViewController {
 extension PacketWorkspaceViewController: PacketTableViewControllerDelegate {
     func packetTableViewController(_ controller: PacketTableViewController, didSelectPacket identifier: PacketSummary.ID?) {
         delegate?.packetWorkspaceViewController(self, didSelectPacket: identifier)
+    }
+
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        didRequestPin kind: PacketPinCreationKind,
+        packetID: PacketSummary.ID,
+        clickedColumn: PacketTableColumnRole
+    ) {
+        delegate?.packetWorkspaceViewController(
+            self,
+            didRequestPin: kind,
+            packetID: packetID,
+            clickedColumn: clickedColumn
+        )
+    }
+
+    func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID]) {
+        delegate?.packetWorkspaceViewController(self, didRequestSavePackets: identifiers)
+    }
+
+    func packetTableViewController(_ controller: PacketTableViewController, didRequestDeletePackets identifiers: [PacketSummary.ID]) {
+        delegate?.packetWorkspaceViewController(self, didRequestDeletePackets: identifiers)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -426,6 +426,14 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
             )
             cell.render(item: item, iconCache: iconCache)
             return cell
+        case .pin:
+            let cell = reusedCell(
+                identifier: SidebarPinCell.reuseIdentifier,
+                in: outlineView,
+                make: { SidebarPinCell(frame: .zero) }
+            )
+            cell.render(item: item, iconCache: iconCache)
+            return cell
         }
     }
 
@@ -588,6 +596,10 @@ private final class SidebarAppCell: SidebarIconCountCell {
 
 private final class SidebarDomainCell: SidebarIconCountCell {
     static let reuseIdentifier = NSUserInterfaceItemIdentifier("SidebarDomainCell")
+}
+
+private final class SidebarPinCell: SidebarIconCountCell {
+    static let reuseIdentifier = NSUserInterfaceItemIdentifier("SidebarPinCell")
 }
 
 private final class SidebarIconCache {

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -3,6 +3,7 @@ import AppKit
 protocol SidebarViewControllerDelegate: AnyObject {
     func sidebarViewController(_ controller: SidebarViewController, didSelect selection: PacketSourceListSelection?)
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String)
+    func sidebarViewController(_ controller: SidebarViewController, didRequestDelete action: PacketSourceListDeletionAction)
 }
 
 enum SidebarOutlineReloadTiming: Equatable {
@@ -80,6 +81,29 @@ private extension PacketSourceListItem {
     }
 }
 
+private protocol SidebarOutlineKeyboardActionHandling: AnyObject {
+    func sidebarOutlineViewDidRequestDeleteFromKeyboard(_ outlineView: SidebarOutlineView)
+}
+
+private final class SidebarOutlineView: NSOutlineView {
+    weak var keyboardActionHandler: SidebarOutlineKeyboardActionHandling?
+
+    @objc func delete(_ sender: Any?) {
+        keyboardActionHandler?.sidebarOutlineViewDidRequestDeleteFromKeyboard(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isDeleteKey = event.keyCode == 51 || event.keyCode == 117
+        if flags.contains(.command), isDeleteKey {
+            delete(nil)
+            return
+        }
+
+        super.keyDown(with: event)
+    }
+}
+
 private final class SidebarOutlineItem: NSObject {
     let sourceItem: PacketSourceListItem
     let children: [SidebarOutlineItem]
@@ -154,7 +178,7 @@ final class SidebarViewController: NSViewController {
     weak var delegate: SidebarViewControllerDelegate?
 
     private let viewModel = SidebarViewModel()
-    private let outlineView = NSOutlineView()
+    private let outlineView = SidebarOutlineView()
     private let scrollView = NSScrollView()
     private let searchField = NSSearchField()
     private let effectView = NSVisualEffectView()
@@ -259,6 +283,12 @@ final class SidebarViewController: NSViewController {
         outlineView.indentationMarkerFollowsCell = false
         outlineView.backgroundColor = .clear
         outlineView.focusRingType = .none
+        outlineView.keyboardActionHandler = self
+
+        let menu = NSMenu()
+        menu.delegate = self
+        menu.autoenablesItems = false
+        outlineView.menu = menu
 
         scrollView.documentView = outlineView
         scrollView.hasVerticalScroller = true
@@ -343,6 +373,46 @@ final class SidebarViewController: NSViewController {
 
     private func outlineItem(for item: Any?) -> SidebarOutlineItem? {
         item as? SidebarOutlineItem
+    }
+
+    private func selectedSourceItem() -> PacketSourceListItem? {
+        let selectedRow = outlineView.selectedRow
+        guard selectedRow >= 0 else {
+            return nil
+        }
+
+        return sourceItem(for: outlineView.item(atRow: selectedRow))
+    }
+
+    private func selectedDeletionAction() -> PacketSourceListDeletionAction {
+        PacketSourceListDeletionPolicy.action(for: selectedSourceItem())
+    }
+
+    private func updateSelectionFromCurrentMenuEvent() {
+        guard let event = view.window?.currentEvent,
+              event.type == .rightMouseDown || event.type == .leftMouseDown || event.type == .otherMouseDown else {
+            return
+        }
+
+        let point = outlineView.convert(event.locationInWindow, from: nil)
+        let row = outlineView.row(at: point)
+        guard row >= 0,
+              let item = outlineView.item(atRow: row),
+              sourceItem(for: item)?.selection != nil else {
+            outlineView.deselectAll(nil)
+            return
+        }
+
+        outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+    }
+
+    @objc private func deleteSelectedSourceListItem(_ sender: Any?) {
+        let action = selectedDeletionAction()
+        guard action.isEnabled else {
+            return
+        }
+
+        delegate?.sidebarViewController(self, didRequestDelete: action)
     }
 
     @objc private func searchFieldChanged(_ sender: NSSearchField) {
@@ -486,6 +556,30 @@ extension SidebarViewController: NSSearchFieldDelegate {
         }
 
         delegate?.sidebarViewController(self, didUpdateFilterText: searchField.stringValue)
+    }
+}
+
+extension SidebarViewController: NSMenuDelegate {
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        updateSelectionFromCurrentMenuEvent()
+        let action = selectedDeletionAction()
+
+        menu.removeAllItems()
+        guard action.isEnabled else {
+            return
+        }
+
+        let deleteItem = NSMenuItem(title: "Delete", action: #selector(deleteSelectedSourceListItem(_:)), keyEquivalent: "\u{8}")
+        deleteItem.keyEquivalentModifierMask = [.command]
+        deleteItem.target = self
+        deleteItem.isEnabled = true
+        menu.addItem(deleteItem)
+    }
+}
+
+extension SidebarViewController: SidebarOutlineKeyboardActionHandling {
+    fileprivate func sidebarOutlineViewDidRequestDeleteFromKeyboard(_ outlineView: SidebarOutlineView) {
+        deleteSelectedSourceListItem(nil)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -209,6 +209,23 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didSelectPacket identifier: PacketSummary.ID?) {
         viewModel.selectPacket(identifier)
     }
+
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestPin kind: PacketPinCreationKind,
+        packetID: PacketSummary.ID,
+        clickedColumn: PacketTableColumnRole
+    ) {
+        viewModel.pinPacket(packetID, kind: kind, clickedColumn: clickedColumn)
+    }
+
+    func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID]) {
+        viewModel.savePackets(identifiers)
+    }
+
+    func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID]) {
+        viewModel.deletePackets(identifiers)
+    }
 }
 
 extension TCPViewerRootViewController: PacketInspectorViewControllerDelegate {

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -203,6 +203,10 @@ extension TCPViewerRootViewController: SidebarViewControllerDelegate {
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String) {
         viewModel.updateSourceListFilterText(text)
     }
+
+    func sidebarViewController(_ controller: SidebarViewController, didRequestDelete action: PacketSourceListDeletionAction) {
+        viewModel.deleteSourceListItem(action)
+    }
 }
 
 extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {

--- a/TCPViewerTests/App/InterfaceSelectionHistoryStoreTests.swift
+++ b/TCPViewerTests/App/InterfaceSelectionHistoryStoreTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import TCPViewer
+
+struct InterfaceSelectionHistoryStoreTests {
+    @Test func startsEmptyAndPersistsRecordedInterfaceInUserDefaults() {
+        let defaults = Self.makeUserDefaults()
+        let store = InterfaceSelectionHistoryStore(defaults: defaults)
+
+        #expect(store.lastUsedInterfaceIDs.isEmpty)
+
+        let history = store.recordInterfaceUsage("en1")
+
+        #expect(history == ["en1"])
+        #expect(store.lastUsedInterfaceIDs == ["en1"])
+        #expect(defaults.stringArray(forKey: InterfaceSelectionHistoryStore.storageKey) == ["en1"])
+    }
+
+    @Test func promotesDuplicatesAndCapsHistoryAtFiveInterfaces() {
+        let defaults = Self.makeUserDefaults()
+        let store = InterfaceSelectionHistoryStore(defaults: defaults)
+
+        store.replaceHistory(with: ["en0", "en2", "en3", "en4", "en5", "en6"])
+
+        let history = store.recordInterfaceUsage("en2")
+
+        #expect(history == ["en2", "en0", "en3", "en4", "en5"])
+    }
+
+    @Test func trimsEmptyAndDuplicateValuesWhenReplacingHistory() {
+        let defaults = Self.makeUserDefaults()
+        let store = InterfaceSelectionHistoryStore(defaults: defaults)
+
+        let history = store.replaceHistory(with: [" en0 ", "", "en1", "en0", "   ", "en2"])
+
+        #expect(history == ["en0", "en1", "en2"])
+        #expect(defaults.stringArray(forKey: InterfaceSelectionHistoryStore.storageKey) == history)
+    }
+
+    @Test func appConfigurationExposesUserDefaultsBackedInterfaceHistory() {
+        let defaults = Self.makeUserDefaults()
+        let configuration = AppConfiguration(defaults: defaults)
+
+        configuration.interfaceSelectionHistory.recordInterfaceUsage("en1")
+
+        let reloadedConfiguration = AppConfiguration(defaults: defaults)
+        #expect(reloadedConfiguration.interfaceSelectionHistory.lastUsedInterfaceIDs == ["en1"])
+    }
+
+    @Test func appConfigurationResetClearsInterfaceHistory() {
+        let defaults = Self.makeUserDefaults()
+        let configuration = AppConfiguration(defaults: defaults)
+        configuration.interfaceSelectionHistory.recordInterfaceUsage("en1")
+
+        configuration.resetToDefaults()
+
+        #expect(configuration.interfaceSelectionHistory.lastUsedInterfaceIDs.isEmpty)
+        #expect(defaults.stringArray(forKey: InterfaceSelectionHistoryStore.storageKey) == nil)
+    }
+
+    private static func makeUserDefaults() -> UserDefaults {
+        let suiteName = "InterfaceSelectionHistoryStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/TCPViewerTests/App/TCPViewerUserDataDirectoryTests.swift
+++ b/TCPViewerTests/App/TCPViewerUserDataDirectoryTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct TCPViewerUserDataDirectoryTests {
+
+    @Test func createsReusableSettingsDirectoryInsideApplicationSupportFolder() throws {
+        let baseURL = temporaryDirectory()
+        let directory = TCPViewerUserDataDirectory(applicationSupportBaseURL: baseURL)
+
+        #expect(directory.appDirectoryURL == baseURL.appendingPathComponent("TCPViewer", isDirectory: true))
+        #expect(directory.settingsDirectoryURL == directory.appDirectoryURL.appendingPathComponent("settings", isDirectory: true))
+        #expect(directory.settingsFileURL(named: "PinnedPackets.json") == directory.settingsDirectoryURL.appendingPathComponent("PinnedPackets.json"))
+
+        try directory.createSettingsDirectoryIfNeeded()
+
+        var isDirectory = ObjCBool(false)
+        #expect(FileManager.default.fileExists(atPath: directory.settingsDirectoryURL.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+    }
+
+    @Test func packetUserDataServicesUseSettingsDirectoryByDefault() throws {
+        let baseURL = temporaryDirectory()
+        let directory = TCPViewerUserDataDirectory(applicationSupportBaseURL: baseURL)
+        let pinService = PacketPinService(userDataDirectory: directory)
+        let savedService = SavedPacketService(userDataDirectory: directory)
+
+        let packet = makePacket()
+        try pinService.upsertPin(from: packet, kind: .domain, clickedColumn: .domain)
+        try savedService.save([packet])
+
+        #expect(FileManager.default.fileExists(atPath: directory.settingsFileURL(named: "PinnedPackets.json").path))
+        #expect(FileManager.default.fileExists(atPath: directory.settingsFileURL(named: "SavedPackets.json").path))
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makePacket() -> PacketSummary {
+        PacketSummary(
+            packetNumber: 1,
+            timestamp: Date(timeIntervalSince1970: 1),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+            ),
+            originalLength: 128,
+            capturedLength: 128,
+            streamID: nil,
+            infoSummary: "Packet 1",
+            layers: [PacketLayer(name: "Ethernet"), PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: "api.example.com"
+        )
+    }
+}

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -655,6 +655,39 @@ struct WindowControllerTests {
         await tearDown(controller)
     }
 
+    @Test func liveCapturePersistsStartedInterfaceAsLastUsed() async {
+        let suiteName = "TCPViewerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let liveSession = FakeLiveSession()
+        let fakeCore = FakeTCPViewerCore(
+            interfaceInventories: [[
+                makeInterface(id: "en0", displayName: "Wi-Fi"),
+                makeInterface(id: "en1", displayName: "USB Ethernet"),
+            ]],
+            liveSession: liveSession
+        )
+        let controller = TCPViewerWorkspaceController(
+            services: TCPViewerServiceRegistry(core: fakeCore),
+            userDefaults: defaults
+        )
+
+        #expect(controller.snapshot.sessionState.lastUsedInterfaceIDs.isEmpty)
+
+        await controller.refreshInterfaces()
+        controller.selectInterface("en1")
+        await controller.startLiveCapture()
+
+        #expect(liveSession.startCount == 1)
+        #expect(controller.snapshot.sessionState.lastUsedInterfaceIDs == ["en1"])
+        #expect(defaults.stringArray(forKey: InterfaceSelectionHistoryStore.storageKey) == ["en1"])
+
+        await tearDown(controller)
+    }
+
     @Test func partialDocumentLoadKeepsLoadedPacketsAndDisablesSave() async {
         let url = URL(fileURLWithPath: "/tmp/partial-load.pcapng")
         let packets = [

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -970,6 +970,55 @@ struct NetworkInspectorViewModelTests {
         #expect(reloadedSavedService.records().isEmpty)
     }
 
+    @Test func sourceListDeleteActionRemovesPinsAndMatchingPackets() async throws {
+        let pinURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let pinService = PacketPinService(storageURL: pinURL)
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, sniDomainName: "api.example.com", client: client),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .tcp, sniDomainName: "api.example.com"),
+            makePacket(packetNumber: 3, source: .offline, transportHint: .tcp, sniDomainName: nil),
+        ]
+        let openURL = URL(fileURLWithPath: "/tmp/source-list-delete-fixture.pcapng")
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: InspectorFakeDocument(url: openURL, packets: packets)
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: pinService
+        )
+
+        await viewModel.openDocument(at: openURL)
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == 3
+        }
+
+        viewModel.pinPacket(packets[0].id, kind: .domain, clickedColumn: .domain)
+        let pinID = try #require(pinService.pins().first?.id)
+        viewModel.deleteSourceListItem(.deletePin(pinID))
+
+        #expect(pinService.pins().isEmpty)
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .pinnedItem(pinID)) == nil)
+        #expect(viewModel.snapshot.selectedSourceListSelection == .pinned)
+
+        let appKey = try #require(PacketSourceListClassifier.clientIdentity(for: packets[0])?.key)
+        viewModel.selectSourceList(.app(appKey))
+        viewModel.deleteSourceListItem(.deletePackets(.app(appKey)))
+
+        #expect(viewModel.snapshot.selectedSourceListSelection == .allPackets)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[1].id, packets[2].id])
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .app(appKey)) == nil)
+
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
+        viewModel.selectSourceList(.ipAddress(ipKey))
+        viewModel.deleteSourceListItem(.deletePackets(.ipAddress(ipKey)))
+
+        #expect(viewModel.snapshot.selectedSourceListSelection == .allPackets)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[1].id])
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .ipAddress(ipKey)) == nil)
+    }
+
     @Test func deletingRowsSelectsRowAfterLastDeletedVisibleIndex() async {
         let packets = (1...5).map {
             makePacket(packetNumber: UInt64($0), source: .offline, transportHint: .tcp)

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -197,35 +197,35 @@ struct NetworkInspectorViewModelTests {
             rows: rows,
             selectedPacketID: packets[1].id,
             selectedRowIndex: 1,
-            tableSelectedRow: 1
+            tableSelectedRowIndexes: IndexSet(integer: 1)
         ) == .none)
 
         #expect(PacketTableSelectionSyncPlanner.action(
             rows: rows,
             selectedPacketID: packets[1].id,
             selectedRowIndex: 1,
-            tableSelectedRow: -1
+            tableSelectedRowIndexes: []
         ) == .select(1))
 
         #expect(PacketTableSelectionSyncPlanner.action(
             rows: rows,
             selectedPacketID: packets[1].id,
             selectedRowIndex: 1,
-            tableSelectedRow: 0
+            tableSelectedRowIndexes: IndexSet(integer: 0)
         ) == .select(1))
 
         #expect(PacketTableSelectionSyncPlanner.action(
             rows: rows,
             selectedPacketID: nil,
             selectedRowIndex: nil,
-            tableSelectedRow: 1
+            tableSelectedRowIndexes: IndexSet(integer: 1)
         ) == .deselect)
 
         #expect(PacketTableSelectionSyncPlanner.action(
             rows: rows,
             selectedPacketID: packets[1].id,
             selectedRowIndex: nil,
-            tableSelectedRow: -1
+            tableSelectedRowIndexes: []
         ) == .none)
     }
 
@@ -913,11 +913,112 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[1].id])
     }
 
+    @Test func pinnedAndSavedSelectionsFilterRowsAndReloadFromDisk() async throws {
+        let directory = temporaryDirectory()
+        let pinURL = directory.appendingPathComponent("Pins.json")
+        let savedURL = directory.appendingPathComponent("Saved.json")
+        let pinService = PacketPinService(storageURL: pinURL)
+        let savedService = SavedPacketService(storageURL: savedURL)
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: "api.example.com"),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .udp, streamID: nil, sniDomainName: "openai.com"),
+        ]
+        let openURL = URL(fileURLWithPath: "/tmp/pinned-saved-fixture.pcapng")
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: InspectorFakeDocument(url: openURL, packets: packets)
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: pinService,
+            savedPacketService: savedService
+        )
+
+        await viewModel.openDocument(at: openURL)
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == 2
+        }
+
+        viewModel.pinPacket(packets[0].id, kind: .domain, clickedColumn: .domain)
+        let pinID = try #require(pinService.pins().first?.id)
+        #expect(viewModel.snapshot.selectedSourceListSelection == .pinnedItem(pinID))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id])
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .pinned)?.count == 1)
+
+        viewModel.savePackets([packets[1].id])
+        viewModel.selectSourceList(.saved)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[1].id])
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .saved)?.count == 1)
+
+        let reloadedPinService = PacketPinService(storageURL: pinURL)
+        let reloadedSavedService = SavedPacketService(storageURL: savedURL)
+        let reloaded = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: reloadedPinService,
+            savedPacketService: reloadedSavedService
+        )
+
+        #expect(reloaded.snapshot.sourceListSnapshot.item(for: .pinnedItem(pinID))?.count == 0)
+        reloaded.selectSourceList(.saved)
+        #expect(reloaded.snapshot.packetRows.map(\.id) == [packets[1].id])
+
+        reloaded.deletePackets([packets[1].id])
+        #expect(reloaded.snapshot.packetRows.isEmpty)
+        #expect(reloadedSavedService.records().isEmpty)
+    }
+
+    @Test func deletingRowsSelectsRowAfterLastDeletedVisibleIndex() async {
+        let packets = (1...5).map {
+            makePacket(packetNumber: UInt64($0), source: .offline, transportHint: .tcp)
+        }
+        let viewModel = makeOfflineViewModel(packets: packets)
+
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/delete-next-selection.pcapng"))
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == packets.count
+        }
+
+        viewModel.selectPacket(packets[1].id)
+        viewModel.deletePackets([packets[1].id, packets[2].id])
+
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[3].id, packets[4].id])
+        #expect(viewModel.snapshot.selectedPacket?.id == packets[3].id)
+        #expect(viewModel.snapshot.selectedPacketRowIndex == 1)
+    }
+
+    @Test func deletingLastRowsSelectsPreviousRemainingRow() async {
+        let packets = (1...5).map {
+            makePacket(packetNumber: UInt64($0), source: .offline, transportHint: .tcp)
+        }
+        let viewModel = makeOfflineViewModel(packets: packets)
+
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/delete-end-selection.pcapng"))
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == packets.count
+        }
+
+        viewModel.selectPacket(packets[3].id)
+        viewModel.deletePackets([packets[3].id, packets[4].id])
+
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[1].id, packets[2].id])
+        #expect(viewModel.snapshot.selectedPacket?.id == packets[2].id)
+        #expect(viewModel.snapshot.selectedPacketRowIndex == 2)
+    }
+
     private func isolatedDefaults() -> UserDefaults {
         let suiteName = "TCPViewer.NetworkInspectorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         return defaults
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 
     private func makeOfflineViewModel(packets: [PacketSummary]) -> NetworkInspectorViewModel {

--- a/TCPViewerTests/Features/NetworkInspector/PacketPinServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketPinServiceTests.swift
@@ -38,6 +38,18 @@ struct PacketPinServiceTests {
         #expect(service.matchingPackets(in: [future], for: .pinnedItem(firstPin.id)).map(\.id) == [future.id])
     }
 
+    @Test func deletePinPersistsRemoval() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let pin = try service.upsertPin(from: makePacket(packetNumber: 1, sniDomainName: "Example.com"), kind: .domain, clickedColumn: .domain)
+
+        try service.deletePin(id: pin.id)
+        let reloaded = PacketPinService(storageURL: storageURL)
+
+        #expect(service.pins().isEmpty)
+        #expect(reloaded.pins().isEmpty)
+    }
+
     @Test func ipPinUsesClickedEndpointThenFallsBackToDestination() throws {
         let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
         let service = PacketPinService(storageURL: storageURL)

--- a/TCPViewerTests/Features/NetworkInspector/PacketPinServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketPinServiceTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct PacketPinServiceTests {
+
+    @Test func persistsCriteriaOnlyAndReloadsWithoutPackets() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let packet = makePacket(packetNumber: 1, sniDomainName: "API.Example.com")
+
+        let pin = try service.upsertPin(from: packet, kind: .domain, clickedColumn: .domain, now: Date(timeIntervalSince1970: 10))
+        let reloaded = PacketPinService(storageURL: storageURL)
+        let rawJSON = try String(contentsOf: storageURL)
+
+        #expect(pin.id.rawValue == "domain:api.example.com")
+        #expect(reloaded.pins().map(\.id) == [pin.id])
+        #expect(reloaded.matchingPackets(in: [], for: .pinnedItem(pin.id)).isEmpty)
+        #expect(!rawJSON.contains("Packet 1"))
+        #expect(!rawJSON.contains("capturedLength"))
+        #expect(!rawJSON.contains("10.0.0.1"))
+    }
+
+    @Test func duplicateDomainUpsertReusesExistingPinAndMatchesFuturePackets() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let first = makePacket(packetNumber: 1, sniDomainName: "Example.com")
+        let second = makePacket(packetNumber: 2, sniDomainName: "example.COM")
+        let future = makePacket(packetNumber: 3, sniDomainName: "example.com")
+
+        let firstPin = try service.upsertPin(from: first, kind: .domain, clickedColumn: .domain)
+        let secondPin = try service.upsertPin(from: second, kind: .domain, clickedColumn: .domain)
+
+        #expect(firstPin.id == secondPin.id)
+        #expect(service.pins().count == 1)
+        #expect(service.matchingPackets(in: [future], for: .pinnedItem(firstPin.id)).map(\.id) == [future.id])
+    }
+
+    @Test func ipPinUsesClickedEndpointThenFallsBackToDestination() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let packet = makePacket(packetNumber: 1)
+
+        let sourcePin = try service.upsertPin(from: packet, kind: .ip, clickedColumn: .source)
+        let destinationPin = try service.upsertPin(from: packet, kind: .ip, clickedColumn: .summary)
+
+        #expect(sourcePin.ipAddress == "10.0.0.1")
+        #expect(destinationPin.ipAddress == "10.0.0.2")
+    }
+
+    @Test func clientPinUsesSourceListClientIdentity() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let packet = makePacket(packetNumber: 1, client: client)
+
+        let pin = try service.upsertPin(from: packet, kind: .client, clickedColumn: .client)
+
+        #expect(pin.title == "Example")
+        #expect(pin.clientKey == "bundleIdentifier:com.example.app")
+        #expect(service.matchingPackets(in: [packet], for: .pinned).map(\.id) == [packet.id])
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makePacket(
+        packetNumber: UInt64,
+        sniDomainName: String? = nil,
+        client: PacketClient? = nil
+    ) -> PacketSummary {
+        PacketSummary(
+            packetNumber: packetNumber,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(packetNumber)),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+            ),
+            originalLength: 128,
+            capturedLength: 128,
+            streamID: nil,
+            infoSummary: "Packet \(packetNumber)",
+            layers: [PacketLayer(name: "Ethernet"), PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: sniDomainName,
+            client: client
+        )
+    }
+
+    private func makeClient(displayName: String, bundleIdentifier: String) -> PacketClient {
+        PacketClient(
+            pid: 123,
+            name: displayName,
+            displayName: displayName,
+            executablePath: "/Applications/\(displayName).app/Contents/MacOS/\(displayName)",
+            bundleIdentifier: bundleIdentifier,
+            bundlePath: "/Applications/\(displayName).app"
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -61,9 +61,49 @@ struct PacketSourceListServiceTests {
 
         let snapshot = PacketSourceListService().snapshot(for: state)
         let domain = snapshot.item(for: .domain(.ipAddresses))
+        let sourceIPKey = PacketSourceIPAddressKey(rawValue: "10.0.0.1")
+        let destinationIPKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
 
         #expect(snapshot.item(for: .domains)?.children.map(\.title) == ["IP Addresses"])
         #expect(domain?.count == 2)
+        #expect(domain?.children.map(\.title) == ["10.0.0.2", "10.0.0.1"])
+        #expect(snapshot.item(for: .ipAddress(destinationIPKey))?.count == 2)
+        #expect(snapshot.item(for: .ipAddress(sourceIPKey))?.count == 2)
+    }
+
+    @Test func deletionPolicyOnlyAllowsDeletableLeafItems() {
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let pinID = PacketPinID(rawValue: "domain:api.example.com")
+        let pin = PacketPin(
+            id: pinID,
+            kind: .domain,
+            title: "api.example.com",
+            createdAt: Date(timeIntervalSince1970: 10),
+            domain: "api.example.com",
+            ipAddress: nil,
+            clientKey: nil,
+            clientDisplayName: nil,
+            clientIconFilePath: nil
+        )
+        var state = PacketIngestState.empty
+        state.append([
+            makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: client),
+            makePacket(packetNumber: 2, sniDomainName: nil),
+        ], source: .live)
+
+        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [pin])
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
+        let domainKey = PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false)
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
+
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .pinned)) == .none)
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .pinnedItem(pinID))) == .deletePin(pinID))
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .apps)) == .none)
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .app(appKey))) == .deletePackets(.app(appKey)))
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .domains)) == .none)
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .domain(domainKey))) == .deletePackets(.domain(domainKey)))
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .domain(.ipAddresses))) == .none)
+        #expect(PacketSourceListDeletionPolicy.action(for: snapshot.item(for: .ipAddress(ipKey))) == .deletePackets(.ipAddress(ipKey)))
     }
 
     @Test func clientIdentityFallsBackThroughAvailableFields() {

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct PacketTableMenuLogicTests {
+
+    @Test func selectedClickedRowTargetsMultipleRowsAndDisablesPin() {
+        let rows = [
+            PacketTableRow(packet: makePacket(packetNumber: 1, sniDomainName: "one.example.com", client: makeClient())),
+            PacketTableRow(packet: makePacket(packetNumber: 2)),
+            PacketTableRow(packet: makePacket(packetNumber: 3, sniDomainName: "three.example.com", client: makeClient())),
+        ]
+
+        let state = PacketTableMenuLogic.state(
+            rows: rows,
+            selectedRowIndexes: IndexSet([0, 2]),
+            clickedRowIndex: 2,
+            clickedColumnIdentifier: "domain"
+        )
+
+        #expect(state.targetRows == [0, 2])
+        #expect(state.copyRowEnabled)
+        #expect(state.copyCellEnabled)
+        #expect(!state.pinDomainEnabled)
+        #expect(!state.pinIPEnabled)
+        #expect(!state.pinClientEnabled)
+        #expect(state.saveEnabled)
+        #expect(state.deleteEnabled)
+    }
+
+    @Test func unselectedClickedRowTargetsSingleRowAndEnablesValidPins() {
+        let rows = [
+            PacketTableRow(packet: makePacket(packetNumber: 1)),
+            PacketTableRow(packet: makePacket(packetNumber: 2, sniDomainName: "api.example.com", client: makeClient())),
+        ]
+
+        let state = PacketTableMenuLogic.state(
+            rows: rows,
+            selectedRowIndexes: IndexSet(integer: 0),
+            clickedRowIndex: 1,
+            clickedColumnIdentifier: "source"
+        )
+
+        #expect(state.targetRows == [1])
+        #expect(state.clickedColumn == .source)
+        #expect(state.pinDomainEnabled)
+        #expect(state.pinIPEnabled)
+        #expect(state.pinClientEnabled)
+    }
+
+    @Test func copyFormatterUsesCSVRowsAndClickedColumnCells() {
+        let rows = [
+            PacketTableRow(packet: makePacket(packetNumber: 1, infoSummary: "Hello, world")),
+            PacketTableRow(packet: makePacket(packetNumber: 2, infoSummary: "Plain")),
+        ]
+
+        let rowCopy = PacketTableCopyFormatter.csvRows(rows)
+        let cellCopy = PacketTableCopyFormatter.csvCells(rows, column: .summary)
+
+        #expect(rowCopy.contains("\"Hello, world\""))
+        #expect(rowCopy.split(separator: "\n").count == 2)
+        #expect(cellCopy == """
+        "Hello, world"
+        Plain
+        """)
+    }
+
+    @Test func selectionSyncUsesFirstSelectedRowForInspector() {
+        let packets = [
+            makePacket(packetNumber: 1),
+            makePacket(packetNumber: 2),
+            makePacket(packetNumber: 3),
+        ]
+        let rows = packets.map(PacketTableRow.init)
+
+        #expect(PacketTableSelectionSyncPlanner.action(
+            rows: rows,
+            selectedPacketID: packets[0].id,
+            selectedRowIndex: 0,
+            tableSelectedRowIndexes: IndexSet([0, 2])
+        ) == .none)
+
+        #expect(PacketTableSelectionSyncPlanner.action(
+            rows: rows,
+            selectedPacketID: packets[2].id,
+            selectedRowIndex: 2,
+            tableSelectedRowIndexes: IndexSet([0, 2])
+        ) == .select(2))
+    }
+
+    private func makePacket(
+        packetNumber: UInt64,
+        infoSummary: String? = nil,
+        sniDomainName: String? = nil,
+        client: PacketClient? = nil
+    ) -> PacketSummary {
+        PacketSummary(
+            packetNumber: packetNumber,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(packetNumber)),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+            ),
+            originalLength: 128,
+            capturedLength: 128,
+            streamID: nil,
+            infoSummary: infoSummary ?? "Packet \(packetNumber)",
+            layers: [PacketLayer(name: "Ethernet"), PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: sniDomainName,
+            client: client
+        )
+    }
+
+    private func makeClient() -> PacketClient {
+        PacketClient(
+            pid: 123,
+            name: "Example",
+            displayName: "Example",
+            executablePath: "/Applications/Example.app/Contents/MacOS/Example",
+            bundleIdentifier: "com.example.app",
+            bundlePath: "/Applications/Example.app"
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct SavedPacketServiceTests {
+
+    @Test func savesReloadsUpsertsAndDeletesPacketSummaryRecords() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Saved.json")
+        let service = SavedPacketService(storageURL: storageURL)
+        let first = makePacket(packetNumber: 1, infoSummary: "First")
+        let second = makePacket(packetNumber: 2, infoSummary: "Second")
+
+        try service.save([first, second], now: Date(timeIntervalSince1970: 20))
+        #expect(service.records().map { $0.packet.id } == [first.id, second.id])
+
+        let reloaded = SavedPacketService(storageURL: storageURL)
+        #expect(reloaded.records().map { $0.packet.infoSummary } == ["First", "Second"])
+
+        let updatedFirst = makePacket(packetNumber: 1, infoSummary: "Updated")
+        try reloaded.save([updatedFirst], now: Date(timeIntervalSince1970: 30))
+        #expect(reloaded.records().count == 2)
+        #expect(reloaded.records().first?.packet.infoSummary == "Updated")
+
+        try reloaded.deletePacketIDs([first.id])
+        #expect(reloaded.records().map { $0.packet.id } == [second.id])
+    }
+
+    @Test func staysEmptyUntilPacketsAreManuallySaved() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Saved.json")
+        let service = SavedPacketService(storageURL: storageURL)
+        let incomingPacket = makePacket(packetNumber: 1)
+
+        #expect(service.records().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: storageURL.path))
+
+        try service.save([incomingPacket])
+
+        #expect(service.records().map { $0.packet.id } == [incomingPacket.id])
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makePacket(packetNumber: UInt64, infoSummary: String? = nil) -> PacketSummary {
+        PacketSummary(
+            packetNumber: packetNumber,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(packetNumber)),
+            source: .offline,
+            transportHint: .udp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 53)
+            ),
+            originalLength: 96,
+            capturedLength: 96,
+            streamID: nil,
+            infoSummary: infoSummary ?? "Packet \(packetNumber)",
+            layers: [PacketLayer(name: "Ethernet"), PacketLayer(name: "UDP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Persist recently used capture interfaces and surface them first in the toolbar menu
- Add source list deletion for pins, app buckets, domains, and IP address buckets
- Improve placeholder spacing and toolbar menu selection handling

## Testing
- Added unit coverage for interface history persistence, pin deletion, and source list deletion behavior
- Not run (not requested)