### PR TITLE
Preserve sidebar scroll position and show nested source rows

### DIFF
--- a/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
@@ -167,15 +167,10 @@ final class PacketPinService {
 
     func matchingPackets(in packets: [PacketSummary], for selection: PacketSourceListSelection) -> [PacketSummary] {
         switch selection {
-        case .pinned:
-            return packets.filter { packet in
-                cachedPins.contains { pin in PacketPinMatcher.matches(packet, pin: pin) }
+        case .pinned, .pinnedItem, .pinnedItemDomain, .pinnedItemIPAddress:
+            return packets.filter {
+                PacketSourceListPacketMatcher.matches($0, selection: selection, pinnedItems: cachedPins)
             }
-        case .pinnedItem(let pinID):
-            guard let pin = cachedPins.first(where: { $0.id == pinID }) else {
-                return []
-            }
-            return packets.filter { PacketPinMatcher.matches($0, pin: pin) }
         default:
             return []
         }

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -27,9 +27,13 @@ enum PacketSourceListSelection: Hashable, Sendable {
     case allPackets
     case pinned
     case pinnedItem(PacketPinID)
+    case pinnedItemDomain(PacketPinID, PacketSourceDomainKey)
+    case pinnedItemIPAddress(PacketPinID, PacketSourceIPAddressKey)
     case saved
     case apps
     case app(PacketSourceClientKey)
+    case appDomain(PacketSourceClientKey, PacketSourceDomainKey)
+    case appIPAddress(PacketSourceClientKey, PacketSourceIPAddressKey)
     case domains
     case domain(PacketSourceDomainKey)
     case ipAddress(PacketSourceIPAddressKey)
@@ -195,7 +199,8 @@ enum PacketSourceListExportPolicy {
         }
 
         switch selection {
-        case .pinned, .pinnedItem, .saved, .apps, .app, .domains, .domain, .ipAddress:
+        case .pinned, .pinnedItem, .pinnedItemDomain, .pinnedItemIPAddress,
+                .saved, .apps, .app, .appDomain, .appIPAddress, .domains, .domain, .ipAddress:
             return selection
         case .allPackets:
             return nil
@@ -231,6 +236,11 @@ enum PacketSourceListPinPolicy {
                 displayName: item.title,
                 iconFilePath: item.iconFilePath
             ))
+        case .appDomain(_, let key) where !key.isMissingDomain:
+            return .domain(PacketSourceDomainIdentity(
+                key: key,
+                displayName: item.title
+            ))
         case .domain(let key) where !key.isMissingDomain:
             return .domain(PacketSourceDomainIdentity(
                 key: key,
@@ -251,7 +261,11 @@ enum PacketSourceListDeletionPolicy {
         switch selection {
         case .pinnedItem(let pinID):
             return .deletePin(pinID)
-        case .app, .ipAddress:
+        case .app, .appIPAddress, .pinnedItemIPAddress, .ipAddress:
+            return .deletePackets(selection)
+        case .appDomain(_, let key) where !key.isMissingDomain:
+            return .deletePackets(selection)
+        case .pinnedItemDomain(_, let key) where !key.isMissingDomain:
             return .deletePackets(selection)
         case .domain(let key) where !key.isMissingDomain:
             return .deletePackets(selection)
@@ -348,12 +362,20 @@ enum PacketSourceListClassifier {
             return clientIdentity(for: packet) != nil
         case .app(let key):
             return clientIdentity(for: packet)?.key == key
+        case .appDomain(let clientKey, let domainKey):
+            return clientIdentity(for: packet)?.key == clientKey &&
+                domainIdentity(for: packet).key == domainKey
+        case .appIPAddress(let clientKey, let ipAddressKey):
+            return clientIdentity(for: packet)?.key == clientKey &&
+                ipAddressIdentities(for: packet).contains { $0.key == ipAddressKey }
         case .domains:
             return true
         case .domain(let key):
             return domainIdentity(for: packet).key == key
         case .ipAddress(let key):
             return ipAddressIdentities(for: packet).contains { $0.key == key }
+        case .pinnedItemDomain, .pinnedItemIPAddress:
+            return false
         }
     }
 
@@ -368,6 +390,42 @@ enum PacketSourceListClassifier {
         }
 
         return trimmed
+    }
+}
+
+enum PacketSourceListPacketMatcher {
+    static func matches(
+        _ packet: PacketSummary,
+        selection: PacketSourceListSelection,
+        pinnedItems: [PacketPin]
+    ) -> Bool {
+        switch selection {
+        case .pinned:
+            return pinnedItems.contains { PacketPinMatcher.matches(packet, pin: $0) }
+        case .pinnedItem(let pinID):
+            guard let pin = pinnedItems.first(where: { $0.id == pinID }) else {
+                return false
+            }
+            return PacketPinMatcher.matches(packet, pin: pin)
+        case .pinnedItemDomain(let pinID, let domainKey):
+            guard let pin = pinnedItems.first(where: { $0.id == pinID }),
+                  pin.kind == .client else {
+                return false
+            }
+            return PacketPinMatcher.matches(packet, pin: pin) &&
+                PacketSourceListClassifier.matches(packet, selection: .domain(domainKey))
+        case .pinnedItemIPAddress(let pinID, let ipAddressKey):
+            guard let pin = pinnedItems.first(where: { $0.id == pinID }),
+                  pin.kind == .client else {
+                return false
+            }
+            return PacketPinMatcher.matches(packet, pin: pin) &&
+                PacketSourceListClassifier.matches(packet, selection: .ipAddress(ipAddressKey))
+        case .saved:
+            return true
+        default:
+            return PacketSourceListClassifier.matches(packet, selection: selection)
+        }
     }
 }
 
@@ -515,11 +573,18 @@ final class PacketSourceListService {
 
     private func increment(for assignment: PacketBucketAssignment) {
         if let appIdentity = assignment.appIdentity {
-            if appBuckets[appIdentity.key] == nil {
+            var appBucket: PacketSourceListTreeBuilder.AppBucket
+            if let existingBucket = appBuckets[appIdentity.key] {
+                appBucket = existingBucket
+            } else {
                 appOrder.append(appIdentity.key)
-                appBuckets[appIdentity.key] = PacketSourceListTreeBuilder.AppBucket(identity: appIdentity)
+                appBucket = PacketSourceListTreeBuilder.AppBucket(identity: appIdentity)
             }
-            appBuckets[appIdentity.key]?.packetCount += 1
+            appBucket.increment(
+                domainIdentity: assignment.domainIdentity,
+                ipAddressIdentities: assignment.ipAddressIdentities
+            )
+            appBuckets[appIdentity.key] = appBucket
         }
 
         let domainIdentity = assignment.domainIdentity
@@ -542,7 +607,10 @@ final class PacketSourceListService {
 
     private func decrement(for assignment: PacketBucketAssignment) {
         if let appIdentity = assignment.appIdentity, var bucket = appBuckets[appIdentity.key] {
-            bucket.packetCount -= 1
+            bucket.decrement(
+                domainIdentity: assignment.domainIdentity,
+                ipAddressIdentities: assignment.ipAddressIdentities
+            )
             if bucket.packetCount <= 0 {
                 appBuckets.removeValue(forKey: appIdentity.key)
                 appOrder.removeAll { $0 == appIdentity.key }
@@ -587,9 +655,12 @@ final class PacketSourceListService {
             domainBuckets: domainOrder.compactMap { domainBuckets[$0] },
             ipAddressBuckets: ipAddressOrder.compactMap { ipAddressBuckets[$0] },
             pinnedBuckets: pinnedItems.map { pin in
-                PacketSourceListTreeBuilder.PinnedBucket(
+                let pinnedAppBucket = pin.clientKey.map { PacketSourceClientKey(rawValue: $0) }.flatMap { appBuckets[$0] }
+                return PacketSourceListTreeBuilder.PinnedBucket(
                     pin: pin,
-                    packetCount: pinnedPacketCountsByID[pin.id, default: 0]
+                    packetCount: pinnedPacketCountsByID[pin.id, default: 0],
+                    domainBuckets: pinnedAppBucket?.orderedDomainBuckets ?? [],
+                    ipAddressBuckets: pinnedAppBucket?.orderedIPAddressBuckets ?? []
                 )
             },
             savedPacketCount: savedPacketCount
@@ -668,6 +739,86 @@ enum PacketSourceListTreeBuilder {
     struct AppBucket: Equatable, Sendable {
         let identity: PacketSourceClientIdentity
         var packetCount = 0
+        private var domainBuckets: [PacketSourceDomainKey: DomainBucket] = [:]
+        private var domainOrder: [PacketSourceDomainKey] = []
+        private var ipAddressBuckets: [PacketSourceIPAddressKey: IPAddressBucket] = [:]
+        private var ipAddressOrder: [PacketSourceIPAddressKey] = []
+
+        init(identity: PacketSourceClientIdentity) {
+            self.identity = identity
+        }
+
+        var orderedDomainBuckets: [DomainBucket] {
+            domainOrder.compactMap { domainBuckets[$0] }
+        }
+
+        var orderedIPAddressBuckets: [IPAddressBucket] {
+            ipAddressOrder.compactMap { ipAddressBuckets[$0] }
+        }
+
+        mutating func increment(
+            domainIdentity: PacketSourceDomainIdentity,
+            ipAddressIdentities: [PacketSourceIPAddressIdentity]
+        ) {
+            packetCount += 1
+            incrementDomain(domainIdentity)
+            for ipAddressIdentity in ipAddressIdentities {
+                incrementIPAddress(ipAddressIdentity)
+            }
+        }
+
+        mutating func decrement(
+            domainIdentity: PacketSourceDomainIdentity,
+            ipAddressIdentities: [PacketSourceIPAddressIdentity]
+        ) {
+            packetCount -= 1
+            decrementDomain(domainIdentity.key)
+            for ipAddressIdentity in ipAddressIdentities {
+                decrementIPAddress(ipAddressIdentity.key)
+            }
+        }
+
+        private mutating func incrementDomain(_ identity: PacketSourceDomainIdentity) {
+            if domainBuckets[identity.key] == nil {
+                domainOrder.append(identity.key)
+                domainBuckets[identity.key] = DomainBucket(identity: identity)
+            }
+            domainBuckets[identity.key]?.packetCount += 1
+        }
+
+        private mutating func decrementDomain(_ key: PacketSourceDomainKey) {
+            guard var bucket = domainBuckets[key] else {
+                return
+            }
+            bucket.packetCount -= 1
+            if bucket.packetCount <= 0 {
+                domainBuckets.removeValue(forKey: key)
+                domainOrder.removeAll { $0 == key }
+            } else {
+                domainBuckets[key] = bucket
+            }
+        }
+
+        private mutating func incrementIPAddress(_ identity: PacketSourceIPAddressIdentity) {
+            if ipAddressBuckets[identity.key] == nil {
+                ipAddressOrder.append(identity.key)
+                ipAddressBuckets[identity.key] = IPAddressBucket(identity: identity)
+            }
+            ipAddressBuckets[identity.key]?.packetCount += 1
+        }
+
+        private mutating func decrementIPAddress(_ key: PacketSourceIPAddressKey) {
+            guard var bucket = ipAddressBuckets[key] else {
+                return
+            }
+            bucket.packetCount -= 1
+            if bucket.packetCount <= 0 {
+                ipAddressBuckets.removeValue(forKey: key)
+                ipAddressOrder.removeAll { $0 == key }
+            } else {
+                ipAddressBuckets[key] = bucket
+            }
+        }
     }
 
     struct DomainBucket: Equatable, Sendable {
@@ -683,6 +834,8 @@ enum PacketSourceListTreeBuilder {
     struct PinnedBucket: Equatable, Sendable {
         let pin: PacketPin
         var packetCount = 0
+        var domainBuckets: [DomainBucket] = []
+        var ipAddressBuckets: [IPAddressBucket] = []
     }
 
     static let favoritesGroupID = "group:favorites"
@@ -733,33 +886,22 @@ enum PacketSourceListTreeBuilder {
                 count: bucket.packetCount,
                 kind: .app,
                 selection: .app(bucket.identity.key),
-                children: []
+                children: makeDomainItems(
+                    domainBuckets: bucket.orderedDomainBuckets,
+                    ipAddressBuckets: bucket.orderedIPAddressBuckets,
+                    idPrefix: "app:\(bucket.identity.key.rawValue)",
+                    domainSelection: { .appDomain(bucket.identity.key, $0) },
+                    ipAddressSelection: { .appIPAddress(bucket.identity.key, $0) }
+                )
             )
         }
-        let ipAddressItems = ipAddressBuckets.map { bucket in
-            PacketSourceListItem(
-                id: "ip:\(bucket.identity.key.rawValue)",
-                title: bucket.identity.displayName,
-                systemImageName: "network",
-                iconFilePath: nil,
-                count: bucket.packetCount,
-                kind: .domain,
-                selection: .ipAddress(bucket.identity.key),
-                children: []
-            )
-        }
-        let domainItems = domainBuckets.map { bucket in
-            PacketSourceListItem(
-                id: "domain:\(bucket.identity.key.rawValue)",
-                title: bucket.identity.displayName,
-                systemImageName: "network",
-                iconFilePath: nil,
-                count: bucket.packetCount,
-                kind: .domain,
-                selection: .domain(bucket.identity.key),
-                children: bucket.identity.key.isMissingDomain ? ipAddressItems : []
-            )
-        }
+        let domainItems = makeDomainItems(
+            domainBuckets: domainBuckets,
+            ipAddressBuckets: ipAddressBuckets,
+            idPrefix: nil,
+            domainSelection: { .domain($0) },
+            ipAddressSelection: { .ipAddress($0) }
+        )
         let pinnedItems = pinnedBuckets.map { bucket in
             PacketSourceListItem(
                 id: "pin:\(bucket.pin.id.rawValue)",
@@ -772,7 +914,13 @@ enum PacketSourceListTreeBuilder {
                 count: bucket.packetCount,
                 kind: .pin,
                 selection: .pinnedItem(bucket.pin.id),
-                children: []
+                children: makeDomainItems(
+                    domainBuckets: bucket.domainBuckets,
+                    ipAddressBuckets: bucket.ipAddressBuckets,
+                    idPrefix: "pin:\(bucket.pin.id.rawValue)",
+                    domainSelection: { .pinnedItemDomain(bucket.pin.id, $0) },
+                    ipAddressSelection: { .pinnedItemIPAddress(bucket.pin.id, $0) }
+                )
             )
         }
 
@@ -840,6 +988,48 @@ enum PacketSourceListTreeBuilder {
                 ]
             ),
         ]
+    }
+
+    private static func makeDomainItems(
+        domainBuckets: [DomainBucket],
+        ipAddressBuckets: [IPAddressBucket],
+        idPrefix: String?,
+        domainSelection: (PacketSourceDomainKey) -> PacketSourceListSelection,
+        ipAddressSelection: (PacketSourceIPAddressKey) -> PacketSourceListSelection
+    ) -> [PacketSourceListItem] {
+        let ipAddressItems = ipAddressBuckets.map { bucket in
+            PacketSourceListItem(
+                id: itemID(prefix: idPrefix, kind: "ip", key: bucket.identity.key.rawValue),
+                title: bucket.identity.displayName,
+                systemImageName: "network",
+                iconFilePath: nil,
+                count: bucket.packetCount,
+                kind: .domain,
+                selection: ipAddressSelection(bucket.identity.key),
+                children: []
+            )
+        }
+
+        return domainBuckets.map { bucket in
+            PacketSourceListItem(
+                id: itemID(prefix: idPrefix, kind: "domain", key: bucket.identity.key.rawValue),
+                title: bucket.identity.displayName,
+                systemImageName: "network",
+                iconFilePath: nil,
+                count: bucket.packetCount,
+                kind: .domain,
+                selection: domainSelection(bucket.identity.key),
+                children: bucket.identity.key.isMissingDomain ? ipAddressItems : []
+            )
+        }
+    }
+
+    private static func itemID(prefix: String?, kind: String, key: String) -> String {
+        if let prefix {
+            return "\(prefix):\(kind):\(key)"
+        }
+
+        return "\(kind):\(key)"
     }
 
     private static func systemImageName(for pin: PacketPin) -> String {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -205,7 +205,7 @@ private enum PacketTableContentBuilder {
         switch input.signature.sourceListSelection {
         case .saved:
             return input.signature.savedRecords.map(\.packet)
-        case .pinned, .pinnedItem:
+        case .pinned, .pinnedItem, .pinnedItemDomain, .pinnedItemIPAddress:
             return input.ingestState.packets.filter {
                 matches($0, selection: input.signature.sourceListSelection, pinnedItems: input.signature.pinnedItems)
             }
@@ -219,19 +219,7 @@ private enum PacketTableContentBuilder {
         selection: PacketSourceListSelection,
         pinnedItems: [PacketPin]
     ) -> Bool {
-        switch selection {
-        case .pinned:
-            return pinnedItems.contains { PacketPinMatcher.matches(packet, pin: $0) }
-        case .pinnedItem(let pinID):
-            guard let pin = pinnedItems.first(where: { $0.id == pinID }) else {
-                return false
-            }
-            return PacketPinMatcher.matches(packet, pin: pin)
-        case .saved:
-            return true
-        default:
-            return PacketSourceListClassifier.matches(packet, selection: selection)
-        }
+        PacketSourceListPacketMatcher.matches(packet, selection: selection, pinnedItems: pinnedItems)
     }
 }
 
@@ -815,7 +803,7 @@ private struct PacketTableContentCache {
         switch sourceListSelection {
         case .saved:
             return savedRecords.map(\.packet)
-        case .pinned, .pinnedItem:
+        case .pinned, .pinnedItem, .pinnedItemDomain, .pinnedItemIPAddress:
             return ingestState.packets.filter { matches($0, selection: sourceListSelection, pinnedItems: pinnedItems) }
         default:
             return ingestState.packets
@@ -827,19 +815,7 @@ private struct PacketTableContentCache {
         selection: PacketSourceListSelection,
         pinnedItems: [PacketPin]
     ) -> Bool {
-        switch selection {
-        case .pinned:
-            return pinnedItems.contains { PacketPinMatcher.matches(packet, pin: $0) }
-        case .pinnedItem(let pinID):
-            guard let pin = pinnedItems.first(where: { $0.id == pinID }) else {
-                return false
-            }
-            return PacketPinMatcher.matches(packet, pin: pin)
-        case .saved:
-            return true
-        default:
-            return PacketSourceListClassifier.matches(packet, selection: selection)
-        }
+        PacketSourceListPacketMatcher.matches(packet, selection: selection, pinnedItems: pinnedItems)
     }
 }
 
@@ -1422,22 +1398,10 @@ final class NetworkInspectorViewModel {
         case .saved:
             let identifiers = savedPacketService.records().map(\.packet.id)
             return try validatedExportPacketIDs(identifiers, requiresSavedBacking: true)
-        case .pinned:
+        default:
             let pins = pinService.pins()
             return controller.snapshot.packetIngestState.packets.compactMap { packet in
-                pins.contains { PacketPinMatcher.matches(packet, pin: $0) } ? packet.id : nil
-            }
-        case .pinnedItem(let pinID):
-            guard let pin = pinService.pins().first(where: { $0.id == pinID }) else {
-                return []
-            }
-
-            return controller.snapshot.packetIngestState.packets.compactMap { packet in
-                PacketPinMatcher.matches(packet, pin: pin) ? packet.id : nil
-            }
-        default:
-            return controller.snapshot.packetIngestState.packets.compactMap { packet in
-                PacketSourceListClassifier.matches(packet, selection: selection) ? packet.id : nil
+                PacketSourceListPacketMatcher.matches(packet, selection: selection, pinnedItems: pins) ? packet.id : nil
             }
         }
     }
@@ -1448,8 +1412,9 @@ final class NetworkInspectorViewModel {
     }
 
     private func packetIDs(matching selection: PacketSourceListSelection) -> [PacketSummary.ID] {
-        controller.snapshot.packetIngestState.packets.compactMap { packet in
-            PacketSourceListClassifier.matches(packet, selection: selection) ? packet.id : nil
+        let pins = pinService.pins()
+        return controller.snapshot.packetIngestState.packets.compactMap { packet in
+            PacketSourceListPacketMatcher.matches(packet, selection: selection, pinnedItems: pins) ? packet.id : nil
         }
     }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -72,7 +72,7 @@ final class PacketWorkspaceViewModel {
             emptyTitle = "Pinned Packets"
             emptyMessage = "Pinned matches will appear here as packets arrive."
             emptyImageName = "pin.fill"
-        case .pinnedItem:
+        case .pinnedItem, .pinnedItemDomain, .pinnedItemIPAddress:
             emptyTitle = "Pinned Packets"
             emptyMessage = "No packets match this pinned item yet."
             emptyImageName = "pin.fill"

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -312,7 +312,8 @@ final class SidebarViewController: NSViewController {
         outlineView.allowsMultipleSelection = true
         outlineView.rowHeight = 28
         outlineView.indentationPerLevel = 18
-        outlineView.indentationMarkerFollowsCell = false
+        // Keep disclosure arrows aligned with nested source-list row content.
+        outlineView.indentationMarkerFollowsCell = true
         outlineView.backgroundColor = .clear
         outlineView.focusRingType = .none
         outlineView.keyboardActionHandler = self

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -253,11 +253,13 @@ final class SidebarViewController: NSViewController {
             captureExpandedItemIDs()
         }
 
+        let preservedScrollOrigin = outlineScrollOrigin()
         viewModel.render(state: state)
         syncSearchField(state.filterText)
         outlineView.reloadData()
         restoreExpandedItems(expandAll: !viewModel.filterText.isEmpty)
         syncSelection()
+        restoreOutlineScrollOrigin(preservedScrollOrigin)
         appliedReloadState = state
         hasRenderedOutline = true
     }
@@ -368,6 +370,30 @@ final class SidebarViewController: NSViewController {
         for item in itemsToExpand where item.sourceItem.reservesDisclosureSpace {
             outlineView.expandItem(item)
         }
+    }
+
+    private func outlineScrollOrigin() -> NSPoint {
+        scrollView.contentView.bounds.origin
+    }
+
+    // Put the sidebar viewport back where it was, clamped to the new content height.
+    private func restoreOutlineScrollOrigin(_ origin: NSPoint) {
+        guard let documentView = scrollView.documentView else {
+            return
+        }
+
+        scrollView.layoutSubtreeIfNeeded()
+        outlineView.layoutSubtreeIfNeeded()
+
+        let clipView = scrollView.contentView
+        let maxX = max(0, documentView.bounds.width - clipView.bounds.width)
+        let maxY = max(0, documentView.bounds.height - clipView.bounds.height)
+        let clampedOrigin = NSPoint(
+            x: min(max(0, origin.x), maxX),
+            y: min(max(0, origin.y), maxY)
+        )
+        clipView.scroll(to: clampedOrigin)
+        scrollView.reflectScrolledClipView(clipView)
     }
 
     private func syncSelection() {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1378,6 +1378,36 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[2].id])
     }
 
+    @Test func sourceListAppChildSelectionsFilterPacketRowsByParentAndChild() async throws {
+        let chrome = makeClient(displayName: "Chrome", bundleIdentifier: "com.google.Chrome")
+        let tcpviewer = makeClient(displayName: "TCP Viewer", bundleIdentifier: "com.proxyman.tcpviewer")
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: "api.example.com", client: chrome),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .udp, streamID: nil, sniDomainName: "openai.com", client: chrome),
+            makePacket(packetNumber: 3, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: "api.example.com", client: tcpviewer),
+            makePacket(packetNumber: 4, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: nil, client: chrome, sourceAddress: "10.0.0.3", destinationAddress: "10.0.0.4"),
+            makePacket(packetNumber: 5, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: nil, client: tcpviewer, sourceAddress: "10.0.0.5", destinationAddress: "10.0.0.4"),
+        ]
+        let viewModel = makeOfflineViewModel(packets: packets)
+
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/source-list-app-child-selection.pcapng"))
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == packets.count
+        }
+
+        let chromeKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.google.Chrome")
+        let apiKey = domainKey("api.example.com")
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.4")
+        _ = try #require(viewModel.snapshot.sourceListSnapshot.item(for: .appDomain(chromeKey, apiKey)))
+        _ = try #require(viewModel.snapshot.sourceListSnapshot.item(for: .appIPAddress(chromeKey, ipKey)))
+
+        viewModel.selectSourceList(.appDomain(chromeKey, apiKey))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id])
+
+        viewModel.selectSourceList(.appIPAddress(chromeKey, ipKey))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[3].id])
+    }
+
     @Test func sourceListParentAndFavoriteSelectionsUseExpectedPacketSets() async {
         let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
         let packets = [
@@ -1716,6 +1746,94 @@ struct NetworkInspectorViewModelTests {
 
         #expect(viewModel.snapshot.packetRows.map(\.id) == [first.id, matchingFuture.id])
         #expect(viewModel.snapshot.sourceListSnapshot.item(for: .pinnedItem(pinID))?.count == 2)
+    }
+
+    @Test func pinnedClientChildSelectionsFilterPacketRowsByPinnedClientAndChild() async throws {
+        let pinService = PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json"))
+        let chrome = makeClient(displayName: "Chrome", bundleIdentifier: "com.google.Chrome")
+        let tcpviewer = makeClient(displayName: "TCP Viewer", bundleIdentifier: "com.proxyman.tcpviewer")
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: "api.example.com", client: chrome),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .udp, streamID: nil, sniDomainName: "openai.com", client: chrome),
+            makePacket(packetNumber: 3, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: "api.example.com", client: tcpviewer),
+            makePacket(packetNumber: 4, source: .offline, transportHint: .tcp, streamID: nil, sniDomainName: nil, client: chrome, sourceAddress: "10.0.0.3", destinationAddress: "10.0.0.4"),
+        ]
+        let openURL = URL(fileURLWithPath: "/tmp/pinned-client-child-filter.pcapng")
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: InspectorFakeDocument(url: openURL, packets: packets)
+            )),
+            userDefaults: isolatedDefaults(),
+            pinService: pinService
+        )
+
+        await viewModel.openDocument(at: openURL)
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == packets.count
+        }
+
+        viewModel.pinAppPackets([packets[0].id])
+        let pinID = try #require(pinService.pins().first?.id)
+        let apiKey = domainKey("api.example.com")
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.4")
+        _ = try #require(viewModel.snapshot.sourceListSnapshot.item(for: .pinnedItemDomain(pinID, apiKey)))
+        _ = try #require(viewModel.snapshot.sourceListSnapshot.item(for: .pinnedItemIPAddress(pinID, ipKey)))
+
+        viewModel.selectSourceList(.pinnedItemDomain(pinID, apiKey))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id])
+
+        viewModel.selectSourceList(.pinnedItemIPAddress(pinID, ipKey))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[3].id])
+    }
+
+    @Test func appChildSelectionAppendsFutureMatchingPackets() async {
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let first = makePacket(packetNumber: 1, source: .live, transportHint: .tcp, streamID: nil, sniDomainName: "api.example.com", client: client)
+        let matchingFuture = makePacket(packetNumber: 2, source: .live, transportHint: .udp, streamID: nil, sniDomainName: "api.example.com", client: client)
+        let differentDomainFuture = makePacket(packetNumber: 3, source: .live, transportHint: .tcp, streamID: nil, sniDomainName: "openai.com", client: client)
+        let unrelatedClientFuture = makePacket(
+            packetNumber: 4,
+            source: .live,
+            transportHint: .tcp,
+            streamID: nil,
+            sniDomainName: "api.example.com",
+            client: makeClient(displayName: "Other", bundleIdentifier: "com.example.other")
+        )
+        let liveSession = InspectorFakeLiveSession()
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                liveSession: liveSession
+            ), packetMetadataEnricher: PacketMetadataEnrichmentService(
+                clientResolver: InspectorFakePacketClientResolver(defaultClient: nil)
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.performInitialLoadIfNeeded()
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+        liveSession.send(.packetBatch([first], disposition: .append))
+        await waitUntil {
+            viewModel.snapshot.packetRows.map(\.id) == [first.id]
+        }
+
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
+        let apiKey = domainKey("api.example.com")
+        viewModel.selectSourceList(.appDomain(appKey, apiKey))
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [first.id])
+
+        liveSession.send(.packetBatch([matchingFuture, differentDomainFuture, unrelatedClientFuture], disposition: .append))
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.hasPendingCoalescedRebuildForTesting || viewModel.snapshot.totalPacketCount == 4
+        }
+        viewModel.flushPendingCoalescedRebuildForTesting()
+        await waitUntil(timeoutNanoseconds: 5_000_000_000) {
+            viewModel.snapshot.packetRows.map(\.id) == [first.id, matchingFuture.id]
+        }
+
+        #expect(viewModel.snapshot.sourceListSnapshot.item(for: .appDomain(appKey, apiKey))?.count == 2)
     }
 
     @Test func sourceListDeleteActionRemovesPinsAndMatchingPackets() async throws {
@@ -2370,6 +2488,10 @@ struct NetworkInspectorViewModelTests {
             .selection
     }
 
+    private func domainKey(_ name: String) -> PacketSourceDomainKey {
+        PacketSourceDomainKey(rawValue: name.lowercased(), isMissingDomain: false)
+    }
+
     private func makeInterface(id: String, displayName: String) -> CaptureInterfaceSummary {
         CaptureInterfaceSummary(
             id: id,
@@ -2459,7 +2581,9 @@ struct NetworkInspectorViewModelTests {
         transportLayerName: String? = nil,
         protocolSummary: String? = nil,
         infoSummary: String? = nil,
-        layerNames: [String]? = nil
+        layerNames: [String]? = nil,
+        sourceAddress: String = "10.0.0.1",
+        destinationAddress: String = "10.0.0.2"
     ) -> PacketSummary {
         let packetLayers = layerNames?.map { PacketLayer(name: $0) } ?? [
             PacketLayer(name: "Ethernet"),
@@ -2473,8 +2597,8 @@ struct NetworkInspectorViewModelTests {
             transportHint: transportHint,
             protocolSummary: protocolSummary,
             endpoints: PacketEndpoints(
-                source: PacketEndpoint(address: "10.0.0.1", port: sourcePort),
-                destination: PacketEndpoint(address: "10.0.0.2", port: destinationPort)
+                source: PacketEndpoint(address: sourceAddress, port: sourcePort),
+                destination: PacketEndpoint(address: destinationAddress, port: destinationPort)
             ),
             originalLength: 128,
             capturedLength: 128,

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -78,6 +78,33 @@ struct PacketSourceListServiceTests {
         #expect(snapshot.item(for: .ipAddress(sourceIPKey))?.count == 2)
     }
 
+    @Test func appRowsNestScopedDomainsAndIPAddresses() throws {
+        let chrome = makeClient(displayName: "Chrome", bundleIdentifier: "com.google.Chrome")
+        let tcpviewer = makeClient(displayName: "TCP Viewer", bundleIdentifier: "com.proxyman.tcpviewer")
+        var state = PacketIngestState.empty
+        state.append([
+            makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: chrome),
+            makePacket(packetNumber: 2, sniDomainName: "api.example.com", client: chrome),
+            makePacket(packetNumber: 3, sniDomainName: nil, client: chrome, sourceAddress: "10.0.0.3", destinationAddress: "10.0.0.4"),
+            makePacket(packetNumber: 4, sniDomainName: "api.example.com", client: tcpviewer),
+            makePacket(packetNumber: 5, sniDomainName: nil, client: tcpviewer, sourceAddress: "10.0.0.5", destinationAddress: "10.0.0.6"),
+        ], source: .live)
+
+        let snapshot = PacketSourceListService().snapshot(for: state)
+        let chromeKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.google.Chrome")
+        let tcpviewerKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.proxyman.tcpviewer")
+        let apiKey = domainKey("api.example.com")
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.4")
+
+        let chromeItem = try #require(snapshot.item(for: .app(chromeKey)))
+        #expect(chromeItem.children.map(\.title) == ["api.example.com", "IP Addresses"])
+        #expect(snapshot.item(for: .appDomain(chromeKey, apiKey))?.count == 2)
+        #expect(snapshot.item(for: .appDomain(tcpviewerKey, apiKey))?.count == 1)
+        #expect(snapshot.item(for: .appDomain(chromeKey, .ipAddresses))?.count == 1)
+        #expect(snapshot.item(for: .appDomain(chromeKey, .ipAddresses))?.children.map(\.title) == ["10.0.0.4", "10.0.0.3"])
+        #expect(snapshot.item(for: .appIPAddress(chromeKey, ipKey))?.count == 1)
+    }
+
     @Test func deletionPolicyOnlyAllowsDeletableLeafItems() {
         let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
         let pinID = PacketPinID(rawValue: "domain:api.example.com")
@@ -279,6 +306,26 @@ struct PacketSourceListServiceTests {
         #expect(snapshot.item(for: .pinnedItem(pinID))?.iconFilePath == "/Applications/Google Chrome.app")
     }
 
+    @Test func pinnedClientRowsMirrorScopedAppChildren() throws {
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let pin = makeClientPin(displayName: "Example", key: "bundleIdentifier:com.example.app")
+        var state = PacketIngestState.empty
+        state.append([
+            makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: client),
+            makePacket(packetNumber: 2, sniDomainName: nil, client: client, sourceAddress: "10.0.0.3", destinationAddress: "10.0.0.4"),
+        ], source: .live)
+
+        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [pin])
+        let pinItem = try #require(snapshot.item(for: .pinnedItem(pin.id)))
+        let apiKey = domainKey("api.example.com")
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.4")
+
+        #expect(pinItem.children.map(\.title) == ["api.example.com", "IP Addresses"])
+        #expect(snapshot.item(for: .pinnedItemDomain(pin.id, apiKey))?.count == 1)
+        #expect(snapshot.item(for: .pinnedItemDomain(pin.id, .ipAddresses))?.children.map(\.title) == ["10.0.0.4", "10.0.0.3"])
+        #expect(snapshot.item(for: .pinnedItemIPAddress(pin.id, ipKey))?.count == 1)
+    }
+
     @Test func resetReplaceAndMetadataUpdatesRebuildTree() {
         let service = PacketSourceListService()
         let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
@@ -353,6 +400,34 @@ struct PacketSourceListServiceTests {
 
         #expect(snapshot.item(for: .apps)?.children.map(\.title) == ["Example"])
         #expect(snapshot.item(for: .apps)?.children.first?.count == 1)
+    }
+
+    @Test func metadataUpdateMovesPacketBetweenScopedAppBucketsIncrementally() {
+        let service = PacketSourceListService()
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
+        var state = PacketIngestState.empty
+        let unresolved = makePacket(packetNumber: 1, sniDomainName: nil, client: client)
+        let stable = makePacket(packetNumber: 2, sniDomainName: "stable.example.com", client: client)
+        state.append([unresolved, stable], source: .live)
+
+        var snapshot = service.snapshot(for: state)
+        #expect(snapshot.item(for: .appDomain(appKey, .ipAddresses))?.count == 1)
+        #expect(snapshot.item(for: .appDomain(appKey, domainKey("stable.example.com")))?.count == 1)
+
+        state.applyMetadataUpdates([
+            PacketMetadataUpdate(
+                packetIDs: [unresolved.id],
+                sniDomainName: "api.example.com",
+                client: client,
+                direction: .outbound
+            )
+        ])
+        snapshot = service.snapshot(for: state)
+
+        #expect(snapshot.item(for: .appDomain(appKey, .ipAddresses)) == nil)
+        #expect(snapshot.item(for: .appDomain(appKey, domainKey("api.example.com")))?.count == 1)
+        #expect(snapshot.item(for: .appDomain(appKey, domainKey("stable.example.com")))?.count == 1)
     }
 
     @Test func appendAfterMetadataResolutionPicksUpResolvedBucketsWithoutDoubleCounting() {
@@ -432,7 +507,9 @@ struct PacketSourceListServiceTests {
     private func makePacket(
         packetNumber: UInt64,
         sniDomainName: String? = nil,
-        client: PacketClient? = nil
+        client: PacketClient? = nil,
+        sourceAddress: String = "10.0.0.1",
+        destinationAddress: String = "10.0.0.2"
     ) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,
@@ -441,8 +518,8 @@ struct PacketSourceListServiceTests {
             interfaceID: "en0",
             transportHint: .tcp,
             endpoints: PacketEndpoints(
-                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
-                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+                source: PacketEndpoint(address: sourceAddress, port: 1234),
+                destination: PacketEndpoint(address: destinationAddress, port: 443)
             ),
             originalLength: 128,
             capturedLength: 128,

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import AppKit
+import PcapPlusPlusCore
 import Testing
 @testable import TCPViewer
 
@@ -120,6 +122,51 @@ struct SidebarOutlineReloadPolicyTests {
         ) == nil)
     }
 
+    @MainActor
+    @Test func deferredReloadPreservesSidebarScrollPositionAndSelection() async throws {
+        let selectedKey = PacketSourceDomainKey(rawValue: "domain-32.example.com", isMissingDomain: false)
+        let controller = SidebarViewController()
+        let selectionRecorder = SidebarSelectionRecorder()
+        controller.delegate = selectionRecorder
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 260, height: 240)
+        controller.view.layoutSubtreeIfNeeded()
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithDomains(count: 48),
+            selectedSelection: .domain(selectedKey),
+            packetMutation: .none
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let outlineScrollView = try #require(findOutlineScrollView(in: controller.view))
+        let outlineView = try #require(outlineScrollView.documentView as? NSOutlineView)
+        #expect(outlineView.selectedRow >= 0)
+
+        outlineScrollView.contentView.scroll(to: NSPoint(x: 0, y: 520))
+        outlineScrollView.reflectScrolledClipView(outlineScrollView.contentView)
+        let originalY = outlineScrollView.contentView.bounds.origin.y
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithDomains(count: 49),
+            selectedSelection: .domain(selectedKey),
+            packetMutation: .append(0..<1)
+        ))
+        try await Task.sleep(nanoseconds: 700_000_000)
+        await Task.yield()
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(originalY > 0)
+        #expect(abs(outlineScrollView.contentView.bounds.origin.y - originalY) <= 1)
+
+        selectionRecorder.selectedSelection = nil
+        controller.outlineViewSelectionDidChange(Notification(
+            name: NSTableView.selectionDidChangeNotification,
+            object: outlineView
+        ))
+        #expect(selectionRecorder.selectedSelection == .domain(selectedKey))
+    }
+
     private func reloadState(
         sourceListSnapshot: PacketSourceListSnapshot,
         filterText: String = "",
@@ -158,4 +205,74 @@ struct SidebarOutlineReloadPolicyTests {
             ]
         )
     }
+
+    private func makeSnapshot(
+        sourceListSnapshot: PacketSourceListSnapshot,
+        selectedSelection: PacketSourceListSelection,
+        packetMutation: PacketIngestMutation
+    ) -> NetworkInspectorSnapshot {
+        var base = TCPViewerWindowSnapshot.foundation
+        base.packetIngestState.lastMutation = packetMutation
+        let tableContent = PacketTableContent(
+            displayFilter: PacketDisplayFilter(""),
+            displayFilterChips: [],
+            store: PacketTableRowStore(rows: [], visiblePacketRowIndexByID: [:]),
+            generation: 0,
+            updatePlan: .none,
+            malformedPacketCount: 0
+        )
+
+        return NetworkInspectorSnapshot.make(
+            base: base,
+            selectedSidebar: .liveCapture,
+            selectedSourceListSelection: selectedSelection,
+            sourceListSnapshot: sourceListSnapshot,
+            sourceListFilterText: "",
+            workspaceMode: .packets,
+            inspectorTab: .summary,
+            isInspectorVisible: true,
+            displayFilterText: "",
+            packetTableContent: tableContent
+        )
+    }
+
+    private func snapshotWithDomains(count: Int) -> PacketSourceListSnapshot {
+        PacketSourceListTreeBuilder.makeSnapshot(
+            appBuckets: [],
+            domainBuckets: (0..<count).map { index in
+                let displayName = String(format: "domain-%02d.example.com", index)
+                return PacketSourceListTreeBuilder.DomainBucket(identity: PacketSourceDomainIdentity(
+                    key: PacketSourceDomainKey(rawValue: displayName, isMissingDomain: false),
+                    displayName: displayName
+                ))
+            }
+        )
+    }
+
+    private func findOutlineScrollView(in view: NSView) -> NSScrollView? {
+        allSubviews(ofType: NSScrollView.self, in: view).first { $0.documentView is NSOutlineView }
+    }
+
+    private func allSubviews<T: NSView>(ofType type: T.Type, in view: NSView) -> [T] {
+        let current = (view as? T).map { [$0] } ?? []
+        return view.subviews.reduce(current) { result, subview in
+            result + allSubviews(ofType: type, in: subview)
+        }
+    }
+}
+
+private final class SidebarSelectionRecorder: SidebarViewControllerDelegate {
+    var selectedSelection: PacketSourceListSelection?
+
+    func sidebarViewController(_ controller: SidebarViewController, didSelect selection: PacketSourceListSelection?) {
+        selectedSelection = selection
+    }
+
+    func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String) {}
+
+    func sidebarViewController(_ controller: SidebarViewController, didRequestPin targets: [PacketSourceListPinTarget]) {}
+
+    func sidebarViewController(_ controller: SidebarViewController, didRequestDelete action: PacketSourceListDeletionAction) {}
+
+    func sidebarViewController(_ controller: SidebarViewController, didRequestExport selection: PacketSourceListSelection, format: CaptureFileFormat) {}
 }


### PR DESCRIPTION
## Summary
- Preserve the sidebar outline scroll offset and current selection during deferred source-list reloads.
- Show child domain and IP rows consistently across the source list and pin flows.
- Add regression coverage for reload timing, source-list shaping, and view-model behavior.

## Testing
- Added and updated unit tests for sidebar reload policy, source-list service behavior, and network inspector view-model selection rules.
- Verified locally with the macOS app build and the full scheme test run.