### PR TITLE
Add Wireshark-like packet inspector outline with DNS decoding

### DIFF
--- a/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
+++ b/PcapPlusPlusCore/NativeBridge/TCPViewerNativeBridge.mm
@@ -1110,6 +1110,132 @@ NSString *UDPChecksumStatus(pcpp::UdpLayer *udpLayer)
     return @"Present (unverified)";
 }
 
+NSUInteger DNSHeaderOffset(pcpp::DnsLayer *dnsLayer, NSUInteger layerOffset)
+{
+    return dynamic_cast<pcpp::DnsOverTcpLayer *>(dnsLayer) != nullptr
+        ? layerOffset + sizeof(uint16_t)
+        : layerOffset;
+}
+
+NSString *DNSRecordTypeName(pcpp::DnsType type)
+{
+    switch (type) {
+        case pcpp::DNS_TYPE_A:
+            return @"A";
+        case pcpp::DNS_TYPE_NS:
+            return @"NS";
+        case pcpp::DNS_TYPE_CNAME:
+            return @"CNAME";
+        case pcpp::DNS_TYPE_SOA:
+            return @"SOA";
+        case pcpp::DNS_TYPE_PTR:
+            return @"PTR";
+        case pcpp::DNS_TYPE_MX:
+            return @"MX";
+        case pcpp::DNS_TYPE_TXT:
+            return @"TXT";
+        case pcpp::DNS_TYPE_AAAA:
+            return @"AAAA";
+        case pcpp::DNS_TYPE_SRV:
+            return @"SRV";
+        case pcpp::DNS_TYPE_OPT:
+            return @"OPT";
+        case pcpp::DNS_TYPE_DS:
+            return @"DS";
+        case pcpp::DNS_TYPE_RRSIG:
+            return @"RRSIG";
+        case pcpp::DNS_TYPE_NSEC:
+            return @"NSEC";
+        case pcpp::DNS_TYPE_DNSKEY:
+            return @"DNSKEY";
+        case pcpp::DNS_TYPE_ALL:
+            return @"ANY";
+        default:
+            return @"Unknown";
+    }
+}
+
+NSString *DNSRecordTypeValue(pcpp::DnsType type)
+{
+    return [NSString stringWithFormat:@"%@ (%u)", DNSRecordTypeName(type), static_cast<unsigned>(type)];
+}
+
+NSString *DNSClassName(pcpp::DnsClass dnsClass)
+{
+    switch (dnsClass) {
+        case pcpp::DNS_CLASS_IN:
+            return @"IN";
+        case pcpp::DNS_CLASS_IN_QU:
+            return @"IN QU";
+        case pcpp::DNS_CLASS_CH:
+            return @"CH";
+        case pcpp::DNS_CLASS_HS:
+            return @"HS";
+        case pcpp::DNS_CLASS_ANY:
+            return @"ANY";
+        default:
+            return @"Unknown";
+    }
+}
+
+NSString *DNSClassValue(pcpp::DnsClass dnsClass)
+{
+    return [NSString stringWithFormat:@"%@ (%u)", DNSClassName(dnsClass), static_cast<unsigned>(dnsClass)];
+}
+
+NSString *DNSOpcodeName(uint16_t opcode)
+{
+    switch (opcode) {
+        case 0:
+            return @"Standard query";
+        case 1:
+            return @"Inverse query";
+        case 2:
+            return @"Status";
+        case 4:
+            return @"Notify";
+        case 5:
+            return @"Update";
+        default:
+            return @"Unknown";
+    }
+}
+
+NSString *DNSResponseCodeName(uint16_t responseCode)
+{
+    switch (responseCode) {
+        case 0:
+            return @"No error";
+        case 1:
+            return @"Format error";
+        case 2:
+            return @"Server failure";
+        case 3:
+            return @"Non-existent domain";
+        case 4:
+            return @"Not implemented";
+        case 5:
+            return @"Refused";
+        default:
+            return @"Unknown";
+    }
+}
+
+NSString *DNSQueryResponseValue(bool isResponse)
+{
+    return isResponse ? @"Response" : @"Query";
+}
+
+NSString *DNSResourceDataValue(pcpp::DnsResource *resource)
+{
+    auto data = resource->getData();
+    if (data.get() == nullptr) {
+        return nil;
+    }
+
+    return MakeNSString(data->toString());
+}
+
 class PacketDetailTreeBuilder {
 public:
     PacketDetailTreeBuilder(const pcpp::Packet &packet,
@@ -1196,6 +1322,9 @@ private:
                 break;
             case pcpp::UDP:
                 appendUDP(static_cast<pcpp::UdpLayer *>(layer), offset, nodes);
+                break;
+            case pcpp::DNS:
+                appendDNS(static_cast<pcpp::DnsLayer *>(layer), offset, nodes);
                 break;
             case pcpp::SSL:
                 appendTLS(static_cast<pcpp::SSLLayer *>(layer), offset, nodes);
@@ -1430,6 +1559,273 @@ private:
                                        offset,
                                        udpLayer->getHeaderLen(),
                                        children)];
+    }
+
+    void appendDNS(pcpp::DnsLayer *dnsLayer, NSUInteger offset, NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *nodes)
+    {
+        // Decode the DNS header, flags, and record sections exposed by PcapPlusPlus.
+        auto *header = dnsLayer->getDnsHeader();
+        NSUInteger headerOffset = DNSHeaderOffset(dnsLayer, offset);
+        uint16_t flags = 0;
+        std::memcpy(&flags, dnsLayer->getData() + (headerOffset - offset) + 2, sizeof(flags));
+        flags = ntohs(flags);
+
+        NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children = [NSMutableArray arrayWithArray:@[
+            MakeFieldNode(@"dns.id", @"Transaction ID", FormatHex16(ntohs(header->transactionID)), headerOffset, 0, 2),
+            dnsFlagsNode(header, flags, headerOffset),
+            MakeFieldNode(@"dns.count.queries", @"Questions", [NSString stringWithFormat:@"%u", ntohs(header->numberOfQuestions)], headerOffset, 4, 2),
+            MakeFieldNode(@"dns.count.answers", @"Answer RRs", [NSString stringWithFormat:@"%u", ntohs(header->numberOfAnswers)], headerOffset, 6, 2),
+            MakeFieldNode(@"dns.count.authorities", @"Authority RRs", [NSString stringWithFormat:@"%u", ntohs(header->numberOfAuthority)], headerOffset, 8, 2),
+            MakeFieldNode(@"dns.count.additional", @"Additional RRs", [NSString stringWithFormat:@"%u", ntohs(header->numberOfAdditional)], headerOffset, 10, 2),
+        ]];
+
+        appendDNSQueries(dnsLayer, offset, children);
+        appendDNSResources(dnsLayer, pcpp::DnsAnswerType, @"dns.answers", @"Answers", offset, children);
+        appendDNSResources(dnsLayer, pcpp::DnsAuthorityType, @"dns.authorities", @"Authoritative nameservers", offset, children);
+        appendDNSResources(dnsLayer, pcpp::DnsAdditionalType, @"dns.additional", @"Additional records", offset, children);
+
+        [nodes addObject:MakeLayerNode(@"dns",
+                                       @"Domain Name System",
+                                       MakeNSString(dnsLayer->toString()),
+                                       offset,
+                                       dnsLayer->getHeaderLen(),
+                                       children)];
+    }
+
+    PCPPNativePacketDetailNodeDescriptor *dnsFlagsNode(const pcpp::dnshdr *header, uint16_t flags, NSUInteger headerOffset)
+    {
+        NSArray *flagChildren = @[
+            MakeFieldNode(@"dns.flags.response", @"Query/Response", DNSQueryResponseValue(header->queryOrResponse), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.opcode", @"Opcode", [NSString stringWithFormat:@"%@ (%u)", DNSOpcodeName(header->opcode), header->opcode], headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.authoritative", @"Authoritative", SetStatus(header->authoritativeAnswer), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.truncated", @"Truncated", SetStatus(header->truncation), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.recursionDesired", @"Recursion Desired", SetStatus(header->recursionDesired), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.recursionAvailable", @"Recursion Available", SetStatus(header->recursionAvailable), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.authenticData", @"Authentic Data", SetStatus(header->authenticData), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.checkingDisabled", @"Checking Disabled", SetStatus(header->checkingDisabled), headerOffset, 2, 2),
+            MakeFieldNode(@"dns.flags.rcode", @"Response Code", [NSString stringWithFormat:@"%@ (%u)", DNSResponseCodeName(header->responseCode), header->responseCode], headerOffset, 2, 2),
+        ];
+        return MakeDetailNode(@"dns.flags",
+                              @"Flags",
+                              FormatHex16(flags),
+                              @"field",
+                              MakeByteRange(headerOffset + 2, 2),
+                              nil,
+                              flagChildren);
+    }
+
+    void appendDNSQueries(pcpp::DnsLayer *dnsLayer,
+                          NSUInteger layerOffset,
+                          NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *queryNodes = [NSMutableArray array];
+        pcpp::DnsQuery *query = dnsLayer->getFirstQuery();
+        NSUInteger index = 0;
+        while (query != nullptr && index < 256) {
+            [queryNodes addObject:dnsQueryNode(query, layerOffset, index)];
+            query = dnsLayer->getNextQuery(query);
+            index += 1;
+        }
+
+        if (queryNodes.count == 0) {
+            return;
+        }
+
+        [children addObject:MakeDetailNode(@"dns.queries",
+                                           @"Queries",
+                                           [NSString stringWithFormat:@"%lu", static_cast<unsigned long>(queryNodes.count)],
+                                           @"field",
+                                           nil,
+                                           nil,
+                                           queryNodes)];
+    }
+
+    PCPPNativePacketDetailNodeDescriptor *dnsQueryNode(pcpp::DnsQuery *query, NSUInteger layerOffset, NSUInteger index)
+    {
+        NSUInteger recordOffset = static_cast<NSUInteger>(query->getNameOffset());
+        NSUInteger recordLength = static_cast<NSUInteger>(query->getSize());
+        NSUInteger nameLength = recordLength >= 4 ? recordLength - 4 : 0;
+        NSString *identifier = [NSString stringWithFormat:@"dns.query.%lu", static_cast<unsigned long>(index)];
+        NSArray *children = @[
+            MakeFieldNode([identifier stringByAppendingString:@".name"],
+                          @"Name",
+                          MakeNSString(query->getName()),
+                          layerOffset,
+                          recordOffset,
+                          nameLength),
+            MakeFieldNode([identifier stringByAppendingString:@".type"],
+                          @"Type",
+                          DNSRecordTypeValue(query->getDnsType()),
+                          layerOffset,
+                          recordOffset + nameLength,
+                          2),
+            MakeFieldNode([identifier stringByAppendingString:@".class"],
+                          @"Class",
+                          DNSClassValue(query->getDnsClass()),
+                          layerOffset,
+                          recordOffset + nameLength + 2,
+                          2),
+        ];
+        return MakeDetailNode(identifier,
+                              [NSString stringWithFormat:@"Query: %@", MakeNSString(query->getName())],
+                              DNSRecordTypeValue(query->getDnsType()),
+                              @"field",
+                              MakeByteRange(layerOffset + recordOffset, recordLength),
+                              nil,
+                              children);
+    }
+
+    void appendDNSResources(pcpp::DnsLayer *dnsLayer,
+                            pcpp::DnsResourceType resourceType,
+                            NSString *identifier,
+                            NSString *name,
+                            NSUInteger layerOffset,
+                            NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children)
+    {
+        NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *resourceNodes = [NSMutableArray array];
+        pcpp::DnsResource *resource = firstDNSResource(dnsLayer, resourceType);
+        NSUInteger index = 0;
+        while (resource != nullptr && index < 512) {
+            [resourceNodes addObject:dnsResourceNode(resource, resourceType, layerOffset, index)];
+            resource = nextDNSResource(dnsLayer, resource, resourceType);
+            index += 1;
+        }
+
+        if (resourceNodes.count == 0) {
+            return;
+        }
+
+        [children addObject:MakeDetailNode(identifier,
+                                           name,
+                                           [NSString stringWithFormat:@"%lu", static_cast<unsigned long>(resourceNodes.count)],
+                                           @"field",
+                                           nil,
+                                           nil,
+                                           resourceNodes)];
+    }
+
+    pcpp::DnsResource *firstDNSResource(pcpp::DnsLayer *dnsLayer, pcpp::DnsResourceType resourceType)
+    {
+        switch (resourceType) {
+            case pcpp::DnsAnswerType:
+                return dnsLayer->getFirstAnswer();
+            case pcpp::DnsAuthorityType:
+                return dnsLayer->getFirstAuthority();
+            case pcpp::DnsAdditionalType:
+                return dnsLayer->getFirstAdditionalRecord();
+            case pcpp::DnsQueryType:
+                return nullptr;
+        }
+    }
+
+    pcpp::DnsResource *nextDNSResource(pcpp::DnsLayer *dnsLayer,
+                                       pcpp::DnsResource *resource,
+                                       pcpp::DnsResourceType resourceType)
+    {
+        switch (resourceType) {
+            case pcpp::DnsAnswerType:
+                return dnsLayer->getNextAnswer(resource);
+            case pcpp::DnsAuthorityType:
+                return dnsLayer->getNextAuthority(resource);
+            case pcpp::DnsAdditionalType:
+                return dnsLayer->getNextAdditionalRecord(resource);
+            case pcpp::DnsQueryType:
+                return nullptr;
+        }
+    }
+
+    PCPPNativePacketDetailNodeDescriptor *dnsResourceNode(pcpp::DnsResource *resource,
+                                                         pcpp::DnsResourceType resourceType,
+                                                         NSUInteger layerOffset,
+                                                         NSUInteger index)
+    {
+        NSUInteger recordOffset = static_cast<NSUInteger>(resource->getNameOffset());
+        NSUInteger recordLength = static_cast<NSUInteger>(resource->getSize());
+        NSUInteger dataOffset = static_cast<NSUInteger>(resource->getDataOffset());
+        NSUInteger dataLength = static_cast<NSUInteger>(resource->getDataLength());
+        NSUInteger fixedFieldsLength = 10;
+        NSUInteger nameLength = dataOffset >= recordOffset + fixedFieldsLength
+            ? dataOffset - recordOffset - fixedFieldsLength
+            : 0;
+        NSString *identifier = [NSString stringWithFormat:@"dns.%@.%lu", DNSResourceSectionIdentifier(resourceType), static_cast<unsigned long>(index)];
+        NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *children = [NSMutableArray arrayWithArray:@[
+            MakeFieldNode([identifier stringByAppendingString:@".name"],
+                          @"Name",
+                          MakeNSString(resource->getName()),
+                          layerOffset,
+                          recordOffset,
+                          nameLength),
+            MakeFieldNode([identifier stringByAppendingString:@".type"],
+                          @"Type",
+                          DNSRecordTypeValue(resource->getDnsType()),
+                          layerOffset,
+                          recordOffset + nameLength,
+                          2),
+            MakeFieldNode([identifier stringByAppendingString:@".class"],
+                          @"Class",
+                          DNSClassValue(resource->getDnsClass()),
+                          layerOffset,
+                          recordOffset + nameLength + 2,
+                          2),
+            MakeFieldNode([identifier stringByAppendingString:@".ttl"],
+                          @"Time to Live",
+                          [NSString stringWithFormat:@"%u", resource->getTTL()],
+                          layerOffset,
+                          recordOffset + nameLength + 4,
+                          4),
+            MakeFieldNode([identifier stringByAppendingString:@".dataLength"],
+                          @"Data Length",
+                          [NSString stringWithFormat:@"%zu", resource->getDataLength()],
+                          layerOffset,
+                          recordOffset + nameLength + 8,
+                          2),
+        ]];
+
+        NSString *dataValue = DNSResourceDataValue(resource);
+        if (dataValue != nil) {
+            [children addObject:MakeFieldNode([identifier stringByAppendingString:@".data"],
+                                              @"Data",
+                                              dataValue,
+                                              layerOffset,
+                                              dataOffset,
+                                              dataLength)];
+        }
+
+        return MakeDetailNode(identifier,
+                              [NSString stringWithFormat:@"%@: %@", DNSResourceRecordName(resourceType), MakeNSString(resource->getName())],
+                              dataValue ?: DNSRecordTypeValue(resource->getDnsType()),
+                              @"field",
+                              MakeByteRange(layerOffset + recordOffset, recordLength),
+                              nil,
+                              children);
+    }
+
+    NSString *DNSResourceSectionIdentifier(pcpp::DnsResourceType resourceType)
+    {
+        switch (resourceType) {
+            case pcpp::DnsAnswerType:
+                return @"answer";
+            case pcpp::DnsAuthorityType:
+                return @"authority";
+            case pcpp::DnsAdditionalType:
+                return @"additional";
+            case pcpp::DnsQueryType:
+                return @"query";
+        }
+    }
+
+    NSString *DNSResourceRecordName(pcpp::DnsResourceType resourceType)
+    {
+        switch (resourceType) {
+            case pcpp::DnsAnswerType:
+                return @"Answer";
+            case pcpp::DnsAuthorityType:
+                return @"Authority";
+            case pcpp::DnsAdditionalType:
+                return @"Additional";
+            case pcpp::DnsQueryType:
+                return @"Query";
+        }
     }
 
     void appendTLS(pcpp::SSLLayer *sslLayer, NSUInteger offset, NSMutableArray<PCPPNativePacketDetailNodeDescriptor *> *nodes)

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -224,6 +224,31 @@ struct InspectorPipelineTests {
         #expect(options.children[8].name == "TCP Option - End of Option List")
     }
 
+    @Test func dnsInspectionRendersHeaderFlagsAndRecords() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let captureURL = directory.appendingPathComponent("dns-response.pcap")
+        try writePCAP(to: captureURL, packets: [makeIPv4DNSResponsePacket()])
+
+        let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: captureURL)
+        let packets = try await document.open()
+        let packet = try #require(packets.first)
+        let inspection = try await document.inspectPacket(id: packet.id)
+
+        #expect(packet.transportHint == .dns)
+        let dnsNode = try #require(inspection.detailNodes.first { $0.name == "Domain Name System" })
+        #expect(findNode(in: dnsNode.children, id: "dns.id")?.value == "0x1234")
+        #expect(findNode(in: dnsNode.children, id: "dns.flags.response")?.value == "Response")
+        #expect(findNode(in: dnsNode.children, id: "dns.count.queries")?.value == "1")
+        #expect(findNode(in: dnsNode.children, id: "dns.count.answers")?.value == "1")
+        #expect(findNode(in: dnsNode.children, id: "dns.query.0.name")?.value == "www.example.com")
+        #expect(findNode(in: dnsNode.children, id: "dns.query.0.type")?.value == "A (1)")
+        #expect(findNode(in: dnsNode.children, id: "dns.answer.0.name")?.value == "www.example.com")
+        #expect(findNode(in: dnsNode.children, id: "dns.answer.0.data")?.value == "93.184.216.34")
+        #expect(findNode(in: dnsNode.children, id: "dns.answer.0.data")?.byteRange == PacketByteRange(offset: 87, length: 4))
+    }
+
     @Test func malformedInspectionAddsDecodeWarningAndKeepsRawBytes() async throws {
         let fixtureURL = CoreFixtureCatalog.captureCategoryURL("malformed").appendingPathComponent("partial-http-request.pcap")
         let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: fixtureURL)
@@ -645,6 +670,49 @@ private func makeIPv4UDPPayloadPacket() -> Data {
         0x0f, 0xa0, 0x13, 0x88, 0x00, 0x0c, 0x00, 0x00,
         0xca, 0xfe, 0xba, 0xbe,
     ])
+}
+
+private func makeIPv4DNSResponsePacket() -> Data {
+    let dnsPayload: [UInt8] = [
+        0x12, 0x34,
+        0x81, 0x80,
+        0x00, 0x01,
+        0x00, 0x01,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x03, 0x77, 0x77, 0x77,
+        0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+        0x03, 0x63, 0x6f, 0x6d,
+        0x00,
+        0x00, 0x01,
+        0x00, 0x01,
+        0xc0, 0x0c,
+        0x00, 0x01,
+        0x00, 0x01,
+        0x00, 0x00, 0x00, 0x3c,
+        0x00, 0x04,
+        0x5d, 0xb8, 0xd8, 0x22,
+    ]
+    let udpLength = UInt16(8 + dnsPayload.count)
+    let ipv4TotalLength = UInt16(20 + Int(udpLength))
+    var packet = Data([
+        0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+        0x08, 0x00,
+        0x45, 0x00,
+    ])
+    packet.appendBigEndian(ipv4TotalLength)
+    packet.append(contentsOf: [
+        0x12, 0x38, 0x40, 0x00, 0x40, 0x11, 0x00, 0x00,
+        0xc0, 0xa8, 0x00, 0x02,
+        0xc0, 0xa8, 0x00, 0x01,
+    ])
+    packet.appendBigEndian(UInt16(53))
+    packet.appendBigEndian(UInt16(54_321))
+    packet.appendBigEndian(udpLength)
+    packet.appendBigEndian(UInt16(0))
+    packet.append(contentsOf: dnsPayload)
+    return packet
 }
 
 private func makeIPv6UDPPayloadPacket() -> Data {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -652,6 +652,7 @@ final class NetworkInspectorViewModel {
     private var packetTableContentCache = PacketTableContentCache()
     private var hasPerformedInitialLoad = false
     private var pendingRebuildWorkItem: DispatchWorkItem?
+    private var rebuildGeneration = 0
 
     // Trailing-edge debounce for delegate-driven rebuilds. Live ingest fires the controller delegate
     // up to ~10 Hz; coalescing to ~12 Hz keeps the UI feeling live without burning CPU on redundant
@@ -1423,8 +1424,13 @@ final class NetworkInspectorViewModel {
         guard pendingRebuildWorkItem == nil else {
             return
         }
+        let generation = rebuildGeneration
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else {
+                return
+            }
+            // Skip canceled coalesced ticks that were queued before a user-driven rebuild.
+            guard self.rebuildGeneration == generation else {
                 return
             }
             self.pendingRebuildWorkItem = nil
@@ -1437,6 +1443,7 @@ final class NetworkInspectorViewModel {
     private func cancelPendingRebuild() {
         pendingRebuildWorkItem?.cancel()
         pendingRebuildWorkItem = nil
+        rebuildGeneration += 1
     }
 
     deinit {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -1,53 +1,158 @@
 import AppKit
+import PcapPlusPlusCore
 
-struct PacketInspectorRenderState: Equatable {
-    let title: String
-    let imageName: String
-    let message: String
+protocol PacketInspectorViewControllerDelegate: AnyObject {
+    func packetInspectorViewController(_ controller: PacketInspectorViewController, didSelectDetailNode identifier: String?)
+}
+
+enum PacketInspectorTreeItemKind: Equatable {
+    case layer
+    case field
+    case warning
+    case message
+}
+
+final class PacketInspectorTreeItem: NSObject {
+    let id: String
+    let nodeID: String?
+    let name: String
+    let value: String?
+    let kind: PacketInspectorTreeItemKind
+    let byteRange: PacketByteRange?
+    let children: [PacketInspectorTreeItem]
 
     init(
-        title: String = "Inspector Panel",
-        imageName: String = "sidebar.trailing",
-        message: String = "A redesigned inspector is coming soon."
+        id: String,
+        nodeID: String? = nil,
+        name: String,
+        value: String? = nil,
+        kind: PacketInspectorTreeItemKind,
+        byteRange: PacketByteRange? = nil,
+        children: [PacketInspectorTreeItem] = []
     ) {
-        self.title = title
-        self.imageName = imageName
-        self.message = message
+        self.id = id
+        self.nodeID = nodeID
+        self.name = name
+        self.value = value
+        self.kind = kind
+        self.byteRange = byteRange
+        self.children = children
     }
 
-    init(snapshot _: NetworkInspectorSnapshot) {
-        self.init()
+    var displayText: String {
+        guard let value, !value.isEmpty else {
+            return name
+        }
+
+        return "\(name): \(value)"
     }
 }
 
-final class PacketInspectorPanelViewModel {
-    private(set) var state = PacketInspectorRenderState()
-    private var hasRendered = false
+final class PacketInspectorTreeViewModel {
+    private(set) var rootItems: [PacketInspectorTreeItem] = []
+    private(set) var selectedNodeID: String?
+    private var itemByNodeID: [String: PacketInspectorTreeItem] = [:]
+    private var renderedInspectionState: PacketInspectionState?
 
-    // Keep the inspector render model stable while the panel is awaiting its redesign.
     @discardableResult
     func render(snapshot: NetworkInspectorSnapshot) -> Bool {
-        let nextState = PacketInspectorRenderState(snapshot: snapshot)
-        guard hasRendered else {
-            state = nextState
-            hasRendered = true
-            return true
-        }
-
-        guard nextState != state else {
+        let inspectionState = snapshot.base.inspectionState
+        guard inspectionState != renderedInspectionState else {
             return false
         }
 
-        state = nextState
+        renderedInspectionState = inspectionState
+        itemByNodeID = [:]
+        rootItems = makeRootItems(from: inspectionState)
+
+        if let selectedDetailNodeID = inspectionState.selectedDetailNodeID,
+           itemByNodeID[selectedDetailNodeID] != nil {
+            selectedNodeID = selectedDetailNodeID
+        } else {
+            selectedNodeID = nil
+        }
+
         return true
+    }
+
+    func item(withNodeID nodeID: String?) -> PacketInspectorTreeItem? {
+        guard let nodeID else {
+            return nil
+        }
+
+        return itemByNodeID[nodeID]
+    }
+
+    private func makeRootItems(from inspectionState: PacketInspectionState) -> [PacketInspectorTreeItem] {
+        if inspectionState.isLoading {
+            return [messageItem(id: "loading", message: inspectionState.statusMessage)]
+        }
+
+        guard let inspection = inspectionState.inspection else {
+            let message = inspectionState.selectedPacketID == nil
+                ? "Select a packet to inspect its decode tree."
+                : inspectionState.statusMessage
+            return [messageItem(id: "empty", message: message)]
+        }
+
+        guard !inspection.detailNodes.isEmpty else {
+            return [messageItem(id: "empty-details", message: "No packet details are available.")]
+        }
+
+        return inspection.detailNodes.map { makeItem(from: $0, parentPath: "") }
+    }
+
+    private func messageItem(id: String, message: String) -> PacketInspectorTreeItem {
+        PacketInspectorTreeItem(id: "__\(id)", name: message, kind: .message)
+    }
+
+    private func makeItem(from node: PacketDetailNode, parentPath: String) -> PacketInspectorTreeItem {
+        let path = parentPath.isEmpty ? node.id : "\(parentPath).\(node.id)"
+        let children = node.children.map { makeItem(from: $0, parentPath: path) }
+        let treeItem = PacketInspectorTreeItem(
+            id: path,
+            nodeID: node.id,
+            name: node.name,
+            value: node.value,
+            kind: itemKind(from: node.kind),
+            byteRange: node.byteRange,
+            children: children
+        )
+        itemByNodeID[node.id] = treeItem
+        return treeItem
+    }
+
+    private func itemKind(from kind: PacketDetailNodeKind) -> PacketInspectorTreeItemKind {
+        switch kind {
+        case .layer:
+            .layer
+        case .field:
+            .field
+        case .warning:
+            .warning
+        @unknown default:
+            .field
+        }
     }
 }
 
 final class PacketInspectorViewController: NSViewController {
-    private let viewModel = PacketInspectorPanelViewModel()
-    private var emptyStateView: NSView?
+    private enum Metrics {
+        static let rowHeight: CGFloat = 20
+        static let cellIdentifier = NSUserInterfaceItemIdentifier("PacketInspectorCell")
+    }
 
-    init(configuration _: AppConfiguration) {
+    weak var delegate: PacketInspectorViewControllerDelegate?
+
+    private let configuration: AppConfiguration
+    private let viewModel = PacketInspectorTreeViewModel()
+    private let scrollView = NSScrollView()
+    private let outlineView = NSOutlineView()
+    private let detailColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("detail"))
+    private var isApplyingSelection = false
+
+    init(configuration: AppConfiguration) {
+        self.configuration = configuration
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -60,28 +165,185 @@ final class PacketInspectorViewController: NSViewController {
         view = NSView()
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        setupOutlineView()
     }
 
-    // Render only the temporary empty state until the redesigned inspector is implemented.
+    // Render the current packet inspection tree as a single Wireshark-style outline.
     func render(snapshot: NetworkInspectorSnapshot) {
-        let didChange = viewModel.render(snapshot: snapshot)
-        guard didChange || emptyStateView == nil else {
+        guard viewModel.render(snapshot: snapshot) else {
             return
         }
 
-        showEmptyState()
+        outlineView.reloadData()
+        expandAllItems()
+        applySelectedNode()
     }
 
-    private func showEmptyState() {
-        emptyStateView?.removeFromSuperview()
-        let state = viewModel.state
-        let placeholder = TCPViewerUI.placeholder(
-            title: state.title,
-            imageName: state.imageName,
-            message: state.message,
-            iconTitleSpacing: 18
-        )
-        TCPViewerUI.pin(placeholder, to: view)
-        emptyStateView = placeholder
+    private func setupOutlineView() {
+        detailColumn.minWidth = 160
+        detailColumn.width = 320
+        detailColumn.resizingMask = .autoresizingMask
+        detailColumn.title = ""
+
+        outlineView.addTableColumn(detailColumn)
+        outlineView.outlineTableColumn = detailColumn
+        outlineView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+        outlineView.headerView = nil
+        outlineView.rowHeight = Metrics.rowHeight
+        outlineView.indentationPerLevel = 14
+        outlineView.usesAlternatingRowBackgroundColors = false
+        outlineView.selectionHighlightStyle = .regular
+        outlineView.dataSource = self
+        outlineView.delegate = self
+        outlineView.allowsEmptySelection = true
+        outlineView.backgroundColor = .controlBackgroundColor
+
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.documentView = outlineView
+
+        TCPViewerUI.pin(scrollView, to: view)
+    }
+
+    private func expandAllItems() {
+        for item in viewModel.rootItems {
+            expand(item)
+        }
+    }
+
+    private func expand(_ item: PacketInspectorTreeItem) {
+        outlineView.expandItem(item)
+        for child in item.children {
+            expand(child)
+        }
+    }
+
+    private func applySelectedNode() {
+        isApplyingSelection = true
+        defer { isApplyingSelection = false }
+
+        guard let item = viewModel.item(withNodeID: viewModel.selectedNodeID) else {
+            outlineView.deselectAll(nil)
+            return
+        }
+
+        let row = outlineView.row(forItem: item)
+        guard row >= 0 else {
+            outlineView.deselectAll(nil)
+            return
+        }
+
+        outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+        outlineView.scrollRowToVisible(row)
+    }
+
+    private func configuredCell(for item: PacketInspectorTreeItem) -> NSTableCellView {
+        let cell = outlineView.makeView(withIdentifier: Metrics.cellIdentifier, owner: self) as? NSTableCellView
+            ?? makeCell()
+        let textField = cell.textField ?? NSTextField(labelWithString: "")
+        if cell.textField == nil {
+            cell.textField = textField
+            cell.addSubview(textField)
+            textField.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                textField.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+                textField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+                textField.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            ])
+        }
+
+        textField.stringValue = item.displayText
+        textField.font = font(for: item.kind)
+        textField.textColor = textColor(for: item.kind)
+        textField.lineBreakMode = .byTruncatingTail
+        textField.maximumNumberOfLines = 1
+        return cell
+    }
+
+    private func makeCell() -> NSTableCellView {
+        let cell = NSTableCellView()
+        cell.identifier = Metrics.cellIdentifier
+        return cell
+    }
+
+    private func font(for kind: PacketInspectorTreeItemKind) -> NSFont {
+        switch kind {
+        case .layer:
+            configuration.packetFont(weight: .semibold)
+        case .field, .warning, .message:
+            configuration.packetFont()
+        }
+    }
+
+    private func textColor(for kind: PacketInspectorTreeItemKind) -> NSColor {
+        switch kind {
+        case .warning:
+            .systemOrange
+        case .message:
+            .secondaryLabelColor
+        case .layer, .field:
+            .labelColor
+        }
+    }
+}
+
+extension PacketInspectorViewController: NSOutlineViewDataSource {
+    func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+        guard let item = item as? PacketInspectorTreeItem else {
+            return viewModel.rootItems.count
+        }
+
+        return item.children.count
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+        guard let item = item as? PacketInspectorTreeItem else {
+            return viewModel.rootItems[index]
+        }
+
+        return item.children[index]
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
+        guard let item = item as? PacketInspectorTreeItem else {
+            return false
+        }
+
+        return !item.children.isEmpty
+    }
+}
+
+extension PacketInspectorViewController: NSOutlineViewDelegate {
+    func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+        guard let item = item as? PacketInspectorTreeItem else {
+            return nil
+        }
+
+        return configuredCell(for: item)
+    }
+
+    func outlineViewSelectionDidChange(_ notification: Notification) {
+        guard !isApplyingSelection else {
+            return
+        }
+
+        let selectedRow = outlineView.selectedRow
+        guard selectedRow >= 0,
+              let item = outlineView.item(atRow: selectedRow) as? PacketInspectorTreeItem else {
+            delegate?.packetInspectorViewController(self, didSelectDetailNode: nil)
+            return
+        }
+
+        delegate?.packetInspectorViewController(self, didSelectDetailNode: item.nodeID)
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
+        guard let item = item as? PacketInspectorTreeItem else {
+            return false
+        }
+
+        return item.nodeID != nil
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -12,6 +12,12 @@ enum PacketInspectorTreeItemKind: Equatable {
     case message
 }
 
+enum PacketInspectorTreeRenderChange: Equatable {
+    case none
+    case reload
+    case selection
+}
+
 final class PacketInspectorTreeItem: NSObject {
     let id: String
     let nodeID: String?
@@ -52,27 +58,27 @@ final class PacketInspectorTreeViewModel {
     private(set) var rootItems: [PacketInspectorTreeItem] = []
     private(set) var selectedNodeID: String?
     private var itemByNodeID: [String: PacketInspectorTreeItem] = [:]
-    private var renderedInspectionState: PacketInspectionState?
+    private var renderedContentState: PacketInspectorTreeContentState?
 
     @discardableResult
-    func render(snapshot: NetworkInspectorSnapshot) -> Bool {
+    func render(snapshot: NetworkInspectorSnapshot) -> PacketInspectorTreeRenderChange {
         let inspectionState = snapshot.base.inspectionState
-        guard inspectionState != renderedInspectionState else {
-            return false
+        let contentState = PacketInspectorTreeContentState(inspectionState: inspectionState)
+        let contentChanged = contentState != renderedContentState
+
+        if contentChanged {
+            renderedContentState = contentState
+            itemByNodeID = [:]
+            rootItems = makeRootItems(from: inspectionState)
         }
 
-        renderedInspectionState = inspectionState
-        itemByNodeID = [:]
-        rootItems = makeRootItems(from: inspectionState)
-
-        if let selectedDetailNodeID = inspectionState.selectedDetailNodeID,
-           itemByNodeID[selectedDetailNodeID] != nil {
-            selectedNodeID = selectedDetailNodeID
-        } else {
-            selectedNodeID = nil
+        let nextSelectedNodeID = validSelectedNodeID(from: inspectionState)
+        guard nextSelectedNodeID != selectedNodeID else {
+            return contentChanged ? .reload : .none
         }
 
-        return true
+        selectedNodeID = nextSelectedNodeID
+        return contentChanged ? .reload : .selection
     }
 
     func item(withNodeID nodeID: String?) -> PacketInspectorTreeItem? {
@@ -88,7 +94,7 @@ final class PacketInspectorTreeViewModel {
             return [messageItem(id: "loading", message: inspectionState.statusMessage)]
         }
 
-        guard let inspection = inspectionState.inspection else {
+        guard let inspection = inspectionState.currentInspection else {
             let message = inspectionState.selectedPacketID == nil
                 ? "Select a packet to inspect its decode tree."
                 : inspectionState.statusMessage
@@ -100,6 +106,15 @@ final class PacketInspectorTreeViewModel {
         }
 
         return inspection.detailNodes.map { makeItem(from: $0, parentPath: "") }
+    }
+
+    private func validSelectedNodeID(from inspectionState: PacketInspectionState) -> String? {
+        guard let selectedDetailNodeID = inspectionState.selectedDetailNodeID,
+              itemByNodeID[selectedDetailNodeID] != nil else {
+            return nil
+        }
+
+        return selectedDetailNodeID
     }
 
     private func messageItem(id: String, message: String) -> PacketInspectorTreeItem {
@@ -133,6 +148,31 @@ final class PacketInspectorTreeViewModel {
         @unknown default:
             .field
         }
+    }
+}
+
+private struct PacketInspectorTreeContentState: Equatable {
+    let selectedPacketID: PacketSummary.ID?
+    let inspection: PacketInspection?
+    let isLoading: Bool
+    let statusMessage: String
+
+    init(inspectionState: PacketInspectionState) {
+        selectedPacketID = inspectionState.selectedPacketID
+        inspection = inspectionState.currentInspection
+        isLoading = inspectionState.isLoading
+        statusMessage = inspectionState.statusMessage
+    }
+}
+
+private extension PacketInspectionState {
+    var currentInspection: PacketInspection? {
+        guard let inspection,
+              selectedPacketID == inspection.packetID else {
+            return nil
+        }
+
+        return inspection
     }
 }
 
@@ -170,10 +210,20 @@ final class PacketInspectorViewController: NSViewController {
 
     // Render the current packet inspection tree as a single Wireshark-style outline.
     func render(snapshot: NetworkInspectorSnapshot) {
-        guard viewModel.render(snapshot: snapshot) else {
+        switch viewModel.render(snapshot: snapshot) {
+        case .none:
             return
+        case .selection:
+            applySelectedNode()
+            return
+        case .reload:
+            break
         }
 
+        if let inspection = snapshot.base.inspectionState.inspection,
+           snapshot.base.inspectionState.selectedPacketID == inspection.packetID {
+            print("[TCPViewer] \(NetworkInspectorDebugLog.timestamp()) ✅ Inspector View rendering data: packet=#\(inspection.packetNumber), rootNodes=\(viewModel.rootItems.count)")
+        }
         outlineView.reloadData()
         expandAllItems()
         applySelectedNode()
@@ -197,6 +247,7 @@ final class PacketInspectorViewController: NSViewController {
         outlineView.delegate = self
         outlineView.allowsEmptySelection = true
         outlineView.backgroundColor = .controlBackgroundColor
+        outlineView.style = .fullWidth
 
         scrollView.borderType = .noBorder
         scrollView.drawsBackground = false

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -151,6 +151,7 @@ final class TCPViewerRootViewController: NSViewController {
         // Build the two-level split layout: sidebar | (table | inspector).
         sidebarViewController.delegate = self
         workspaceViewController.delegate = self
+        inspectorViewController.delegate = self
         statusStripViewController.delegate = self
 
         mainSplitViewController.splitView.isVertical = true
@@ -163,6 +164,7 @@ final class TCPViewerRootViewController: NSViewController {
         // Use a regular split item so the same inspector view can resize correctly on both axes.
         let inspectorItem = NSSplitViewItem(viewController: inspectorViewController)
         inspectorItem.canCollapse = true
+        inspectorItem.minimumThickness = 200
         contentSplitViewController.addSplitViewItem(inspectorItem)
         self.inspectorItem = inspectorItem
 
@@ -450,6 +452,12 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID]) {
         viewModel.deletePackets(identifiers)
+    }
+}
+
+extension TCPViewerRootViewController: PacketInspectorViewControllerDelegate {
+    func packetInspectorViewController(_ controller: PacketInspectorViewController, didSelectDetailNode identifier: String?) {
+        viewModel.selectDetailNode(identifier)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -158,13 +158,14 @@ final class TCPViewerRootViewController: NSViewController {
         contentSplitViewController.splitView.isVertical = true
 
         // Keep the table and inspector inside the main container split.
-        let workspaceItem = NSSplitViewItem(viewController: workspaceViewController)
+        let workspaceItem = NSSplitViewItem(contentListWithViewController: workspaceViewController)
         contentSplitViewController.addSplitViewItem(workspaceItem)
 
         // Use a regular split item so the same inspector view can resize correctly on both axes.
         let inspectorItem = NSSplitViewItem(viewController: inspectorViewController)
         inspectorItem.canCollapse = true
         inspectorItem.minimumThickness = 200
+        inspectorItem.preferredThicknessFraction = 0.4
         contentSplitViewController.addSplitViewItem(inspectorItem)
         self.inspectorItem = inspectorItem
 

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -276,9 +276,9 @@ struct NetworkInspectorViewModelTests {
             updatePlan: .append(1..<2)
         )
 
-        #expect(treeViewModel.render(snapshot: firstSnapshot))
+        #expect(treeViewModel.render(snapshot: firstSnapshot) == .reload)
         #expect(treeViewModel.rootItems.first?.displayText == "Frame: Packet 1")
-        #expect(!treeViewModel.render(snapshot: appendSnapshot))
+        #expect(treeViewModel.render(snapshot: appendSnapshot) == .none)
     }
 
     @Test func statusStripKeepsCancelAvailableDuringZeroPacketLoad() {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -257,10 +257,10 @@ struct NetworkInspectorViewModelTests {
         ) == .none)
     }
 
-    @Test func inspectorPanelUsesTemporaryEmptyState() {
+    @Test func inspectorTreeIgnoresUnchangedInspectionDuringAppend() {
         let selectedPacket = makePacket(packetNumber: 1, source: .live, transportHint: .tcp, streamID: nil)
         let appendedPacket = makePacket(packetNumber: 2, source: .live, transportHint: .udp, streamID: nil)
-        let panelViewModel = PacketInspectorPanelViewModel()
+        let treeViewModel = PacketInspectorTreeViewModel()
         let firstSnapshot = makeInspectorSnapshot(
             packets: [selectedPacket],
             selectedPacketID: selectedPacket.id,
@@ -276,11 +276,9 @@ struct NetworkInspectorViewModelTests {
             updatePlan: .append(1..<2)
         )
 
-        #expect(panelViewModel.render(snapshot: firstSnapshot))
-        #expect(panelViewModel.state.title == "Inspector Panel")
-        #expect(panelViewModel.state.imageName == "sidebar.trailing")
-        #expect(panelViewModel.state.message == "A redesigned inspector is coming soon.")
-        #expect(!panelViewModel.render(snapshot: appendSnapshot))
+        #expect(treeViewModel.render(snapshot: firstSnapshot))
+        #expect(treeViewModel.rootItems.first?.displayText == "Frame: Packet 1")
+        #expect(!treeViewModel.render(snapshot: appendSnapshot))
     }
 
     @Test func statusStripKeepsCancelAvailableDuringZeroPacketLoad() {

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+struct PacketInspectorTreeViewModelTests {
+    @Test func emptyStateShowsSelectionPrompt() {
+        let viewModel = PacketInspectorTreeViewModel()
+
+        viewModel.render(snapshot: makeSnapshot(inspectionState: .empty))
+
+        #expect(viewModel.rootItems.count == 1)
+        #expect(viewModel.rootItems[0].kind == .message)
+        #expect(viewModel.rootItems[0].displayText == "Select a packet to inspect its decode tree.")
+    }
+
+    @Test func loadingStateShowsStatusMessage() {
+        let packet = makePacket()
+        let state = PacketInspectionState(
+            selectedPacketID: packet.id,
+            inspection: nil,
+            selectedDetailNodeID: nil,
+            highlightedByteRange: nil,
+            isLoading: true,
+            statusMessage: "Inspecting packet 1..."
+        )
+        let viewModel = PacketInspectorTreeViewModel()
+
+        viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state))
+
+        #expect(viewModel.rootItems.count == 1)
+        #expect(viewModel.rootItems[0].kind == .message)
+        #expect(viewModel.rootItems[0].displayText == "Inspecting packet 1...")
+    }
+
+    @Test func loadedTreeMapsNodeKindsAndDisplayText() {
+        let packet = makePacket()
+        let inspection = PacketInspection(
+            packetID: packet.id,
+            packetNumber: packet.packetNumber,
+            rawBytes: Data([0x01, 0x02]),
+            detailNodes: [
+                PacketDetailNode(
+                    id: "frame",
+                    name: "Frame",
+                    value: "Packet 1",
+                    kind: .layer,
+                    children: [
+                        PacketDetailNode(id: "frame.number", name: "Frame Number", value: "1"),
+                    ]
+                ),
+                PacketDetailNode(id: "warning.decode", name: "Decode Warning", value: "Partial decode", kind: .warning),
+            ],
+            decodeStatus: PacketDecodeStatus(kind: .partial, reason: "Partial decode")
+        )
+        let state = PacketInspectionState(
+            selectedPacketID: packet.id,
+            inspection: inspection,
+            selectedDetailNodeID: nil,
+            highlightedByteRange: nil,
+            isLoading: false,
+            statusMessage: "Inspecting packet 1."
+        )
+        let viewModel = PacketInspectorTreeViewModel()
+
+        viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state))
+
+        #expect(viewModel.rootItems.map(\.kind) == [.layer, .warning])
+        #expect(viewModel.rootItems[0].displayText == "Frame: Packet 1")
+        #expect(viewModel.rootItems[0].children.first?.displayText == "Frame Number: 1")
+        #expect(viewModel.rootItems[1].displayText == "Decode Warning: Partial decode")
+    }
+
+    @Test func selectedDetailNodeIsPreservedWhenPresent() {
+        let packet = makePacket()
+        let selectedRange = PacketByteRange(offset: 26, length: 4)
+        let inspection = PacketInspection(
+            packetID: packet.id,
+            packetNumber: packet.packetNumber,
+            rawBytes: Data([0x01, 0x02]),
+            detailNodes: [
+                PacketDetailNode(
+                    id: "ipv4",
+                    name: "IPv4",
+                    kind: .layer,
+                    children: [
+                        PacketDetailNode(id: "ipv4.src", name: "Source", value: "10.0.0.1", byteRange: selectedRange),
+                    ]
+                ),
+            ],
+            decodeStatus: PacketDecodeStatus(kind: .complete)
+        )
+        let state = PacketInspectionState(
+            selectedPacketID: packet.id,
+            inspection: inspection,
+            selectedDetailNodeID: "ipv4.src",
+            highlightedByteRange: selectedRange,
+            isLoading: false,
+            statusMessage: "Inspecting packet 1."
+        )
+        let viewModel = PacketInspectorTreeViewModel()
+
+        viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state))
+
+        #expect(viewModel.selectedNodeID == "ipv4.src")
+        #expect(viewModel.item(withNodeID: "ipv4.src")?.displayText == "Source: 10.0.0.1")
+        #expect(viewModel.item(withNodeID: "missing") == nil)
+    }
+
+    private func makeSnapshot(packet: PacketSummary? = nil, inspectionState: PacketInspectionState) -> NetworkInspectorSnapshot {
+        var base = TCPViewerWindowSnapshot.foundation
+        if let packet {
+            base.packetIngestState.replace(with: [packet], source: packet.source)
+            base.navigationState.visiblePacketIDs = [packet.id]
+        }
+        base.inspectionState = inspectionState
+
+        let rows = packet.map { [PacketTableRow(packet: $0)] } ?? []
+        let visibleIndex = Dictionary(uniqueKeysWithValues: rows.enumerated().map { index, row in
+            (row.id, index)
+        })
+        let tableContent = PacketTableContent(
+            displayFilter: PacketDisplayFilter(""),
+            displayFilterChips: [],
+            store: PacketTableRowStore(rows: rows, visiblePacketRowIndexByID: visibleIndex),
+            generation: 1,
+            updatePlan: rows.isEmpty ? .none : .reload,
+            malformedPacketCount: 0
+        )
+
+        return NetworkInspectorSnapshot.make(
+            base: base,
+            selectedSidebar: .liveCapture,
+            selectedSourceListSelection: .allPackets,
+            sourceListSnapshot: .empty,
+            sourceListFilterText: "",
+            workspaceMode: .packets,
+            inspectorTab: .summary,
+            isInspectorVisible: true,
+            displayFilterText: "",
+            packetTableContent: tableContent
+        )
+    }
+
+    private func makePacket() -> PacketSummary {
+        PacketSummary(
+            packetNumber: 1,
+            timestamp: Date(timeIntervalSince1970: 0),
+            source: .offline,
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+            ),
+            originalLength: 64,
+            capturedLength: 64,
+            infoSummary: "TCP packet",
+            layers: [PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false)
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
@@ -7,7 +7,7 @@ struct PacketInspectorTreeViewModelTests {
     @Test func emptyStateShowsSelectionPrompt() {
         let viewModel = PacketInspectorTreeViewModel()
 
-        viewModel.render(snapshot: makeSnapshot(inspectionState: .empty))
+        #expect(viewModel.render(snapshot: makeSnapshot(inspectionState: .empty)) == .reload)
 
         #expect(viewModel.rootItems.count == 1)
         #expect(viewModel.rootItems[0].kind == .message)
@@ -26,7 +26,7 @@ struct PacketInspectorTreeViewModelTests {
         )
         let viewModel = PacketInspectorTreeViewModel()
 
-        viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state))
+        #expect(viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state)) == .reload)
 
         #expect(viewModel.rootItems.count == 1)
         #expect(viewModel.rootItems[0].kind == .message)
@@ -63,7 +63,7 @@ struct PacketInspectorTreeViewModelTests {
         )
         let viewModel = PacketInspectorTreeViewModel()
 
-        viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state))
+        #expect(viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state)) == .reload)
 
         #expect(viewModel.rootItems.map(\.kind) == [.layer, .warning])
         #expect(viewModel.rootItems[0].displayText == "Frame: Packet 1")
@@ -100,11 +100,56 @@ struct PacketInspectorTreeViewModelTests {
         )
         let viewModel = PacketInspectorTreeViewModel()
 
-        viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state))
+        #expect(viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: state)) == .reload)
 
         #expect(viewModel.selectedNodeID == "ipv4.src")
         #expect(viewModel.item(withNodeID: "ipv4.src")?.displayText == "Source: 10.0.0.1")
         #expect(viewModel.item(withNodeID: "missing") == nil)
+    }
+
+    @Test func selectionChangeDoesNotRebuildTreeItems() throws {
+        let packet = makePacket()
+        let selectedRange = PacketByteRange(offset: 26, length: 4)
+        let inspection = PacketInspection(
+            packetID: packet.id,
+            packetNumber: packet.packetNumber,
+            rawBytes: Data([0x01, 0x02]),
+            detailNodes: [
+                PacketDetailNode(
+                    id: "ipv4",
+                    name: "IPv4",
+                    kind: .layer,
+                    children: [
+                        PacketDetailNode(id: "ipv4.src", name: "Source", value: "10.0.0.1", byteRange: selectedRange),
+                    ]
+                ),
+            ],
+            decodeStatus: PacketDecodeStatus(kind: .complete)
+        )
+        let unselectedState = PacketInspectionState(
+            selectedPacketID: packet.id,
+            inspection: inspection,
+            selectedDetailNodeID: nil,
+            highlightedByteRange: nil,
+            isLoading: false,
+            statusMessage: "Inspecting packet 1."
+        )
+        let selectedState = PacketInspectionState(
+            selectedPacketID: packet.id,
+            inspection: inspection,
+            selectedDetailNodeID: "ipv4.src",
+            highlightedByteRange: selectedRange,
+            isLoading: false,
+            statusMessage: "Inspecting packet 1."
+        )
+        let viewModel = PacketInspectorTreeViewModel()
+
+        #expect(viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: unselectedState)) == .reload)
+        let originalRootItem = try #require(viewModel.rootItems.first)
+
+        #expect(viewModel.render(snapshot: makeSnapshot(packet: packet, inspectionState: selectedState)) == .selection)
+        #expect(viewModel.selectedNodeID == "ipv4.src")
+        #expect(viewModel.rootItems.first === originalRootItem)
     }
 
     private func makeSnapshot(packet: PacketSummary? = nil, inspectionState: PacketInspectionState) -> NetworkInspectorSnapshot {


### PR DESCRIPTION
## Summary
- Replace the inspector placeholder with a full-height single-column `NSOutlineView` that renders packet decode trees
- Add a controller-specific tree view model and delegate wiring so detail selection updates the shared inspection state
- Extend the PcapPlusPlus native bridge to decode DNS headers, flags, counts, queries, and resource records
- Add coverage for the inspector tree model and DNS inspection byte ranges

## Testing
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`
- Added unit coverage for the new outline tree model and DNS inspection rendering