### PR TITLE
Implement pin logic in left panel

### DIFF
--- a/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
@@ -51,9 +51,7 @@ struct PacketTableMenuState: Equatable {
     let clickedColumn: PacketTableColumnRole
     let copyRowEnabled: Bool
     let copyCellEnabled: Bool
-    let pinDomainEnabled: Bool
-    let pinIPEnabled: Bool
-    let pinClientEnabled: Bool
+    let pinEnabled: Bool
     let saveEnabled: Bool
     let exportEnabled: Bool
     let deleteEnabled: Bool
@@ -63,9 +61,7 @@ struct PacketTableMenuState: Equatable {
         clickedColumn: .unknown,
         copyRowEnabled: false,
         copyCellEnabled: false,
-        pinDomainEnabled: false,
-        pinIPEnabled: false,
-        pinClientEnabled: false,
+        pinEnabled: false,
         saveEnabled: false,
         exportEnabled: false,
         deleteEnabled: false
@@ -94,16 +90,13 @@ enum PacketTableMenuLogic {
         )
         let targetRows = targetIndexes.compactMap { rows.indices.contains($0) ? rows[$0] : nil }
         let clickedColumn = PacketTableColumnRole(columnIdentifier: clickedColumnIdentifier)
-        let singleRow = targetRows.count == 1 ? targetRows[0] : nil
 
         return PacketTableMenuState(
             targetRows: targetIndexes,
             clickedColumn: clickedColumn,
             copyRowEnabled: !targetRows.isEmpty,
             copyCellEnabled: !targetRows.isEmpty && clickedColumn != .unknown,
-            pinDomainEnabled: singleRow?.canPinDomain == true,
-            pinIPEnabled: singleRow?.ipAddress(for: clickedColumn) != nil,
-            pinClientEnabled: singleRow?.canPinClient == true,
+            pinEnabled: targetRows.contains { $0.canPinClient },
             saveEnabled: !targetRows.isEmpty,
             exportEnabled: !targetRows.isEmpty,
             deleteEnabled: !targetRows.isEmpty

--- a/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
@@ -115,6 +115,47 @@ final class PacketPinService {
         now: Date = Date()
     ) throws -> PacketPin {
         let pin = try makePin(from: packet, kind: kind, clickedColumn: clickedColumn, now: now)
+        return try upsert(pin)
+    }
+
+    @discardableResult
+    func upsertClientPin(_ identity: PacketSourceClientIdentity, now: Date = Date()) throws -> PacketPin {
+        let pin = PacketPin(
+            id: PacketPinID(rawValue: "client:\(identity.key.rawValue)"),
+            kind: .client,
+            title: identity.displayName,
+            createdAt: now,
+            domain: nil,
+            ipAddress: nil,
+            clientKey: identity.key.rawValue,
+            clientDisplayName: identity.displayName,
+            clientIconFilePath: identity.iconFilePath
+        )
+        return try upsert(pin)
+    }
+
+    @discardableResult
+    func upsertDomainPin(_ identity: PacketSourceDomainIdentity, now: Date = Date()) throws -> PacketPin {
+        guard !identity.key.isMissingDomain else {
+            throw PacketPinCreationError.missingDomain
+        }
+
+        let domain = identity.key.rawValue
+        let pin = PacketPin(
+            id: PacketPinID(rawValue: "domain:\(domain)"),
+            kind: .domain,
+            title: identity.displayName,
+            createdAt: now,
+            domain: domain,
+            ipAddress: nil,
+            clientKey: nil,
+            clientDisplayName: nil,
+            clientIconFilePath: nil
+        )
+        return try upsert(pin)
+    }
+
+    private func upsert(_ pin: PacketPin) throws -> PacketPin {
         if let existingIndex = cachedPins.firstIndex(where: { $0.id == pin.id }) {
             return cachedPins[existingIndex]
         }

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -171,6 +171,11 @@ struct PacketSourceIPAddressIdentity: Hashable, Sendable {
     let displayName: String
 }
 
+enum PacketSourceListPinTarget: Hashable, Sendable {
+    case client(PacketSourceClientIdentity)
+    case domain(PacketSourceDomainIdentity)
+}
+
 enum PacketSourceListDeletionAction: Equatable, Sendable {
     case none
     case deletePin(PacketPinID)
@@ -193,6 +198,45 @@ enum PacketSourceListExportPolicy {
         case .pinned, .pinnedItem, .saved, .apps, .app, .domains, .domain, .ipAddress:
             return selection
         case .allPackets:
+            return nil
+        }
+    }
+}
+
+enum PacketSourceListPinPolicy {
+    static func targets(for items: [PacketSourceListItem]) -> [PacketSourceListPinTarget] {
+        var seenTargets = Set<PacketSourceListPinTarget>()
+        var targets: [PacketSourceListPinTarget] = []
+
+        for item in items {
+            guard let target = target(for: item),
+                  seenTargets.insert(target).inserted else {
+                continue
+            }
+            targets.append(target)
+        }
+
+        return targets
+    }
+
+    static func target(for item: PacketSourceListItem?) -> PacketSourceListPinTarget? {
+        guard let item else {
+            return nil
+        }
+
+        switch item.selection {
+        case .app(let key):
+            return .client(PacketSourceClientIdentity(
+                key: key,
+                displayName: item.title,
+                iconFilePath: item.iconFilePath
+            ))
+        case .domain(let key) where !key.isMissingDomain:
+            return .domain(PacketSourceDomainIdentity(
+                key: key,
+                displayName: item.title
+            ))
+        default:
             return nil
         }
     }
@@ -332,6 +376,7 @@ final class PacketSourceListService {
         var appIdentity: PacketSourceClientIdentity?
         var domainIdentity: PacketSourceDomainIdentity
         var ipAddressIdentities: [PacketSourceIPAddressIdentity]
+        var pinIPAddresses: Set<String>
     }
 
     private var packetRevision: UInt64?
@@ -346,6 +391,7 @@ final class PacketSourceListService {
     private var ipAddressOrder: [PacketSourceIPAddressKey] = []
     private var packetAssignmentsByID: [PacketSummary.ID: PacketBucketAssignment] = [:]
     private var pinnedItems: [PacketPin] = []
+    private var pinnedPacketCountsByID: [PacketPinID: Int] = [:]
     private var savedPacketCount = 0
 
     func reset() {
@@ -361,6 +407,7 @@ final class PacketSourceListService {
         ipAddressOrder.removeAll(keepingCapacity: false)
         packetAssignmentsByID.removeAll(keepingCapacity: false)
         pinnedItems = []
+        pinnedPacketCountsByID.removeAll(keepingCapacity: false)
         savedPacketCount = 0
     }
 
@@ -379,8 +426,9 @@ final class PacketSourceListService {
         pinnedItems: [PacketPin] = [],
         savedPacketCount: Int = 0
     ) -> PacketSourceListSnapshot {
+        let didChangePinnedItems = self.pinnedItems != pinnedItems
         guard packetRevision != ingestState.packetRevision ||
-                self.pinnedItems != pinnedItems ||
+                didChangePinnedItems ||
                 self.savedPacketCount != savedPacketCount else {
             return cachedSnapshot
         }
@@ -390,6 +438,9 @@ final class PacketSourceListService {
 
         if packetLineageRevision == ingestState.packetLineageRevision,
            sourcePacketCount <= ingestState.packets.count {
+            if didChangePinnedItems {
+                rebuildPinnedCountsFromAssignments()
+            }
             switch ingestState.lastMutation {
             case .append:
                 return appendSnapshot(from: ingestState)
@@ -416,6 +467,7 @@ final class PacketSourceListService {
         ipAddressBuckets = [:]
         ipAddressOrder = []
         packetAssignmentsByID.removeAll(keepingCapacity: true)
+        pinnedPacketCountsByID.removeAll(keepingCapacity: true)
         appendPackets(ingestState.packets)
         return storeSnapshot(for: ingestState)
     }
@@ -437,7 +489,8 @@ final class PacketSourceListService {
         PacketBucketAssignment(
             appIdentity: PacketSourceListClassifier.clientIdentity(for: packet),
             domainIdentity: PacketSourceListClassifier.domainIdentity(for: packet),
-            ipAddressIdentities: PacketSourceListClassifier.ipAddressIdentities(for: packet)
+            ipAddressIdentities: PacketSourceListClassifier.ipAddressIdentities(for: packet),
+            pinIPAddresses: Self.pinIPAddresses(for: packet)
         )
     }
 
@@ -483,6 +536,8 @@ final class PacketSourceListService {
             }
             ipAddressBuckets[ipAddressIdentity.key]?.packetCount += 1
         }
+
+        incrementPinnedCounts(for: assignment)
     }
 
     private func decrement(for assignment: PacketBucketAssignment) {
@@ -519,6 +574,8 @@ final class PacketSourceListService {
                 }
             }
         }
+
+        decrementPinnedCounts(for: assignment)
     }
 
     private func storeSnapshot(for ingestState: PacketIngestState) -> PacketSourceListSnapshot {
@@ -532,16 +589,71 @@ final class PacketSourceListService {
             pinnedBuckets: pinnedItems.map { pin in
                 PacketSourceListTreeBuilder.PinnedBucket(
                     pin: pin,
-                    packetCount: ingestState.packets.reduce(into: 0) { count, packet in
-                        if PacketPinMatcher.matches(packet, pin: pin) {
-                            count += 1
-                        }
-                    }
+                    packetCount: pinnedPacketCountsByID[pin.id, default: 0]
                 )
             },
             savedPacketCount: savedPacketCount
         )
         return cachedSnapshot
+    }
+
+    private func rebuildPinnedCountsFromAssignments() {
+        pinnedPacketCountsByID.removeAll(keepingCapacity: true)
+        for assignment in packetAssignmentsByID.values {
+            incrementPinnedCounts(for: assignment)
+        }
+    }
+
+    private func incrementPinnedCounts(for assignment: PacketBucketAssignment) {
+        guard !pinnedItems.isEmpty else {
+            return
+        }
+
+        for pin in pinnedItems where matches(assignment, pin: pin) {
+            pinnedPacketCountsByID[pin.id, default: 0] += 1
+        }
+    }
+
+    private func decrementPinnedCounts(for assignment: PacketBucketAssignment) {
+        guard !pinnedItems.isEmpty else {
+            return
+        }
+
+        for pin in pinnedItems where matches(assignment, pin: pin) {
+            let updatedCount = pinnedPacketCountsByID[pin.id, default: 0] - 1
+            if updatedCount > 0 {
+                pinnedPacketCountsByID[pin.id] = updatedCount
+            } else {
+                pinnedPacketCountsByID.removeValue(forKey: pin.id)
+            }
+        }
+    }
+
+    private func matches(_ assignment: PacketBucketAssignment, pin: PacketPin) -> Bool {
+        switch pin.kind {
+        case .domain:
+            return assignment.domainIdentity.key.rawValue == pin.domain
+        case .ip:
+            guard let ipAddress = pin.ipAddress?.lowercased() else {
+                return false
+            }
+            return assignment.pinIPAddresses.contains(ipAddress)
+        case .client:
+            return assignment.appIdentity?.key.rawValue == pin.clientKey
+        }
+    }
+
+    private static func pinIPAddresses(for packet: PacketSummary) -> Set<String> {
+        [
+            packet.endpoints.source.address,
+            packet.endpoints.destination.address,
+        ].reduce(into: Set<String>()) { result, address in
+            guard let address = address?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !address.isEmpty else {
+                return
+            }
+            result.insert(address.lowercased())
+        }
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1201,9 +1201,30 @@ final class NetworkInspectorViewModel {
             return
         }
 
-        selectedSourceListSelection = .pinnedItem(pin.id)
-        workspaceMode = .packets
-        rebuildSnapshot()
+        selectAfterPinning([pin])
+    }
+
+    func pinAppPackets(_ identifiers: [PacketSummary.ID]) {
+        let pins = identifiers.compactMap { identifier -> PacketPin? in
+            guard let packet = packet(withID: identifier),
+                  let identity = PacketSourceListClassifier.clientIdentity(for: packet) else {
+                return nil
+            }
+            return try? pinService.upsertClientPin(identity)
+        }
+        selectAfterPinning(pins)
+    }
+
+    func pinSourceListItems(_ targets: [PacketSourceListPinTarget]) {
+        let pins = targets.compactMap { target -> PacketPin? in
+            switch target {
+            case .client(let identity):
+                return try? pinService.upsertClientPin(identity)
+            case .domain(let identity):
+                return try? pinService.upsertDomainPin(identity)
+            }
+        }
+        selectAfterPinning(pins)
     }
 
     func savePackets(_ identifiers: [PacketSummary.ID]) {
@@ -1251,6 +1272,28 @@ final class NetworkInspectorViewModel {
             selectedSourceListSelection = .pinned
         }
         rebuildSnapshot()
+    }
+
+    private func selectAfterPinning(_ pins: [PacketPin]) {
+        let uniquePins = uniquePins(pins)
+        guard !uniquePins.isEmpty else {
+            return
+        }
+
+        selectedSourceListSelection = uniquePins.count == 1 ? .pinnedItem(uniquePins[0].id) : .pinned
+        workspaceMode = .packets
+        rebuildSnapshot()
+    }
+
+    private func uniquePins(_ pins: [PacketPin]) -> [PacketPin] {
+        var seenIDs = Set<PacketPinID>()
+        var uniquePins: [PacketPin] = []
+
+        for pin in pins where seenIDs.insert(pin.id).inserted {
+            uniquePins.append(pin)
+        }
+
+        return uniquePins
     }
 
     private func presentExportPanel(

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
@@ -15,9 +15,7 @@ import AppKit
     func copyRowsAsCSVFromMenu(_ sender: Any?)
     func copyRowsAsCSVWithHeaderFromMenu(_ sender: Any?)
     func copyCellFromMenu(_ sender: Any?)
-    func pinDomainFromMenu(_ sender: Any?)
-    func pinIPFromMenu(_ sender: Any?)
-    func pinClientFromMenu(_ sender: Any?)
+    func pinRowsFromMenu(_ sender: Any?)
     func saveRowsFromMenu(_ sender: Any?)
     func exportRowsAsPcapFromMenu(_ sender: Any?)
     func exportRowsAsPcapngFromMenu(_ sender: Any?)
@@ -61,7 +59,13 @@ final class PacketTableContextMenuController: NSObject {
         menu.addItem(copyRowsAsMenuItem(state: state))
 
         menu.addItem(.separator())
-        menu.addItem(pinMenuItem(state: state))
+        menu.addItem(item(
+            title: "Pin",
+            action: #selector(PacketTableContextMenuActionHandling.pinRowsFromMenu(_:)),
+            isEnabled: state.pinEnabled,
+            toolTip: "Pin the selected app or apps for quick access.",
+            systemSymbolName: "pin"
+        ))
         menu.addItem(item(
             title: "Save",
             action: #selector(PacketTableContextMenuActionHandling.saveRowsFromMenu(_:)),
@@ -127,38 +131,6 @@ final class PacketTableContextMenuController: NSObject {
         menuItem.submenu = submenu
         menuItem.isEnabled = state.copyRowEnabled
         menuItem.toolTip = "Choose a text format for copying the selected packet rows."
-        return menuItem
-    }
-
-    // Create the pin submenu with item enablement derived from packet metadata.
-    private func pinMenuItem(state: PacketTableMenuState) -> NSMenuItem {
-        let menuItem = NSMenuItem(title: "Pin", action: nil, keyEquivalent: "")
-        let submenu = NSMenu(title: "Pin")
-        submenu.autoenablesItems = false
-
-        submenu.addItem(item(
-            title: "Domain",
-            action: #selector(PacketTableContextMenuActionHandling.pinDomainFromMenu(_:)),
-            isEnabled: state.pinDomainEnabled,
-            toolTip: "Pin this packet's domain for quick access."
-        ))
-        submenu.addItem(item(
-            title: "IP",
-            action: #selector(PacketTableContextMenuActionHandling.pinIPFromMenu(_:)),
-            isEnabled: state.pinIPEnabled,
-            toolTip: "Pin the clicked source or destination IP address."
-        ))
-        submenu.addItem(item(
-            title: "Client",
-            action: #selector(PacketTableContextMenuActionHandling.pinClientFromMenu(_:)),
-            isEnabled: state.pinClientEnabled,
-            toolTip: "Pin the client application for quick access."
-        ))
-
-        menuItem.submenu = submenu
-        menuItem.isEnabled = state.pinDomainEnabled || state.pinIPEnabled || state.pinClientEnabled
-        menuItem.toolTip = "Pin packet metadata for quick access."
-        menuItem.image = NSImage(systemSymbolName: "pin", accessibilityDescription: "Pin")
         return menuItem
     }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -12,9 +12,7 @@ protocol PacketTableViewControllerDelegate: AnyObject {
     func packetTableViewController(_ controller: PacketTableViewController, didSelectPacket identifier: PacketSummary.ID?)
     func packetTableViewController(
         _ controller: PacketTableViewController,
-        didRequestPin kind: PacketPinCreationKind,
-        packetID: PacketSummary.ID,
-        clickedColumn: PacketTableColumnRole
+        didRequestPinPackets identifiers: [PacketSummary.ID]
     )
     func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
     func packetTableViewController(_ controller: PacketTableViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
@@ -583,16 +581,8 @@ final class PacketTableViewController: NSViewController {
         writeToPasteboard(PacketTableCopyFormatter.csvCells(rows, column: state.clickedColumn))
     }
 
-    @objc func pinDomainFromMenu(_ sender: Any?) {
-        requestPin(.domain)
-    }
-
-    @objc func pinIPFromMenu(_ sender: Any?) {
-        requestPin(.ip)
-    }
-
-    @objc func pinClientFromMenu(_ sender: Any?) {
-        requestPin(.client)
+    @objc func pinRowsFromMenu(_ sender: Any?) {
+        requestPin()
     }
 
     @objc func saveRowsFromMenu(_ sender: Any?) {
@@ -638,19 +628,15 @@ final class PacketTableViewController: NSViewController {
         delegate?.packetTableViewController(self, didRequestExportPackets: identifiers, format: format)
     }
 
-    private func requestPin(_ kind: PacketPinCreationKind) {
-        let state = menuState()
-        guard state.targetRows.count == 1,
-              let rowIndex = state.targetRows.first,
-              rows.indices.contains(rowIndex) else {
+    private func requestPin() {
+        let identifiers = targetPacketIDs()
+        guard !identifiers.isEmpty else {
             return
         }
 
         delegate?.packetTableViewController(
             self,
-            didRequestPin: kind,
-            packetID: rows[rowIndex].id,
-            clickedColumn: state.clickedColumn
+            didRequestPinPackets: identifiers
         )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -12,9 +12,7 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didSelectPacket identifier: PacketSummary.ID?)
     func packetWorkspaceViewController(
         _ controller: PacketWorkspaceViewController,
-        didRequestPin kind: PacketPinCreationKind,
-        packetID: PacketSummary.ID,
-        clickedColumn: PacketTableColumnRole
+        didRequestPinPackets identifiers: [PacketSummary.ID]
     )
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
@@ -354,15 +352,11 @@ extension PacketWorkspaceViewController: PacketTableViewControllerDelegate {
 
     func packetTableViewController(
         _ controller: PacketTableViewController,
-        didRequestPin kind: PacketPinCreationKind,
-        packetID: PacketSummary.ID,
-        clickedColumn: PacketTableColumnRole
+        didRequestPinPackets identifiers: [PacketSummary.ID]
     ) {
         delegate?.packetWorkspaceViewController(
             self,
-            didRequestPin: kind,
-            packetID: packetID,
-            clickedColumn: clickedColumn
+            didRequestPinPackets: identifiers
         )
     }
 

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -74,6 +74,26 @@ enum SidebarOutlineReloadPolicy {
     }
 }
 
+enum SidebarSelectionPolicy {
+    static func navigationRow(
+        selectedRowIndexes: IndexSet,
+        selectedRow: Int,
+        currentEventRow: Int?
+    ) -> Int? {
+        if let currentEventRow,
+           selectedRowIndexes.contains(currentEventRow) {
+            return currentEventRow
+        }
+
+        if selectedRow >= 0,
+           selectedRowIndexes.contains(selectedRow) {
+            return selectedRow
+        }
+
+        return selectedRowIndexes.first
+    }
+}
+
 private extension PacketIngestMutation {
     var isBatchableSidebarMutation: Bool {
         switch self {
@@ -288,6 +308,7 @@ final class SidebarViewController: NSViewController {
         outlineView.dataSource = self
         outlineView.style = .sourceList
         outlineView.allowsEmptySelection = true
+        // Multi-selection is only used by context-menu Pin; navigation still picks one active row.
         outlineView.allowsMultipleSelection = true
         outlineView.rowHeight = 28
         outlineView.indentationPerLevel = 18
@@ -447,6 +468,16 @@ final class SidebarViewController: NSViewController {
         outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
     }
 
+    private func rowFromCurrentMouseEvent() -> Int? {
+        guard let event = view.window?.currentEvent,
+              event.type == .rightMouseDown || event.type == .leftMouseDown || event.type == .otherMouseDown else {
+            return nil
+        }
+
+        let row = outlineView.row(at: outlineView.convert(event.locationInWindow, from: nil))
+        return row >= 0 ? row : nil
+    }
+
     @objc private func pinSelectedSourceListItems(_ sender: Any?) {
         let targets = selectedPinTargets()
         guard !targets.isEmpty else {
@@ -589,8 +620,11 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
         }
 
         contextMenuItemID = nil
-        let selectedRow = outlineView.selectedRow
-        guard selectedRow >= 0,
+        guard let selectedRow = SidebarSelectionPolicy.navigationRow(
+            selectedRowIndexes: outlineView.selectedRowIndexes,
+            selectedRow: outlineView.selectedRow,
+            currentEventRow: rowFromCurrentMouseEvent()
+        ),
               let item = outlineView.item(atRow: selectedRow) as? SidebarOutlineItem else {
             delegate?.sidebarViewController(self, didSelect: nil)
             return

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -11,6 +11,7 @@ import PcapPlusPlusCore
 protocol SidebarViewControllerDelegate: AnyObject {
     func sidebarViewController(_ controller: SidebarViewController, didSelect selection: PacketSourceListSelection?)
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String)
+    func sidebarViewController(_ controller: SidebarViewController, didRequestPin targets: [PacketSourceListPinTarget])
     func sidebarViewController(_ controller: SidebarViewController, didRequestDelete action: PacketSourceListDeletionAction)
     func sidebarViewController(_ controller: SidebarViewController, didRequestExport selection: PacketSourceListSelection, format: CaptureFileFormat)
 }
@@ -200,6 +201,7 @@ final class SidebarViewController: NSViewController {
     private var pendingReloadWorkItem: DispatchWorkItem?
     private var isSyncingSelection = false
     private var isSyncingFilter = false
+    private var contextMenuItemID: String?
 
     deinit {
         pendingReloadWorkItem?.cancel()
@@ -286,7 +288,7 @@ final class SidebarViewController: NSViewController {
         outlineView.dataSource = self
         outlineView.style = .sourceList
         outlineView.allowsEmptySelection = true
-        outlineView.allowsMultipleSelection = false
+        outlineView.allowsMultipleSelection = true
         outlineView.rowHeight = 28
         outlineView.indentationPerLevel = 18
         outlineView.indentationMarkerFollowsCell = false
@@ -393,15 +395,37 @@ final class SidebarViewController: NSViewController {
         return sourceItem(for: outlineView.item(atRow: selectedRow))
     }
 
+    private func selectedSourceItems() -> [PacketSourceListItem] {
+        outlineView.selectedRowIndexes.compactMap { row in
+            guard row >= 0 else {
+                return nil
+            }
+            return sourceItem(for: outlineView.item(atRow: row))
+        }
+    }
+
+    private func contextSourceItem() -> PacketSourceListItem? {
+        guard let contextMenuItemID else {
+            return nil
+        }
+
+        return viewModel.item(withID: contextMenuItemID)?.sourceItem
+    }
+
     private func selectedDeletionAction() -> PacketSourceListDeletionAction {
-        PacketSourceListDeletionPolicy.action(for: selectedSourceItem())
+        PacketSourceListDeletionPolicy.action(for: contextSourceItem() ?? selectedSourceItem())
     }
 
     private func selectedExportSelection() -> PacketSourceListSelection? {
-        PacketSourceListExportPolicy.selection(for: selectedSourceItem())
+        PacketSourceListExportPolicy.selection(for: contextSourceItem() ?? selectedSourceItem())
+    }
+
+    private func selectedPinTargets() -> [PacketSourceListPinTarget] {
+        PacketSourceListPinPolicy.targets(for: selectedSourceItems())
     }
 
     private func updateSelectionFromCurrentMenuEvent() {
+        contextMenuItemID = nil
         guard let event = view.window?.currentEvent,
               event.type == .rightMouseDown || event.type == .leftMouseDown || event.type == .otherMouseDown else {
             return
@@ -416,7 +440,20 @@ final class SidebarViewController: NSViewController {
             return
         }
 
+        contextMenuItemID = sourceItem(for: item)?.id
+        if outlineView.selectedRowIndexes.contains(row) {
+            return
+        }
         outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+    }
+
+    @objc private func pinSelectedSourceListItems(_ sender: Any?) {
+        let targets = selectedPinTargets()
+        guard !targets.isEmpty else {
+            return
+        }
+
+        delegate?.sidebarViewController(self, didRequestPin: targets)
     }
 
     @objc private func deleteSelectedSourceListItem(_ sender: Any?) {
@@ -551,6 +588,7 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
             return
         }
 
+        contextMenuItemID = nil
         let selectedRow = outlineView.selectedRow
         guard selectedRow >= 0,
               let item = outlineView.item(atRow: selectedRow) as? SidebarOutlineItem else {
@@ -591,15 +629,28 @@ extension SidebarViewController: NSSearchFieldDelegate {
 extension SidebarViewController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         updateSelectionFromCurrentMenuEvent()
+        let pinTargets = selectedPinTargets()
         let action = selectedDeletionAction()
         let exportSelection = selectedExportSelection()
 
         menu.removeAllItems()
-        guard action.isEnabled || exportSelection != nil else {
+        guard !pinTargets.isEmpty || action.isEnabled || exportSelection != nil else {
             return
         }
 
+        if !pinTargets.isEmpty {
+            let pinItem = NSMenuItem(title: "Pin", action: #selector(pinSelectedSourceListItems(_:)), keyEquivalent: "")
+            pinItem.target = self
+            pinItem.isEnabled = true
+            pinItem.image = NSImage(systemSymbolName: "pin", accessibilityDescription: "Pin")
+            menu.addItem(pinItem)
+        }
+
         if exportSelection != nil {
+            if !pinTargets.isEmpty {
+                menu.addItem(.separator())
+            }
+
             let exportItem = NSMenuItem(title: "Export", action: nil, keyEquivalent: "")
             let exportSubmenu = NSMenu(title: "Export")
             let exportPcapItem = NSMenuItem(title: "as pcap...", action: #selector(exportSelectedSourceListItemAsPcap(_:)), keyEquivalent: "")
@@ -616,7 +667,7 @@ extension SidebarViewController: NSMenuDelegate {
         }
 
         if action.isEnabled {
-            if exportSelection != nil {
+            if !pinTargets.isEmpty || exportSelection != nil {
                 menu.addItem(.separator())
             }
 
@@ -632,6 +683,7 @@ extension SidebarViewController: NSMenuDelegate {
 
 extension SidebarViewController: SidebarOutlineKeyboardActionHandling {
     fileprivate func sidebarOutlineViewDidRequestDeleteFromKeyboard(_ outlineView: SidebarOutlineView) {
+        contextMenuItemID = nil
         deleteSelectedSourceListItem(nil)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -695,6 +695,15 @@ extension TCPViewerRootViewController: SidebarViewControllerDelegate {
         viewModel.updateSourceListFilterText(text)
     }
 
+    func sidebarViewController(_ controller: SidebarViewController, didRequestPin targets: [PacketSourceListPinTarget]) {
+        guard canUsePinFeature() else {
+            delegate?.tcpviewerRootViewControllerDidRequestPaywall(self)
+            return
+        }
+
+        viewModel.pinSourceListItems(targets)
+    }
+
     func sidebarViewController(_ controller: SidebarViewController, didRequestDelete action: PacketSourceListDeletionAction) {
         viewModel.deleteSourceListItem(action)
     }
@@ -711,11 +720,14 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 
     func packetWorkspaceViewController(
         _ controller: PacketWorkspaceViewController,
-        didRequestPin kind: PacketPinCreationKind,
-        packetID: PacketSummary.ID,
-        clickedColumn: PacketTableColumnRole
+        didRequestPinPackets identifiers: [PacketSummary.ID]
     ) {
-        viewModel.pinPacket(packetID, kind: kind, clickedColumn: clickedColumn)
+        guard canUsePinFeature() else {
+            delegate?.tcpviewerRootViewControllerDidRequestPaywall(self)
+            return
+        }
+
+        viewModel.pinAppPackets(identifiers)
     }
 
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID]) {
@@ -748,6 +760,10 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 
     func packetWorkspaceViewControllerDidRequestHideStructuredFilter(_ controller: PacketWorkspaceViewController) {
         viewModel.setStructuredFilterVisible(false)
+    }
+
+    fileprivate func canUsePinFeature() -> Bool {
+        TCPViewerLicenseService.shared.isLicenseAuthorized
     }
 }
 

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1604,6 +1604,120 @@ struct NetworkInspectorViewModelTests {
         #expect(reloadedSavedService.records().isEmpty)
     }
 
+    @Test func bulkAppPinningPinsUniqueAppsAndSelectsPinnedFolder() async throws {
+        let pinService = PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json"))
+        let chrome = makeClient(displayName: "Chrome", bundleIdentifier: "com.google.Chrome")
+        let tcpviewer = makeClient(displayName: "TCP Viewer", bundleIdentifier: "com.proxyman.tcpviewer")
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, streamID: nil, client: chrome),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .udp, streamID: nil, client: tcpviewer),
+            makePacket(packetNumber: 3, source: .offline, transportHint: .dns, streamID: nil),
+            makePacket(packetNumber: 4, source: .offline, transportHint: .tcp, streamID: nil, client: chrome),
+        ]
+        let openURL = URL(fileURLWithPath: "/tmp/bulk-app-pin-fixture.pcapng")
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: InspectorFakeDocument(url: openURL, packets: packets)
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: pinService
+        )
+
+        await viewModel.openDocument(at: openURL)
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == packets.count
+        }
+
+        viewModel.pinAppPackets(packets.map(\.id))
+
+        #expect(pinService.pins().map(\.id.rawValue) == [
+            "client:bundleIdentifier:com.google.Chrome",
+            "client:bundleIdentifier:com.proxyman.tcpviewer",
+        ])
+        #expect(viewModel.snapshot.selectedSourceListSelection == .pinned)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[1].id, packets[3].id])
+    }
+
+    @Test func sourceListPinTargetsCreateAppAndDomainPins() async throws {
+        let pinService = PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json"))
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, streamID: nil, client: client),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .udp, streamID: nil, sniDomainName: "api.example.com"),
+        ]
+        let openURL = URL(fileURLWithPath: "/tmp/source-list-pin-fixture.pcapng")
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: InspectorFakeDocument(url: openURL, packets: packets)
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: pinService
+        )
+
+        await viewModel.openDocument(at: openURL)
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == packets.count
+        }
+
+        let appItem = try #require(viewModel.snapshot.sourceListSnapshot.item(for: .app(PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app"))))
+        let domainItem = try #require(viewModel.snapshot.sourceListSnapshot.item(for: .domain(PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false))))
+        let targets = PacketSourceListPinPolicy.targets(for: [appItem, domainItem])
+        viewModel.pinSourceListItems(targets)
+
+        #expect(pinService.pins().map(\.id.rawValue) == [
+            "client:bundleIdentifier:com.example.app",
+            "domain:api.example.com",
+        ])
+        #expect(viewModel.snapshot.selectedSourceListSelection == .pinned)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == packets.map(\.id))
+    }
+
+    @Test func pinnedAppSelectionAppendsFutureMatchingPackets() async throws {
+        let pinService = PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json"))
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let first = makePacket(packetNumber: 1, source: .live, transportHint: .tcp, streamID: nil, client: client)
+        let matchingFuture = makePacket(packetNumber: 2, source: .live, transportHint: .udp, streamID: nil, client: client)
+        let unrelatedFuture = makePacket(packetNumber: 3, source: .live, transportHint: .dns, streamID: nil)
+        let liveSession = InspectorFakeLiveSession()
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                liveSession: liveSession
+            ), packetMetadataEnricher: PacketMetadataEnrichmentService(
+                clientResolver: InspectorFakePacketClientResolver(defaultClient: nil)
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: pinService
+        )
+
+        await viewModel.performInitialLoadIfNeeded()
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+        liveSession.send(.packetBatch([first], disposition: .append))
+        await waitUntil {
+            viewModel.snapshot.packetRows.map(\.id) == [first.id]
+        }
+
+        viewModel.pinAppPackets([first.id])
+        let pinID = try #require(pinService.pins().first?.id)
+        #expect(viewModel.snapshot.selectedSourceListSelection == .pinnedItem(pinID))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [first.id])
+
+        liveSession.send(.packetBatch([matchingFuture, unrelatedFuture], disposition: .append))
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.hasPendingCoalescedRebuildForTesting || viewModel.snapshot.totalPacketCount == 3
+        }
+        viewModel.flushPendingCoalescedRebuildForTesting()
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.snapshot.packetRows.map(\.id) == [first.id, matchingFuture.id]
+        }
+
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [first.id, matchingFuture.id])
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .pinnedItem(pinID))?.count == 2)
+    }
+
     @Test func sourceListDeleteActionRemovesPinsAndMatchingPackets() async throws {
         let pinURL = temporaryDirectory().appendingPathComponent("Pins.json")
         let pinService = PacketPinService(storageURL: pinURL)
@@ -2216,6 +2330,8 @@ struct NetworkInspectorViewModelTests {
                 document: InspectorFakeDocument(url: openURL, packets: packets)
             )),
             userDefaults: isolatedDefaults(),
+            pinService: PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json")),
+            savedPacketService: SavedPacketService(storageURL: temporaryDirectory().appendingPathComponent("Saved.json")),
             packetTableAsyncRebuildThreshold: packetTableAsyncRebuildThreshold
         )
     }

--- a/TCPViewerTests/Features/NetworkInspector/PacketPinServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketPinServiceTests.swift
@@ -82,6 +82,59 @@ struct PacketPinServiceTests {
         #expect(service.matchingPackets(in: [packet], for: .pinned).map(\.id) == [packet.id])
     }
 
+    @Test func sourceListClientPinPersistsCriteriaOnlyAndDeduplicates() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let identity = PacketSourceClientIdentity(
+            key: PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app"),
+            displayName: "Example",
+            iconFilePath: "/Applications/Example.app"
+        )
+
+        let firstPin = try service.upsertClientPin(identity, now: Date(timeIntervalSince1970: 10))
+        let duplicatePin = try service.upsertClientPin(identity, now: Date(timeIntervalSince1970: 20))
+        let reloaded = PacketPinService(storageURL: storageURL)
+        let rawJSON = try String(contentsOf: storageURL)
+
+        #expect(firstPin.id == duplicatePin.id)
+        #expect(firstPin.id.rawValue == "client:bundleIdentifier:com.example.app")
+        #expect(service.pins().count == 1)
+        #expect(reloaded.pins().map(\.id) == [firstPin.id])
+        #expect(!rawJSON.contains("Packet 1"))
+        #expect(!rawJSON.contains("capturedLength"))
+    }
+
+    @Test func sourceListDomainPinRejectsMissingDomainPlaceholder() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let missingDomain = PacketSourceDomainIdentity(key: .ipAddresses, displayName: "IP Addresses")
+
+        do {
+            _ = try service.upsertDomainPin(missingDomain)
+            Issue.record("Expected missing-domain placeholder pin creation to fail.")
+        } catch let error as PacketPinCreationError {
+            #expect(error == .missingDomain)
+        } catch {
+            Issue.record("Expected PacketPinCreationError.missingDomain, got \(error).")
+        }
+    }
+
+    @Test func sourceListDomainPinMatchesFuturePackets() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
+        let service = PacketPinService(storageURL: storageURL)
+        let identity = PacketSourceDomainIdentity(
+            key: PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false),
+            displayName: "API.Example.com"
+        )
+        let future = makePacket(packetNumber: 3, sniDomainName: "api.example.com")
+
+        let pin = try service.upsertDomainPin(identity, now: Date(timeIntervalSince1970: 10))
+
+        #expect(pin.id.rawValue == "domain:api.example.com")
+        #expect(pin.title == "API.Example.com")
+        #expect(service.matchingPackets(in: [future], for: .pinnedItem(pin.id)).map(\.id) == [future.id])
+    }
+
     @Test func clientPinStoresResolvedIconPath() throws {
         let storageURL = temporaryDirectory().appendingPathComponent("Pins.json")
         let service = PacketPinService(storageURL: storageURL)

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -147,6 +147,73 @@ struct PacketSourceListServiceTests {
         #expect(PacketSourceListExportPolicy.selection(for: PacketSourceListSnapshot.empty.item(for: .saved)) == nil)
     }
 
+    @Test func pinPolicyExtractsOnlyAppAndRealDomainTargets() throws {
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        var state = PacketIngestState.empty
+        state.append([
+            makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: client),
+            makePacket(packetNumber: 2, sniDomainName: nil),
+        ], source: .live)
+
+        let snapshot = PacketSourceListService().snapshot(for: state)
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
+        let domainKey = PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false)
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
+        let items = [
+            try #require(snapshot.item(for: .apps)),
+            try #require(snapshot.item(for: .app(appKey))),
+            try #require(snapshot.item(for: .domains)),
+            try #require(snapshot.item(for: .domain(domainKey))),
+            try #require(snapshot.item(for: .domain(.ipAddresses))),
+            try #require(snapshot.item(for: .ipAddress(ipKey))),
+        ]
+
+        let targets = PacketSourceListPinPolicy.targets(for: items)
+
+        #expect(targets == [
+            .client(PacketSourceClientIdentity(
+                key: appKey,
+                displayName: "Example",
+                iconFilePath: "/Applications/Example.app"
+            )),
+            .domain(PacketSourceDomainIdentity(
+                key: domainKey,
+                displayName: "api.example.com"
+            )),
+        ])
+    }
+
+    @Test func pinnedCountsUpdateForAppendsAndMetadataChanges() {
+        let service = PacketSourceListService()
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let appPin = makeClientPin(displayName: "Example", key: "bundleIdentifier:com.example.app")
+        let domainPin = makeDomainPin("api.example.com")
+        var state = PacketIngestState.empty
+        let unresolved = makePacket(packetNumber: 1)
+        state.append([unresolved], source: .live)
+
+        var snapshot = service.snapshot(for: state, pinnedItems: [appPin, domainPin])
+        #expect(snapshot.item(for: .pinnedItem(appPin.id))?.count == 0)
+        #expect(snapshot.item(for: .pinnedItem(domainPin.id))?.count == 0)
+
+        state.applyMetadataUpdates([
+            PacketMetadataUpdate(
+                packetIDs: [unresolved.id],
+                sniDomainName: "api.example.com",
+                client: client,
+                direction: .outbound
+            )
+        ])
+        snapshot = service.snapshot(for: state, pinnedItems: [appPin, domainPin])
+        #expect(snapshot.item(for: .pinnedItem(appPin.id))?.count == 1)
+        #expect(snapshot.item(for: .pinnedItem(domainPin.id))?.count == 1)
+
+        state.append([makePacket(packetNumber: 2, sniDomainName: "api.example.com", client: client)], source: .live)
+        snapshot = service.snapshot(for: state, pinnedItems: [appPin, domainPin])
+        #expect(snapshot.item(for: .pinnedItem(appPin.id))?.count == 2)
+        #expect(snapshot.item(for: .pinnedItem(domainPin.id))?.count == 2)
+    }
+
     @Test func clientIdentityFallsBackThroughAvailableFields() {
         let clients = [
             makeClient(displayName: "Bundle", bundleIdentifier: "com.example.bundle", bundlePath: "/Applications/Bundle.app", executablePath: "/Applications/Bundle.app/Contents/MacOS/Bundle"),
@@ -316,6 +383,34 @@ struct PacketSourceListServiceTests {
 
     private func domainKey(_ name: String) -> PacketSourceDomainKey {
         PacketSourceDomainKey(rawValue: name.lowercased(), isMissingDomain: false)
+    }
+
+    private func makeDomainPin(_ domain: String) -> PacketPin {
+        PacketPin(
+            id: PacketPinID(rawValue: "domain:\(domain)"),
+            kind: .domain,
+            title: domain,
+            createdAt: Date(timeIntervalSince1970: 10),
+            domain: domain,
+            ipAddress: nil,
+            clientKey: nil,
+            clientDisplayName: nil,
+            clientIconFilePath: nil
+        )
+    }
+
+    private func makeClientPin(displayName: String, key: String) -> PacketPin {
+        PacketPin(
+            id: PacketPinID(rawValue: "client:\(key)"),
+            kind: .client,
+            title: displayName,
+            createdAt: Date(timeIntervalSince1970: 10),
+            domain: nil,
+            ipAddress: nil,
+            clientKey: key,
+            clientDisplayName: displayName,
+            clientIconFilePath: "/Applications/\(displayName).app"
+        )
     }
 
     @Test func filteringKeepsMatchingDescendantsAndAncestors() {

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -14,7 +14,7 @@ import PcapPlusPlusCore
 @Suite(.serialized)
 struct PacketTableMenuLogicTests {
 
-    @Test func selectedClickedRowTargetsMultipleRowsAndDisablesPin() {
+    @Test func selectedClickedRowTargetsMultipleRowsAndEnablesPinWhenAnyRowHasApp() {
         let rows = [
             PacketTableRow(packet: makePacket(packetNumber: 1, sniDomainName: "one.example.com", client: makeClient())),
             PacketTableRow(packet: makePacket(packetNumber: 2)),
@@ -31,9 +31,7 @@ struct PacketTableMenuLogicTests {
         #expect(state.targetRows == [0, 2])
         #expect(state.copyRowEnabled)
         #expect(state.copyCellEnabled)
-        #expect(!state.pinDomainEnabled)
-        #expect(!state.pinIPEnabled)
-        #expect(!state.pinClientEnabled)
+        #expect(state.pinEnabled)
         #expect(state.saveEnabled)
         #expect(state.exportEnabled)
         #expect(state.deleteEnabled)
@@ -54,9 +52,7 @@ struct PacketTableMenuLogicTests {
 
         #expect(state.targetRows == [1])
         #expect(state.clickedColumn == .source)
-        #expect(state.pinDomainEnabled)
-        #expect(state.pinIPEnabled)
-        #expect(state.pinClientEnabled)
+        #expect(state.pinEnabled)
         #expect(state.exportEnabled)
     }
 
@@ -203,9 +199,7 @@ struct PacketTableMenuLogicTests {
             clickedColumn: .source,
             copyRowEnabled: true,
             copyCellEnabled: true,
-            pinDomainEnabled: true,
-            pinIPEnabled: true,
-            pinClientEnabled: true,
+            pinEnabled: true,
             saveEnabled: true,
             exportEnabled: true,
             deleteEnabled: true
@@ -225,6 +219,7 @@ struct PacketTableMenuLogicTests {
 
         #expect(copyRowsAsTitles == ["Plain text", "JSON", "Markdown Table", "CSV", "CSV with Header"])
         #expect(copyRowsAsSubmenu.items.filter(\.isSeparatorItem).count == 2)
+        #expect(menu.items.contains { $0.title == "Pin" && $0.submenu == nil })
         #expect(!items.isEmpty)
         #expect(items.allSatisfy { item in item.toolTip?.isEmpty == false })
     }
@@ -311,9 +306,7 @@ private final class MenuActionHandler: NSObject, PacketTableContextMenuActionHan
     func copyRowsAsCSVFromMenu(_ sender: Any?) {}
     func copyRowsAsCSVWithHeaderFromMenu(_ sender: Any?) {}
     func copyCellFromMenu(_ sender: Any?) {}
-    func pinDomainFromMenu(_ sender: Any?) {}
-    func pinIPFromMenu(_ sender: Any?) {}
-    func pinClientFromMenu(_ sender: Any?) {}
+    func pinRowsFromMenu(_ sender: Any?) {}
     func saveRowsFromMenu(_ sender: Any?) {}
     func exportRowsAsPcapFromMenu(_ sender: Any?) {}
     func exportRowsAsPcapngFromMenu(_ sender: Any?) {}

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -97,6 +97,29 @@ struct SidebarOutlineReloadPolicyTests {
         #expect(SidebarOutlineReloadPolicy.timing(previous: previous, next: replaced) == .immediate)
     }
 
+    @Test func multiSelectionNavigationUsesCurrentEventRow() {
+        let selectedRows = IndexSet([2, 5])
+
+        #expect(SidebarSelectionPolicy.navigationRow(
+            selectedRowIndexes: selectedRows,
+            selectedRow: 2,
+            currentEventRow: 5
+        ) == 5)
+    }
+
+    @Test func selectionNavigationFallsBackToSingleSelectedRow() {
+        #expect(SidebarSelectionPolicy.navigationRow(
+            selectedRowIndexes: IndexSet(integer: 3),
+            selectedRow: 3,
+            currentEventRow: nil
+        ) == 3)
+        #expect(SidebarSelectionPolicy.navigationRow(
+            selectedRowIndexes: IndexSet(),
+            selectedRow: -1,
+            currentEventRow: nil
+        ) == nil)
+    }
+
     private func reloadState(
         sourceListSnapshot: PacketSourceListSnapshot,
         filterText: String = "",


### PR DESCRIPTION
## Summary
- Add PRO-gated Pin actions for sidebar app/domain context menus and table app pinning.
- Persist pin criteria while keeping pinned packet matches session/document-only.
- Keep sidebar navigation single-row while context-menu Pin can use multi-selection.

## Tests
- [x] git diff --check
- [x] xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build
- [x] xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'\n\n## Disclosure\nThis PR was substantially assisted by AI and reviewed/tested locally.