### PR TITLE
[codex] Add custom structured filter presets

### DIFF
--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -252,6 +252,22 @@ extension TCPViewerWindowController: PacketQuickFilterViewControllerDelegate {
         rootViewController.toggleQuickFilter(filterID)
     }
 
+    func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didApplyCustomFilter filterID: PacketCustomFilter.ID) {
+        rootViewController.applyCustomFilter(filterID)
+    }
+
+    func packetQuickFilterViewController(
+        _ controller: PacketQuickFilterViewController,
+        didRenameCustomFilter filterID: PacketCustomFilter.ID,
+        name: String
+    ) {
+        rootViewController.renameCustomFilter(filterID, name: name)
+    }
+
+    func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didDeleteCustomFilter filterID: PacketCustomFilter.ID) {
+        rootViewController.deleteCustomFilter(filterID)
+    }
+
     func packetQuickFilterViewControllerDidRequestReset(_ controller: PacketQuickFilterViewController) {
         rootViewController.resetQuickFilters()
     }

--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -264,6 +264,10 @@ extension TCPViewerWindowController: PacketQuickFilterViewControllerDelegate {
         rootViewController.renameCustomFilter(filterID, name: name)
     }
 
+    func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didDuplicateCustomFilter filterID: PacketCustomFilter.ID) {
+        rootViewController.duplicateCustomFilter(filterID)
+    }
+
     func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didDeleteCustomFilter filterID: PacketCustomFilter.ID) {
         rootViewController.deleteCustomFilter(filterID)
     }

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -629,6 +629,12 @@ struct NetworkInspectorSnapshot: Equatable {
         quickFilterSelection.isActive
     }
 
+    var activeFilterBarLabels: [String] {
+        quickFilterSelection.activeLabels + customFilterItems
+            .filter(\.isSelected)
+            .map(\.title)
+    }
+
     var isQuickFilterResetVisible: Bool {
         quickFilterSelection.isActive
     }

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -514,6 +514,7 @@ struct NetworkInspectorSnapshot: Equatable {
     var sourceListSnapshot: PacketSourceListSnapshot
     var sourceListFilterText: String
     var quickFilterItems: [PacketQuickFilterItem]
+    var customFilterItems: [PacketCustomFilterItem]
     var quickFilterSelection: PacketQuickFilterSelection
     var workspaceMode: NetworkInspectorWorkspaceMode
     var inspectorTab: PacketInspectorTab
@@ -541,6 +542,7 @@ struct NetworkInspectorSnapshot: Equatable {
         sourceListSnapshot: PacketSourceListSnapshot,
         sourceListFilterText: String,
         quickFilterItems: [PacketQuickFilterItem] = PacketQuickFilterService().items(),
+        customFilterItems: [PacketCustomFilterItem] = [],
         quickFilterSelection: PacketQuickFilterSelection = .all,
         workspaceMode: NetworkInspectorWorkspaceMode,
         inspectorTab: PacketInspectorTab,
@@ -559,6 +561,7 @@ struct NetworkInspectorSnapshot: Equatable {
             sourceListSnapshot: sourceListSnapshot,
             sourceListFilterText: sourceListFilterText,
             quickFilterItems: quickFilterItems,
+            customFilterItems: customFilterItems,
             quickFilterSelection: quickFilterSelection,
             workspaceMode: workspaceMode,
             inspectorTab: inspectorTab,
@@ -591,6 +594,7 @@ struct NetworkInspectorSnapshot: Equatable {
             lhs.sourceListSnapshot == rhs.sourceListSnapshot &&
             lhs.sourceListFilterText == rhs.sourceListFilterText &&
             lhs.quickFilterItems == rhs.quickFilterItems &&
+            lhs.customFilterItems == rhs.customFilterItems &&
             lhs.quickFilterSelection == rhs.quickFilterSelection &&
             lhs.workspaceMode == rhs.workspaceMode &&
             lhs.inspectorTab == rhs.inspectorTab &&

--- a/TCPViewer/Features/NetworkInspector/Models/PacketQuickFilterModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketQuickFilterModels.swift
@@ -79,6 +79,12 @@ struct PacketQuickFilterItem: Identifiable, Equatable, Sendable {
     let isSelected: Bool
 }
 
+struct PacketCustomFilterItem: Identifiable, Equatable, Sendable {
+    let id: PacketCustomFilter.ID
+    let title: String
+    let isSelected: Bool
+}
+
 struct PacketQuickFilterSelection: Equatable, Sendable, Hashable {
     let selectedIDs: Set<PacketQuickFilterID>
 

--- a/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
@@ -84,7 +84,12 @@ final class PacketCustomFilterService {
             group: PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
         )
         cachedFilters.append(filter)
-        try persist()
+        do {
+            try persist()
+        } catch {
+            cachedFilters.removeAll { $0.id == filter.id }
+            throw error
+        }
         return filter
     }
 
@@ -104,6 +109,48 @@ final class PacketCustomFilterService {
             cachedFilters[index] = previousFilter
             throw error
         }
+    }
+
+    // Replace a saved filter payload while keeping its user-facing name and identity.
+    func updateGroup(id: PacketCustomFilter.ID, group: PacketStructuredFilterGroup, now: Date = Date()) throws {
+        guard let index = cachedFilters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let previousFilter = cachedFilters[index]
+        cachedFilters[index].group = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
+        cachedFilters[index].updatedAt = now
+        do {
+            try persist()
+        } catch {
+            cachedFilters[index] = previousFilter
+            throw error
+        }
+    }
+
+    // Duplicate a saved filter beside its source without changing either filter payload.
+    @discardableResult
+    func duplicate(id: PacketCustomFilter.ID, now: Date = Date()) throws -> PacketCustomFilter? {
+        guard let index = cachedFilters.firstIndex(where: { $0.id == id }) else {
+            return nil
+        }
+
+        let sourceFilter = cachedFilters[index]
+        let duplicatedFilter = PacketCustomFilter(
+            id: UUID().uuidString,
+            name: sourceFilter.name,
+            createdAt: now,
+            updatedAt: now,
+            group: PacketStructuredFilterGroup(filters: sourceFilter.group.filters, operator: sourceFilter.group.operator)
+        )
+        cachedFilters.insert(duplicatedFilter, at: cachedFilters.index(after: index))
+        do {
+            try persist()
+        } catch {
+            cachedFilters.removeAll { $0.id == duplicatedFilter.id }
+            throw error
+        }
+        return duplicatedFilter
     }
 
     // Delete one saved filter and roll back the cache if persistence fails.

--- a/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
@@ -1,0 +1,149 @@
+//
+//  PacketCustomFilterService.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/6/26.
+//
+
+import Foundation
+
+struct PacketCustomFilter: Identifiable, Codable, Hashable, Sendable {
+    let id: String
+    var name: String
+    let createdAt: Date
+    var updatedAt: Date
+    var group: PacketStructuredFilterGroup
+}
+
+enum PacketCustomFilterValidationError: Error, Equatable, LocalizedError {
+    case emptyName
+    case nameTooLong(maxLength: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "Enter a custom filter name."
+        case .nameTooLong(let maxLength):
+            return "Custom filter names must be \(maxLength) characters or fewer."
+        }
+    }
+}
+
+final class PacketCustomFilterService {
+    static let maxNameLength = 40
+
+    private let storageURL: URL
+    private let fileManager: FileManager
+    private let userDataDirectory: TCPViewerUserDataDirectory
+    private let usesUserDataDirectoryStorage: Bool
+    private var cachedFilters: [PacketCustomFilter]
+
+    init(
+        storageURL: URL? = nil,
+        fileManager: FileManager = .default,
+        userDataDirectory: TCPViewerUserDataDirectory = .shared
+    ) {
+        self.userDataDirectory = userDataDirectory
+        self.usesUserDataDirectoryStorage = storageURL == nil
+        self.storageURL = storageURL ?? PacketCustomFilterService.defaultStorageURL(userDataDirectory: userDataDirectory)
+        self.fileManager = fileManager
+        self.cachedFilters = (try? Self.loadFilters(from: self.storageURL, fileManager: fileManager)) ?? []
+    }
+
+    // Return cached filters in saved order for stable titlebar rendering.
+    func filters() -> [PacketCustomFilter] {
+        cachedFilters
+    }
+
+    // Look up a saved filter by stable identifier for quick button actions.
+    func filter(id: PacketCustomFilter.ID) -> PacketCustomFilter? {
+        cachedFilters.first { $0.id == id }
+    }
+
+    // Validate and trim display names before they reach disk or UI snapshots.
+    static func normalizedName(_ name: String) throws -> String {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw PacketCustomFilterValidationError.emptyName
+        }
+        guard trimmedName.count <= maxNameLength else {
+            throw PacketCustomFilterValidationError.nameTooLong(maxLength: maxNameLength)
+        }
+        return trimmedName
+    }
+
+    // Append a new custom filter while allowing duplicate display names by design.
+    @discardableResult
+    func save(name: String, group: PacketStructuredFilterGroup, now: Date = Date()) throws -> PacketCustomFilter {
+        let normalizedName = try Self.normalizedName(name)
+        let filter = PacketCustomFilter(
+            id: UUID().uuidString,
+            name: normalizedName,
+            createdAt: now,
+            updatedAt: now,
+            group: PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
+        )
+        cachedFilters.append(filter)
+        try persist()
+        return filter
+    }
+
+    // Rename one saved filter without changing the structured filter payload.
+    func rename(id: PacketCustomFilter.ID, name: String, now: Date = Date()) throws {
+        guard let index = cachedFilters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let normalizedName = try Self.normalizedName(name)
+        let previousFilter = cachedFilters[index]
+        cachedFilters[index].name = normalizedName
+        cachedFilters[index].updatedAt = now
+        do {
+            try persist()
+        } catch {
+            cachedFilters[index] = previousFilter
+            throw error
+        }
+    }
+
+    // Delete one saved filter and roll back the cache if persistence fails.
+    func delete(id: PacketCustomFilter.ID) throws {
+        guard let index = cachedFilters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let removedFilter = cachedFilters.remove(at: index)
+        do {
+            try persist()
+        } catch {
+            cachedFilters.insert(removedFilter, at: index)
+            throw error
+        }
+    }
+
+    private func persist() throws {
+        if usesUserDataDirectoryStorage {
+            try userDataDirectory.createSettingsDirectoryIfNeeded()
+        } else {
+            try fileManager.createDirectory(at: storageURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(cachedFilters).write(to: storageURL, options: .atomic)
+    }
+
+    private static func loadFilters(from url: URL, fileManager: FileManager) throws -> [PacketCustomFilter] {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([PacketCustomFilter].self, from: Data(contentsOf: url))
+    }
+
+    private static func defaultStorageURL(userDataDirectory: TCPViewerUserDataDirectory) -> URL {
+        userDataDirectory.settingsFileURL(named: "CustomFilters.json")
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -876,6 +876,7 @@ final class NetworkInspectorViewModel {
     private let pinService: PacketPinService
     private let savedPacketService: SavedPacketService
     private let quickFilterService: PacketQuickFilterService
+    private let customFilterService: PacketCustomFilterService
     private let structuredFilterService: PacketStructuredFilterService
     private let structuredFilterStore: PacketStructuredFilterStore
     private let packetExportService: PacketExportService
@@ -906,6 +907,7 @@ final class NetworkInspectorViewModel {
     private var isStructuredFilterVisible: Bool
     private var displayFilterText: String
     private var structuredFilterGroup: PacketStructuredFilterGroup
+    private var selectedCustomFilterID: PacketCustomFilter.ID?
     private var helperOnboardingDismissed = false
 
     convenience init(userDefaults: UserDefaults = .standard) {
@@ -919,6 +921,7 @@ final class NetworkInspectorViewModel {
         pinService: PacketPinService = PacketPinService(),
         savedPacketService: SavedPacketService = SavedPacketService(),
         quickFilterService: PacketQuickFilterService = PacketQuickFilterService(),
+        customFilterService: PacketCustomFilterService = PacketCustomFilterService(),
         structuredFilterService: PacketStructuredFilterService = PacketStructuredFilterService(),
         packetExportService: PacketExportService? = nil,
         packetTableAsyncRebuildThreshold: Int = 5_000,
@@ -933,6 +936,7 @@ final class NetworkInspectorViewModel {
         self.pinService = pinService
         self.savedPacketService = savedPacketService
         self.quickFilterService = quickFilterService
+        self.customFilterService = customFilterService
         self.structuredFilterService = structuredFilterService
         self.structuredFilterStore = PacketStructuredFilterStore(defaults: userDefaults)
         self.packetExportService = packetExportService ?? PacketExportService(defaults: userDefaults)
@@ -967,6 +971,9 @@ final class NetworkInspectorViewModel {
         case .ready(let content), .deferred(let content, _):
             packetTableContent = content
         }
+        let initialCustomFilterItems = customFilterService.filters().map { filter in
+            PacketCustomFilterItem(id: filter.id, title: filter.name, isSelected: false)
+        }
         self.snapshot = NetworkInspectorSnapshot.make(
             base: controller.snapshot,
             selectedSidebar: selectedSidebar,
@@ -974,6 +981,7 @@ final class NetworkInspectorViewModel {
             sourceListSnapshot: sourceListSnapshot,
             sourceListFilterText: sourceListFilterText,
             quickFilterItems: quickFilterService.items(),
+            customFilterItems: initialCustomFilterItems,
             quickFilterSelection: quickFilterService.selection,
             workspaceMode: workspaceMode,
             inspectorTab: inspectorTab,
@@ -1128,6 +1136,7 @@ final class NetworkInspectorViewModel {
 
     func updateStructuredFilterGroup(_ group: PacketStructuredFilterGroup) {
         structuredFilterGroup = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
+        selectedCustomFilterID = nil
         structuredFilterStore.save(structuredFilterGroup)
         rebuildSnapshot()
     }
@@ -1150,6 +1159,46 @@ final class NetworkInspectorViewModel {
     func resetQuickFilters() {
         quickFilterService.reset()
         rebuildSnapshot(clearsSelectedPacket: true)
+    }
+
+    // Save the current structured filter group as a reusable custom titlebar filter.
+    @discardableResult
+    func saveCustomFilter(name: String, group: PacketStructuredFilterGroup) throws -> PacketCustomFilter {
+        let savedFilter = try customFilterService.save(name: name, group: group)
+        selectedCustomFilterID = savedFilter.id
+        rebuildSnapshot()
+        return savedFilter
+    }
+
+    // Replace the structured filter editor with a saved custom filter and apply it immediately.
+    func applyCustomFilter(id: PacketCustomFilter.ID) {
+        guard let filter = customFilterService.filter(id: id) else {
+            return
+        }
+
+        structuredFilterGroup = PacketStructuredFilterGroup(filters: filter.group.filters, operator: filter.group.operator)
+        structuredFilterStore.save(structuredFilterGroup)
+        selectedCustomFilterID = filter.id
+        if !isStructuredFilterVisible {
+            isStructuredFilterVisible = true
+            preferences.persistStructuredFilterVisible(true)
+        }
+        rebuildSnapshot()
+    }
+
+    // Rename a saved custom filter and refresh titlebar render models.
+    func renameCustomFilter(id: PacketCustomFilter.ID, name: String) throws {
+        try customFilterService.rename(id: id, name: name)
+        rebuildSnapshot()
+    }
+
+    // Delete a saved custom filter while leaving any currently applied structured group intact.
+    func deleteCustomFilter(id: PacketCustomFilter.ID) throws {
+        try customFilterService.delete(id: id)
+        if selectedCustomFilterID == id {
+            selectedCustomFilterID = nil
+        }
+        rebuildSnapshot()
     }
 
     func clearPackets() {
@@ -1756,6 +1805,7 @@ final class NetworkInspectorViewModel {
             sourceListSnapshot: sourceListSnapshot,
             sourceListFilterText: sourceListFilterText,
             quickFilterItems: quickFilterService.items(),
+            customFilterItems: customFilterItems(),
             quickFilterSelection: quickFilterService.selection,
             workspaceMode: workspaceMode,
             inspectorTab: inspectorTab,
@@ -1772,6 +1822,17 @@ final class NetworkInspectorViewModel {
         }
 
         snapshot = updatedSnapshot
+    }
+
+    // Convert saved custom filters into stable button models for the quick-filter bar.
+    private func customFilterItems() -> [PacketCustomFilterItem] {
+        customFilterService.filters().map { filter in
+            PacketCustomFilterItem(
+                id: filter.id,
+                title: filter.name,
+                isSelected: isStructuredFilterVisible && selectedCustomFilterID == filter.id
+            )
+        }
     }
 
     private func makePacketTableBuildInput(

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1170,9 +1170,16 @@ final class NetworkInspectorViewModel {
         return savedFilter
     }
 
-    // Replace the structured filter editor with a saved custom filter and apply it immediately.
+    // Toggle or replace the structured filter editor with a saved custom filter.
     func applyCustomFilter(id: PacketCustomFilter.ID) {
         guard let filter = customFilterService.filter(id: id) else {
+            return
+        }
+
+        if isStructuredFilterVisible, selectedCustomFilterID == filter.id {
+            isStructuredFilterVisible = false
+            preferences.persistStructuredFilterVisible(false)
+            rebuildSnapshot()
             return
         }
 
@@ -1189,6 +1196,22 @@ final class NetworkInspectorViewModel {
     // Rename a saved custom filter and refresh titlebar render models.
     func renameCustomFilter(id: PacketCustomFilter.ID, name: String) throws {
         try customFilterService.rename(id: id, name: name)
+        rebuildSnapshot()
+    }
+
+    // Replace one saved custom filter with the current structured filter group.
+    func overrideCustomFilter(id: PacketCustomFilter.ID, group: PacketStructuredFilterGroup) throws {
+        let replacementGroup = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
+        try customFilterService.updateGroup(id: id, group: replacementGroup)
+        structuredFilterGroup = replacementGroup
+        structuredFilterStore.save(replacementGroup)
+        selectedCustomFilterID = id
+        rebuildSnapshot()
+    }
+
+    // Duplicate a saved custom filter without changing the active structured filter group.
+    func duplicateCustomFilter(id: PacketCustomFilter.ID) throws {
+        _ = try customFilterService.duplicate(id: id)
         rebuildSnapshot()
     }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
@@ -15,6 +15,7 @@ protocol PacketQuickFilterViewControllerDelegate: AnyObject {
         didRenameCustomFilter filterID: PacketCustomFilter.ID,
         name: String
     )
+    func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didDuplicateCustomFilter filterID: PacketCustomFilter.ID)
     func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didDeleteCustomFilter filterID: PacketCustomFilter.ID)
     func packetQuickFilterViewControllerDidRequestReset(_ controller: PacketQuickFilterViewController)
 }
@@ -294,11 +295,19 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
 
         let menu = NSMenu()
         menu.autoenablesItems = false
-        let renameItem = NSMenuItem(title: "Rename", action: #selector(renameCustomFilter(_:)), keyEquivalent: "")
+        let renameItem = NSMenuItem(title: "Edit Name", action: #selector(renameCustomFilter(_:)), keyEquivalent: "")
         renameItem.target = self
         renameItem.representedObject = item.id
         menu.addItem(renameItem)
 
+        menu.addItem(.separator())
+        let duplicateItem = NSMenuItem(title: "Duplicate", action: #selector(duplicateCustomFilter(_:)), keyEquivalent: "")
+        duplicateItem.target = self
+        duplicateItem.representedObject = item.id
+        duplicateItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Duplicate")
+        menu.addItem(duplicateItem)
+
+        menu.addItem(.separator())
         let deleteItem = NSMenuItem(title: "Delete", action: #selector(deleteCustomFilter(_:)), keyEquivalent: "\u{8}")
         deleteItem.target = self
         deleteItem.representedObject = item.id
@@ -316,6 +325,14 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
         }
 
         delegate?.packetQuickFilterViewController(self, didRenameCustomFilter: filterID, name: name)
+    }
+
+    @objc private func duplicateCustomFilter(_ sender: NSMenuItem) {
+        guard let filterID = sender.representedObject as? PacketCustomFilter.ID else {
+            return
+        }
+
+        delegate?.packetQuickFilterViewController(self, didDuplicateCustomFilter: filterID)
     }
 
     @objc private func deleteCustomFilter(_ sender: NSMenuItem) {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
@@ -9,6 +9,13 @@ import AppKit
 
 protocol PacketQuickFilterViewControllerDelegate: AnyObject {
     func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didToggle filterID: PacketQuickFilterID)
+    func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didApplyCustomFilter filterID: PacketCustomFilter.ID)
+    func packetQuickFilterViewController(
+        _ controller: PacketQuickFilterViewController,
+        didRenameCustomFilter filterID: PacketCustomFilter.ID,
+        name: String
+    )
+    func packetQuickFilterViewController(_ controller: PacketQuickFilterViewController, didDeleteCustomFilter filterID: PacketCustomFilter.ID)
     func packetQuickFilterViewControllerDidRequestReset(_ controller: PacketQuickFilterViewController)
 }
 
@@ -29,6 +36,33 @@ private final class PacketQuickFilterButton: NSButton {
     }
 }
 
+private final class PacketCustomFilterButton: NSButton {
+    let filterID: PacketCustomFilter.ID
+    var rightClickHandler: ((PacketCustomFilterButton, NSEvent) -> Void)?
+
+    init(filterID: PacketCustomFilter.ID, title: String, target: AnyObject?, action: Selector?) {
+        self.filterID = filterID
+        super.init(frame: .zero)
+        self.title = title
+        self.target = target
+        self.action = action
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        rightClickHandler?(self, event)
+    }
+}
+
+private struct PacketCustomFilterButtonSignature: Equatable {
+    let id: PacketCustomFilter.ID
+    let title: String
+}
+
 final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     private enum Metrics {
         static let height: CGFloat = 34
@@ -41,10 +75,15 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     weak var delegate: PacketQuickFilterViewControllerDelegate?
 
     private let stackView = NSStackView()
+    private let customSeparator = NSBox()
     private let resetSeparator = NSBox()
     private let bottomSeparator = NSBox()
     private let resetButton = NSButton(title: "Reset Filters", target: nil, action: nil)
     private var buttons: [PacketQuickFilterID: PacketQuickFilterButton] = [:]
+    private var customButtons: [PacketCustomFilter.ID: PacketCustomFilterButton] = [:]
+    private var customItemsByID: [PacketCustomFilter.ID: PacketCustomFilterItem] = [:]
+    private var renderedQuickFilterIDs: [PacketQuickFilterID] = []
+    private var renderedCustomFilterSignatures: [PacketCustomFilterButtonSignature] = []
 
     override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -68,12 +107,24 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     }
 
     func render(snapshot: NetworkInspectorSnapshot) {
-        ensureButtons(for: snapshot.quickFilterItems)
+        ensureButtons(for: snapshot.quickFilterItems, customItems: snapshot.customFilterItems)
+        customItemsByID = Dictionary(uniqueKeysWithValues: snapshot.customFilterItems.map { ($0.id, $0) })
         for item in snapshot.quickFilterItems {
             guard let button = buttons[item.id] else {
                 continue
             }
             render(button: button, title: item.title, toolTip: item.id.toolTip, isSelected: item.isSelected)
+        }
+        for item in snapshot.customFilterItems {
+            guard let button = customButtons[item.id] else {
+                continue
+            }
+            render(
+                button: button,
+                title: item.title,
+                toolTip: "Apply custom filter \"\(item.title)\"",
+                isSelected: item.isSelected
+            )
         }
 
         resetButton.isHidden = !snapshot.isQuickFilterResetVisible
@@ -96,6 +147,9 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
         resetSeparator.translatesAutoresizingMaskIntoConstraints = false
         resetSeparator.isHidden = true
 
+        customSeparator.boxType = .separator
+        customSeparator.translatesAutoresizingMaskIntoConstraints = false
+
         bottomSeparator.boxType = .separator
         bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
 
@@ -115,6 +169,7 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
             stackView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomSeparator.topAnchor),
+            customSeparator.heightAnchor.constraint(equalToConstant: 18),
             resetSeparator.heightAnchor.constraint(equalToConstant: 18),
             resetButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             bottomSeparator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -124,8 +179,13 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
         ])
     }
 
-    private func ensureButtons(for items: [PacketQuickFilterItem]) {
-        guard buttons.count != items.count else {
+    private func ensureButtons(for items: [PacketQuickFilterItem], customItems: [PacketCustomFilterItem]) {
+        let nextQuickFilterIDs = items.map(\.id)
+        let nextCustomFilterSignatures = customItems.map {
+            PacketCustomFilterButtonSignature(id: $0.id, title: $0.title)
+        }
+        guard renderedQuickFilterIDs != nextQuickFilterIDs ||
+                renderedCustomFilterSignatures != nextCustomFilterSignatures else {
             return
         }
 
@@ -134,6 +194,9 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
             view.removeFromSuperview()
         }
         buttons.removeAll(keepingCapacity: true)
+        customButtons.removeAll(keepingCapacity: true)
+        renderedQuickFilterIDs = nextQuickFilterIDs
+        renderedCustomFilterSignatures = nextCustomFilterSignatures
 
         for item in items {
             let button = PacketQuickFilterButton(filterID: item.id, target: self, action: #selector(toggleFilter(_:)))
@@ -142,6 +205,26 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
             stackView.addArrangedSubview(button)
             button.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight).isActive = true
             button.widthAnchor.constraint(greaterThanOrEqualToConstant: measuredWidth(for: item.title)).isActive = true
+        }
+
+        if !customItems.isEmpty {
+            stackView.addArrangedSubview(customSeparator)
+            for item in customItems {
+                let button = PacketCustomFilterButton(
+                    filterID: item.id,
+                    title: item.title,
+                    target: self,
+                    action: #selector(applyCustomFilter(_:))
+                )
+                button.rightClickHandler = { [weak self] button, event in
+                    self?.showCustomFilterMenu(for: button, event: event)
+                }
+                configure(button: button, isToggle: true)
+                customButtons[item.id] = button
+                stackView.addArrangedSubview(button)
+                button.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight).isActive = true
+                button.widthAnchor.constraint(greaterThanOrEqualToConstant: measuredWidth(for: item.title)).isActive = true
+            }
         }
 
         stackView.addArrangedSubview(resetSeparator)
@@ -191,7 +274,103 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
         delegate?.packetQuickFilterViewController(self, didToggle: sender.filterID)
     }
 
+    @objc private func applyCustomFilter(_ sender: NSButton) {
+        guard let sender = sender as? PacketCustomFilterButton else {
+            return
+        }
+
+        delegate?.packetQuickFilterViewController(self, didApplyCustomFilter: sender.filterID)
+    }
+
     @objc private func resetFilters(_ sender: NSButton) {
         delegate?.packetQuickFilterViewControllerDidRequestReset(self)
+    }
+
+    // Build the per-custom-filter context menu from the current snapshot item.
+    private func showCustomFilterMenu(for button: PacketCustomFilterButton, event: NSEvent) {
+        guard let item = customItemsByID[button.filterID] else {
+            return
+        }
+
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let renameItem = NSMenuItem(title: "Rename", action: #selector(renameCustomFilter(_:)), keyEquivalent: "")
+        renameItem.target = self
+        renameItem.representedObject = item.id
+        menu.addItem(renameItem)
+
+        let deleteItem = NSMenuItem(title: "Delete", action: #selector(deleteCustomFilter(_:)), keyEquivalent: "\u{8}")
+        deleteItem.target = self
+        deleteItem.representedObject = item.id
+        deleteItem.image = NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete")
+        menu.addItem(deleteItem)
+
+        NSMenu.popUpContextMenu(menu, with: event, for: button)
+    }
+
+    @objc private func renameCustomFilter(_ sender: NSMenuItem) {
+        guard let filterID = sender.representedObject as? PacketCustomFilter.ID,
+              let item = customItemsByID[filterID],
+              let name = requestCustomFilterName(initialName: item.title) else {
+            return
+        }
+
+        delegate?.packetQuickFilterViewController(self, didRenameCustomFilter: filterID, name: name)
+    }
+
+    @objc private func deleteCustomFilter(_ sender: NSMenuItem) {
+        guard let filterID = sender.representedObject as? PacketCustomFilter.ID,
+              let item = customItemsByID[filterID],
+              confirmDeleteCustomFilter(named: item.title) else {
+            return
+        }
+
+        delegate?.packetQuickFilterViewController(self, didDeleteCustomFilter: filterID)
+    }
+
+    // Ask for a new custom filter name and trim it before handing it to the model layer.
+    private func requestCustomFilterName(initialName: String) -> String? {
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+        textField.stringValue = initialName
+
+        let alert = NSAlert()
+        alert.messageText = "Rename Custom Filter"
+        alert.informativeText = "Enter a new name for this custom filter."
+        alert.alertStyle = .informational
+        alert.accessoryView = textField
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return nil
+        }
+
+        do {
+            return try PacketCustomFilterService.normalizedName(textField.stringValue)
+        } catch {
+            showCustomFilterNameValidationError(error)
+            return nil
+        }
+    }
+
+    // Confirm deletion because custom filters are persisted user settings.
+    private func confirmDeleteCustomFilter(named name: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Delete Custom Filter?"
+        alert.informativeText = "This removes \"\(name)\" from the quick filter bar."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    // Show validation feedback before dispatching a rename action.
+    private func showCustomFilterNameValidationError(_ error: Error) {
+        let alert = NSAlert()
+        alert.messageText = "Invalid Filter Name"
+        alert.informativeText = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
@@ -14,6 +14,11 @@ protocol PacketStructuredFilterViewControllerDelegate: AnyObject {
         didRequestSaveCustomFilterNamed name: String,
         group: PacketStructuredFilterGroup
     )
+    func packetStructuredFilterViewController(
+        _ controller: PacketStructuredFilterViewController,
+        didRequestOverrideCustomFilter filterID: PacketCustomFilter.ID,
+        group: PacketStructuredFilterGroup
+    )
     func packetStructuredFilterViewControllerCanAddFilter(_ controller: PacketStructuredFilterViewController) -> Bool
     func packetStructuredFilterViewControllerCanSaveCustomFilter(_ controller: PacketStructuredFilterViewController) -> Bool
     func packetStructuredFilterViewControllerDidRequestPaywall(_ controller: PacketStructuredFilterViewController)
@@ -398,7 +403,6 @@ final class PacketStructuredFilterViewController: NSViewController {
 
     private let rootStack = NSStackView()
     private let rowStack = NSStackView()
-    private let saveStack = NSStackView()
     private let footerStack = NSStackView()
     private let operatorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let saveButton = NSButton(title: "Save", target: nil, action: nil)
@@ -408,6 +412,8 @@ final class PacketStructuredFilterViewController: NSViewController {
     private var isFiltering = false
     private var pendingTextChanges: [PacketStructuredFilter.ID: String] = [:]
     private var pendingTextChangeWorkItem: DispatchWorkItem?
+    private var customFilterItems: [PacketCustomFilterItem] = []
+    private var saveMenuGroup: PacketStructuredFilterGroup?
 
     deinit {
         pendingTextChangeWorkItem?.cancel()
@@ -421,10 +427,15 @@ final class PacketStructuredFilterViewController: NSViewController {
         rebuildRows()
     }
 
-    func render(group: PacketStructuredFilterGroup, isFiltering: Bool) {
+    func render(
+        group: PacketStructuredFilterGroup,
+        isFiltering: Bool,
+        customFilterItems: [PacketCustomFilterItem]
+    ) {
         let normalizedGroup = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
         let rebuildsRows = normalizedGroup != self.group
         let rebuildsFooter = isFiltering != self.isFiltering
+        self.customFilterItems = customFilterItems
         self.isFiltering = isFiltering
 
         guard rebuildsRows || rebuildsFooter else {
@@ -467,11 +478,6 @@ final class PacketStructuredFilterViewController: NSViewController {
         rowStack.spacing = 4
         rowStack.translatesAutoresizingMaskIntoConstraints = false
 
-        saveStack.orientation = .horizontal
-        saveStack.alignment = .centerY
-        saveStack.spacing = 0
-        saveStack.translatesAutoresizingMaskIntoConstraints = false
-
         footerStack.orientation = .horizontal
         footerStack.alignment = .centerY
         footerStack.spacing = 18
@@ -484,7 +490,6 @@ final class PacketStructuredFilterViewController: NSViewController {
         view.addSubview(rootStack)
         view.addSubview(bottomSeparator)
         rootStack.addArrangedSubview(rowStack)
-        rootStack.addArrangedSubview(saveStack)
         rootStack.addArrangedSubview(footerStack)
 
         NSLayoutConstraint.activate([
@@ -493,8 +498,7 @@ final class PacketStructuredFilterViewController: NSViewController {
             rootStack.topAnchor.constraint(equalTo: view.topAnchor),
             rootStack.bottomAnchor.constraint(equalTo: bottomSeparator.topAnchor),
             rowStack.widthAnchor.constraint(equalTo: rootStack.widthAnchor, constant: -(Metrics.horizontalInset * 2)),
-            saveStack.widthAnchor.constraint(equalTo: rowStack.widthAnchor),
-            footerStack.widthAnchor.constraint(lessThanOrEqualTo: rootStack.widthAnchor, constant: -(Metrics.horizontalInset * 2)),
+            footerStack.widthAnchor.constraint(equalTo: rowStack.widthAnchor),
             bottomSeparator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomSeparator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomSeparator.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -519,16 +523,11 @@ final class PacketStructuredFilterViewController: NSViewController {
     // Configure the custom-filter save command independently from row add/remove buttons.
     private func configureSaveButton() {
         saveButton.target = self
-        saveButton.action = #selector(saveCustomFilter(_:))
+        saveButton.action = #selector(showSaveCustomFilterMenu(_:))
         saveButton.bezelStyle = .rounded
         saveButton.controlSize = .small
         saveButton.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
         saveButton.toolTip = "Save the current structured filter as a custom filter."
-
-        let spacer = NSView()
-        spacer.translatesAutoresizingMaskIntoConstraints = false
-        saveStack.addArrangedSubview(spacer)
-        saveStack.addArrangedSubview(saveButton)
         NSLayoutConstraint.activate([
             saveButton.heightAnchor.constraint(equalToConstant: 24),
             saveButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 68),
@@ -569,6 +568,14 @@ final class PacketStructuredFilterViewController: NSViewController {
             )
             footerStack.addArrangedSubview(label)
         }
+
+        // Push Save to the trailing edge while keeping shortcut hints on the same footer row.
+        let trailingSpacer = NSView()
+        trailingSpacer.translatesAutoresizingMaskIntoConstraints = false
+        trailingSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        trailingSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        footerStack.addArrangedSubview(trailingSpacer)
+        footerStack.addArrangedSubview(saveButton)
     }
 
     // Build the small inline loader that sits before the shortcut hints.
@@ -853,7 +860,7 @@ final class PacketStructuredFilterViewController: NSViewController {
         apply(currentGroup.updatingOperator(nextOperator))
     }
 
-    @objc private func saveCustomFilter(_ sender: Any?) {
+    @objc private func showSaveCustomFilterMenu(_ sender: Any?) {
         let currentGroup = consumePendingTextChange()
         if currentGroup != group {
             apply(currentGroup)
@@ -864,11 +871,59 @@ final class PacketStructuredFilterViewController: NSViewController {
             return
         }
 
+        saveMenuGroup = currentGroup
+        let menu = makeSaveCustomFilterMenu()
+        let button = (sender as? NSButton) ?? saveButton
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 4), in: button)
+    }
+
+    private func makeSaveCustomFilterMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let newFilterItem = NSMenuItem(title: "New Filter...", action: #selector(saveNewCustomFilter(_:)), keyEquivalent: "")
+        newFilterItem.target = self
+        menu.addItem(newFilterItem)
+        menu.addItem(.separator())
+
+        let overrideItem = NSMenuItem(title: "Override", action: nil, keyEquivalent: "")
+        let overrideMenu = NSMenu()
+        if customFilterItems.isEmpty {
+            let emptyItem = NSMenuItem(title: "No filters", action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            overrideMenu.addItem(emptyItem)
+        } else {
+            customFilterItems.forEach { customItem in
+                let menuItem = NSMenuItem(title: customItem.title, action: #selector(overrideCustomFilter(_:)), keyEquivalent: "")
+                menuItem.target = self
+                menuItem.representedObject = customItem.id
+                overrideMenu.addItem(menuItem)
+            }
+        }
+        menu.addItem(overrideItem)
+        menu.setSubmenu(overrideMenu, for: overrideItem)
+        return menu
+    }
+
+    @objc private func saveNewCustomFilter(_ sender: Any?) {
+        let currentGroup = saveMenuGroup ?? group
         guard let name = requestCustomFilterName() else {
             return
         }
 
         delegate?.packetStructuredFilterViewController(self, didRequestSaveCustomFilterNamed: name, group: currentGroup)
+    }
+
+    @objc private func overrideCustomFilter(_ sender: NSMenuItem) {
+        guard let filterID = sender.representedObject as? PacketCustomFilter.ID else {
+            return
+        }
+
+        delegate?.packetStructuredFilterViewController(
+            self,
+            didRequestOverrideCustomFilter: filterID,
+            group: saveMenuGroup ?? group
+        )
     }
 
     // Ask for a custom filter name and normalize it before saving.

--- a/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
@@ -9,7 +9,13 @@ import AppKit
 
 protocol PacketStructuredFilterViewControllerDelegate: AnyObject {
     func packetStructuredFilterViewController(_ controller: PacketStructuredFilterViewController, didUpdate group: PacketStructuredFilterGroup)
+    func packetStructuredFilterViewController(
+        _ controller: PacketStructuredFilterViewController,
+        didRequestSaveCustomFilterNamed name: String,
+        group: PacketStructuredFilterGroup
+    )
     func packetStructuredFilterViewControllerCanAddFilter(_ controller: PacketStructuredFilterViewController) -> Bool
+    func packetStructuredFilterViewControllerCanSaveCustomFilter(_ controller: PacketStructuredFilterViewController) -> Bool
     func packetStructuredFilterViewControllerDidRequestPaywall(_ controller: PacketStructuredFilterViewController)
     func packetStructuredFilterViewControllerDidRequestHide(_ controller: PacketStructuredFilterViewController)
 }
@@ -392,8 +398,10 @@ final class PacketStructuredFilterViewController: NSViewController {
 
     private let rootStack = NSStackView()
     private let rowStack = NSStackView()
+    private let saveStack = NSStackView()
     private let footerStack = NSStackView()
     private let operatorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+    private let saveButton = NSButton(title: "Save", target: nil, action: nil)
     private let bottomSeparator = TCPViewerUI.separator()
     private var rowViews: [PacketStructuredFilterRowView] = []
     private var group = PacketStructuredFilterGroup.default
@@ -459,17 +467,24 @@ final class PacketStructuredFilterViewController: NSViewController {
         rowStack.spacing = 4
         rowStack.translatesAutoresizingMaskIntoConstraints = false
 
+        saveStack.orientation = .horizontal
+        saveStack.alignment = .centerY
+        saveStack.spacing = 0
+        saveStack.translatesAutoresizingMaskIntoConstraints = false
+
         footerStack.orientation = .horizontal
         footerStack.alignment = .centerY
         footerStack.spacing = 18
         footerStack.translatesAutoresizingMaskIntoConstraints = false
 
         configureOperatorPopup()
+        configureSaveButton()
         rebuildFooter()
 
         view.addSubview(rootStack)
         view.addSubview(bottomSeparator)
         rootStack.addArrangedSubview(rowStack)
+        rootStack.addArrangedSubview(saveStack)
         rootStack.addArrangedSubview(footerStack)
 
         NSLayoutConstraint.activate([
@@ -478,6 +493,7 @@ final class PacketStructuredFilterViewController: NSViewController {
             rootStack.topAnchor.constraint(equalTo: view.topAnchor),
             rootStack.bottomAnchor.constraint(equalTo: bottomSeparator.topAnchor),
             rowStack.widthAnchor.constraint(equalTo: rootStack.widthAnchor, constant: -(Metrics.horizontalInset * 2)),
+            saveStack.widthAnchor.constraint(equalTo: rowStack.widthAnchor),
             footerStack.widthAnchor.constraint(lessThanOrEqualTo: rootStack.widthAnchor, constant: -(Metrics.horizontalInset * 2)),
             bottomSeparator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomSeparator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -498,6 +514,25 @@ final class PacketStructuredFilterViewController: NSViewController {
             item?.toolTip = filterOperator.menuToolTip
         }
         operatorPopup.widthAnchor.constraint(equalToConstant: Metrics.operatorWidth).isActive = true
+    }
+
+    // Configure the custom-filter save command independently from row add/remove buttons.
+    private func configureSaveButton() {
+        saveButton.target = self
+        saveButton.action = #selector(saveCustomFilter(_:))
+        saveButton.bezelStyle = .rounded
+        saveButton.controlSize = .small
+        saveButton.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
+        saveButton.toolTip = "Save the current structured filter as a custom filter."
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        saveStack.addArrangedSubview(spacer)
+        saveStack.addArrangedSubview(saveButton)
+        NSLayoutConstraint.activate([
+            saveButton.heightAnchor.constraint(equalToConstant: 24),
+            saveButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 68),
+        ])
     }
 
     private func rebuildFooter() {
@@ -816,6 +851,59 @@ final class PacketStructuredFilterViewController: NSViewController {
 
         let currentGroup = consumePendingTextChange()
         apply(currentGroup.updatingOperator(nextOperator))
+    }
+
+    @objc private func saveCustomFilter(_ sender: Any?) {
+        let currentGroup = consumePendingTextChange()
+        if currentGroup != group {
+            apply(currentGroup)
+        }
+
+        guard delegate?.packetStructuredFilterViewControllerCanSaveCustomFilter(self) ?? true else {
+            delegate?.packetStructuredFilterViewControllerDidRequestPaywall(self)
+            return
+        }
+
+        guard let name = requestCustomFilterName() else {
+            return
+        }
+
+        delegate?.packetStructuredFilterViewController(self, didRequestSaveCustomFilterNamed: name, group: currentGroup)
+    }
+
+    // Ask for a custom filter name and normalize it before saving.
+    private func requestCustomFilterName() -> String? {
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 260, height: 24))
+        textField.placeholderString = "Custom filter name"
+
+        let alert = NSAlert()
+        alert.messageText = "Save Custom Filter"
+        alert.informativeText = "Enter a name for this custom filter."
+        alert.alertStyle = .informational
+        alert.accessoryView = textField
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return nil
+        }
+
+        do {
+            return try PacketCustomFilterService.normalizedName(textField.stringValue)
+        } catch {
+            showCustomFilterNameValidationError(error)
+            return nil
+        }
+    }
+
+    // Show validation feedback close to the Save action without touching persisted filters.
+    private func showCustomFilterNameValidationError(_ error: Error) {
+        let alert = NSAlert()
+        alert.messageText = "Invalid Filter Name"
+        alert.informativeText = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -19,6 +19,11 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didUpdateStructuredFilterGroup group: PacketStructuredFilterGroup)
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSaveCustomFilterNamed name: String, group: PacketStructuredFilterGroup)
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestOverrideCustomFilter filterID: PacketCustomFilter.ID,
+        group: PacketStructuredFilterGroup
+    )
     func packetWorkspaceViewControllerDidRequestResetQuickFilters(_ controller: PacketWorkspaceViewController)
     func packetWorkspaceViewControllerCanAddStructuredFilter(_ controller: PacketWorkspaceViewController) -> Bool
     func packetWorkspaceViewControllerCanSaveCustomFilter(_ controller: PacketWorkspaceViewController) -> Bool
@@ -130,7 +135,11 @@ final class PacketWorkspaceViewController: NSViewController {
     // Render the packet workspace and swap between the table and empty state as needed.
     func render(snapshot: NetworkInspectorSnapshot) {
         viewModel.render(snapshot: snapshot)
-        structuredFilterController.render(group: snapshot.structuredFilterGroup, isFiltering: snapshot.isPacketTableFiltering)
+        structuredFilterController.render(
+            group: snapshot.structuredFilterGroup,
+            isFiltering: snapshot.isPacketTableFiltering,
+            customFilterItems: snapshot.customFilterItems
+        )
         applyStructuredFilterVisibility(snapshot.isStructuredFilterVisible)
 
         if viewModel.isEmpty {
@@ -386,6 +395,14 @@ extension PacketWorkspaceViewController: PacketStructuredFilterViewControllerDel
         group: PacketStructuredFilterGroup
     ) {
         delegate?.packetWorkspaceViewController(self, didRequestSaveCustomFilterNamed: name, group: group)
+    }
+
+    func packetStructuredFilterViewController(
+        _ controller: PacketStructuredFilterViewController,
+        didRequestOverrideCustomFilter filterID: PacketCustomFilter.ID,
+        group: PacketStructuredFilterGroup
+    ) {
+        delegate?.packetWorkspaceViewController(self, didRequestOverrideCustomFilter: filterID, group: group)
     }
 
     func packetStructuredFilterViewControllerCanAddFilter(_ controller: PacketStructuredFilterViewController) -> Bool {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -51,7 +51,7 @@ final class PacketWorkspaceViewModel {
     private(set) var emptyMessage = "Start a live capture or open a pcap/pcapng file."
     private(set) var emptyImageName = "list.bullet.rectangle"
     private(set) var showsResetFiltersButton = false
-    private(set) var quickFilterLabels: [String] = []
+    private(set) var activeFilterLabels: [String] = []
 
     // Convert the root snapshot into packet-workspace-only render data.
     func render(snapshot: NetworkInspectorSnapshot) {
@@ -60,16 +60,16 @@ final class PacketWorkspaceViewModel {
         chips = snapshot.displayFilterChips
         isEmpty = snapshot.packetRows.isEmpty
         showsResetFiltersButton = isEmpty && snapshot.isQuickFilterActive
-        quickFilterLabels = showsResetFiltersButton ? snapshot.quickFilterSelection.activeLabels : []
+        activeFilterLabels = isEmpty ? snapshot.activeFilterBarLabels : []
 
         if snapshot.isPacketTableFiltering && isEmpty {
             showsResetFiltersButton = false
-            quickFilterLabels = []
+            activeFilterLabels = []
         }
 
-        if showsResetFiltersButton {
+        if !activeFilterLabels.isEmpty {
             emptyTitle = "No Matching Packets"
-            emptyMessage = "Filtered by quick filters"
+            emptyMessage = "Filtered by selected filters"
             emptyImageName = "line.3.horizontal.decrease.circle"
             return
         }
@@ -148,7 +148,7 @@ final class PacketWorkspaceViewController: NSViewController {
                 message: viewModel.emptyMessage,
                 imageName: viewModel.emptyImageName,
                 showsResetFiltersButton: viewModel.showsResetFiltersButton,
-                quickFilterLabels: viewModel.quickFilterLabels
+                activeFilterLabels: viewModel.activeFilterLabels
             )
         } else {
             showTable()
@@ -209,7 +209,7 @@ final class PacketWorkspaceViewController: NSViewController {
         message: String,
         imageName: String,
         showsResetFiltersButton: Bool,
-        quickFilterLabels: [String]
+        activeFilterLabels: [String]
     ) {
         if tableController.view.superview != nil {
             tableController.view.removeFromSuperview()
@@ -221,7 +221,7 @@ final class PacketWorkspaceViewController: NSViewController {
             imageName: imageName,
             message: message,
             showsResetFiltersButton: showsResetFiltersButton,
-            quickFilterLabels: quickFilterLabels
+            activeFilterLabels: activeFilterLabels
         )
         TCPViewerUI.pin(placeholder, to: contentContainer)
         placeholderView = placeholder
@@ -232,7 +232,7 @@ final class PacketWorkspaceViewController: NSViewController {
         imageName: String,
         message: String,
         showsResetFiltersButton: Bool,
-        quickFilterLabels: [String]
+        activeFilterLabels: [String]
     ) -> NSView {
         let imageView = NSImageView(image: TCPViewerUI.image(imageName) ?? NSImage())
         imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 42, weight: .regular)
@@ -243,14 +243,14 @@ final class PacketWorkspaceViewController: NSViewController {
 
         let messageView: NSView
         let messageWidthConstraint: NSLayoutConstraint?
-        if quickFilterLabels.isEmpty {
+        if activeFilterLabels.isEmpty {
             let messageLabel = TCPViewerUI.label(message, font: .systemFont(ofSize: NSFont.systemFontSize), color: .secondaryLabelColor)
             messageLabel.alignment = .center
             messageLabel.maximumNumberOfLines = 3
             messageView = messageLabel
             messageWidthConstraint = messageLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 420)
         } else {
-            messageView = makeQuickFilterMessage(labels: quickFilterLabels)
+            messageView = makeFilterMessage(labels: activeFilterLabels)
             messageWidthConstraint = nil
         }
 
@@ -283,7 +283,7 @@ final class PacketWorkspaceViewController: NSViewController {
         return container
     }
 
-    private func makeQuickFilterMessage(labels: [String]) -> NSView {
+    private func makeFilterMessage(labels: [String]) -> NSView {
         let prefixLabel = TCPViewerUI.label(
             "Filtered by",
             font: .systemFont(ofSize: NSFont.systemFontSize),
@@ -291,9 +291,9 @@ final class PacketWorkspaceViewController: NSViewController {
         )
 
         let visibleLabels = Array(labels.prefix(4))
-        var views: [NSView] = [prefixLabel] + visibleLabels.map(makeQuickFilterChip(title:))
+        var views: [NSView] = [prefixLabel] + visibleLabels.map(makeFilterChip(title:))
         if labels.count > visibleLabels.count {
-            views.append(makeQuickFilterChip(title: "+\(labels.count - visibleLabels.count)"))
+            views.append(makeFilterChip(title: "+\(labels.count - visibleLabels.count)"))
         }
 
         let stack = NSStackView(views: views)
@@ -303,7 +303,7 @@ final class PacketWorkspaceViewController: NSViewController {
         return stack
     }
 
-    private func makeQuickFilterChip(title: String) -> NSView {
+    private func makeFilterChip(title: String) -> NSView {
         let font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium)
         let label = TCPViewerUI.label(title, font: font)
         label.cell = VerticallyCenteredTextFieldCell(textCell: title)

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -18,8 +18,10 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didUpdateStructuredFilterGroup group: PacketStructuredFilterGroup)
+    func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSaveCustomFilterNamed name: String, group: PacketStructuredFilterGroup)
     func packetWorkspaceViewControllerDidRequestResetQuickFilters(_ controller: PacketWorkspaceViewController)
     func packetWorkspaceViewControllerCanAddStructuredFilter(_ controller: PacketWorkspaceViewController) -> Bool
+    func packetWorkspaceViewControllerCanSaveCustomFilter(_ controller: PacketWorkspaceViewController) -> Bool
     func packetWorkspaceViewControllerDidRequestStructuredFilterPaywall(_ controller: PacketWorkspaceViewController)
     func packetWorkspaceViewControllerDidRequestHideStructuredFilter(_ controller: PacketWorkspaceViewController)
 }
@@ -378,8 +380,20 @@ extension PacketWorkspaceViewController: PacketStructuredFilterViewControllerDel
         delegate?.packetWorkspaceViewController(self, didUpdateStructuredFilterGroup: group)
     }
 
+    func packetStructuredFilterViewController(
+        _ controller: PacketStructuredFilterViewController,
+        didRequestSaveCustomFilterNamed name: String,
+        group: PacketStructuredFilterGroup
+    ) {
+        delegate?.packetWorkspaceViewController(self, didRequestSaveCustomFilterNamed: name, group: group)
+    }
+
     func packetStructuredFilterViewControllerCanAddFilter(_ controller: PacketStructuredFilterViewController) -> Bool {
         delegate?.packetWorkspaceViewControllerCanAddStructuredFilter(self) ?? true
+    }
+
+    func packetStructuredFilterViewControllerCanSaveCustomFilter(_ controller: PacketStructuredFilterViewController) -> Bool {
+        delegate?.packetWorkspaceViewControllerCanSaveCustomFilter(self) ?? true
     }
 
     func packetStructuredFilterViewControllerDidRequestPaywall(_ controller: PacketStructuredFilterViewController) {

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -117,9 +117,19 @@ private protocol SidebarOutlineKeyboardActionHandling: AnyObject {
 
 private final class SidebarOutlineView: NSOutlineView {
     weak var keyboardActionHandler: SidebarOutlineKeyboardActionHandling?
+    var suppressesProgrammaticScrollToSelection = false
 
     @objc func delete(_ sender: Any?) {
         keyboardActionHandler?.sidebarOutlineViewDidRequestDeleteFromKeyboard(self)
+    }
+
+    override func scrollRowToVisible(_ row: Int) {
+        // Avoid reload-driven selection sync from pulling a scrolled sidebar back to the selected row.
+        guard !suppressesProgrammaticScrollToSelection else {
+            return
+        }
+
+        super.scrollRowToVisible(row)
     }
 
     override func keyDown(with event: NSEvent) {
@@ -202,6 +212,17 @@ private final class SidebarViewModel {
     }
 }
 
+private struct SidebarOutlineViewport {
+    let origin: NSPoint
+    let anchorItemID: String?
+    let anchorOffsetY: CGFloat
+}
+
+private struct SidebarOutlineState {
+    let viewport: SidebarOutlineViewport
+    let selectedItemIDs: [String]
+}
+
 final class SidebarViewController: NSViewController {
     private static let batchedReloadInterval: TimeInterval = 0.5
 
@@ -222,6 +243,7 @@ final class SidebarViewController: NSViewController {
     private var isSyncingSelection = false
     private var isSyncingFilter = false
     private var contextMenuItemID: String?
+    private var outlineReloadGeneration = 0
 
     deinit {
         pendingReloadWorkItem?.cancel()
@@ -249,19 +271,40 @@ final class SidebarViewController: NSViewController {
     }
 
     private func apply(state: SidebarOutlineReloadState) {
+        outlineReloadGeneration += 1
+        let reloadGeneration = outlineReloadGeneration
+        let shouldPreserveOutlineState = shouldPreserveOutlineState(for: state)
+        let preservedOutlineState = shouldPreserveOutlineState ? captureOutlineState() : nil
         if hasRenderedOutline, viewModel.filterText.isEmpty {
             captureExpandedItemIDs()
         }
 
-        let preservedScrollOrigin = outlineScrollOrigin()
+        isSyncingSelection = true
         viewModel.render(state: state)
         syncSearchField(state.filterText)
         outlineView.reloadData()
         restoreExpandedItems(expandAll: !viewModel.filterText.isEmpty)
-        syncSelection()
-        restoreOutlineScrollOrigin(preservedScrollOrigin)
+        if let preservedOutlineState {
+            restoreOutlineState(preservedOutlineState)
+        } else {
+            syncSelection()
+        }
         appliedReloadState = state
         hasRenderedOutline = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  self.outlineReloadGeneration == reloadGeneration,
+                  self.appliedReloadState == state else {
+                return
+            }
+
+            if let preservedOutlineState {
+                self.restoreOutlineState(preservedOutlineState)
+            } else {
+                self.syncSelection()
+            }
+            self.isSyncingSelection = false
+        }
     }
 
     private func scheduleBatchedReload(state: SidebarOutlineReloadState) {
@@ -372,14 +415,100 @@ final class SidebarViewController: NSViewController {
         }
     }
 
-    private func outlineScrollOrigin() -> NSPoint {
-        scrollView.contentView.bounds.origin
+    private func shouldPreserveOutlineState(for state: SidebarOutlineReloadState) -> Bool {
+        guard hasRenderedOutline,
+              let appliedReloadState else {
+            return false
+        }
+
+        // Preserve the user's outline position only for source data refreshes, not filter or selection changes.
+        return appliedReloadState.filterText == state.filterText &&
+            appliedReloadState.selectedSelection == state.selectedSelection
+    }
+
+    private func captureOutlineState() -> SidebarOutlineState {
+        SidebarOutlineState(
+            viewport: captureOutlineViewport(),
+            selectedItemIDs: selectedOutlineItemIDs()
+        )
+    }
+
+    private func captureOutlineViewport() -> SidebarOutlineViewport {
+        let visibleBounds = scrollView.contentView.bounds
+        let visibleRows = outlineView.rows(in: visibleBounds)
+        guard visibleRows.location != NSNotFound,
+              visibleRows.length > 0,
+              let item = outlineView.item(atRow: visibleRows.location) as? SidebarOutlineItem else {
+            return SidebarOutlineViewport(origin: visibleBounds.origin, anchorItemID: nil, anchorOffsetY: 0)
+        }
+
+        let anchorRect = outlineView.rect(ofRow: visibleRows.location)
+        return SidebarOutlineViewport(
+            origin: visibleBounds.origin,
+            anchorItemID: item.sourceItem.id,
+            anchorOffsetY: visibleBounds.origin.y - anchorRect.minY
+        )
+    }
+
+    private func selectedOutlineItemIDs() -> [String] {
+        outlineView.selectedRowIndexes.compactMap { row in
+            guard row >= 0,
+                  let item = outlineView.item(atRow: row) as? SidebarOutlineItem else {
+                return nil
+            }
+
+            return item.sourceItem.id
+        }
+    }
+
+    private func restoreOutlineState(_ state: SidebarOutlineState) {
+        restoreSelectedOutlineItemIDs(state.selectedItemIDs)
+        restoreOutlineViewport(state.viewport)
+    }
+
+    private func restoreSelectedOutlineItemIDs(_ itemIDs: [String]) {
+        let rows = itemIDs.compactMap { itemID -> Int? in
+            guard let item = viewModel.item(withID: itemID) else {
+                return nil
+            }
+
+            let row = outlineView.row(forItem: item)
+            return row >= 0 ? row : nil
+        }
+
+        guard !rows.isEmpty else {
+            syncSelection()
+            return
+        }
+
+        selectOutlineRows(IndexSet(rows))
+    }
+
+    private func restoreOutlineViewport(_ viewport: SidebarOutlineViewport) {
+        guard let anchorItemID = viewport.anchorItemID,
+              let anchorItem = viewModel.item(withID: anchorItemID) else {
+            restoreOutlineScrollOrigin(viewport.origin)
+            return
+        }
+
+        let row = outlineView.row(forItem: anchorItem)
+        guard row >= 0 else {
+            restoreOutlineScrollOrigin(viewport.origin)
+            return
+        }
+
+        let anchorRect = outlineView.rect(ofRow: row)
+        restoreOutlineScrollOrigin(NSPoint(
+            x: viewport.origin.x,
+            y: anchorRect.minY + viewport.anchorOffsetY
+        ))
     }
 
     // Put the sidebar viewport back where it was, clamped to the new content height.
-    private func restoreOutlineScrollOrigin(_ origin: NSPoint) {
+    @discardableResult
+    private func restoreOutlineScrollOrigin(_ origin: NSPoint) -> NSPoint {
         guard let documentView = scrollView.documentView else {
-            return
+            return origin
         }
 
         scrollView.layoutSubtreeIfNeeded()
@@ -394,14 +523,10 @@ final class SidebarViewController: NSViewController {
         )
         clipView.scroll(to: clampedOrigin)
         scrollView.reflectScrolledClipView(clipView)
+        return clampedOrigin
     }
 
     private func syncSelection() {
-        isSyncingSelection = true
-        defer {
-            isSyncingSelection = false
-        }
-
         guard viewModel.selectedSelection != .allPackets,
               let selectedItem = viewModel.item(for: viewModel.selectedSelection) else {
             outlineView.deselectAll(nil)
@@ -410,10 +535,18 @@ final class SidebarViewController: NSViewController {
 
         let row = outlineView.row(forItem: selectedItem)
         if row >= 0 {
-            outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+            selectOutlineRows(IndexSet(integer: row))
         } else {
             outlineView.deselectAll(nil)
         }
+    }
+
+    private func selectOutlineRows(_ rows: IndexSet) {
+        outlineView.suppressesProgrammaticScrollToSelection = true
+        defer {
+            outlineView.suppressesProgrammaticScrollToSelection = false
+        }
+        outlineView.selectRowIndexes(rows, byExtendingSelection: false)
     }
 
     private func syncSearchField(_ filterText: String) {

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -123,6 +123,26 @@ final class TCPViewerRootViewController: NSViewController {
         viewModel.toggleQuickFilter(filterID)
     }
 
+    func applyCustomFilter(_ filterID: PacketCustomFilter.ID) {
+        viewModel.applyCustomFilter(id: filterID)
+    }
+
+    func renameCustomFilter(_ filterID: PacketCustomFilter.ID, name: String) {
+        do {
+            try viewModel.renameCustomFilter(id: filterID, name: name)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Rename Filter")
+        }
+    }
+
+    func deleteCustomFilter(_ filterID: PacketCustomFilter.ID) {
+        do {
+            try viewModel.deleteCustomFilter(id: filterID)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Delete Filter")
+        }
+    }
+
     func resetQuickFilters() {
         viewModel.resetQuickFilters()
     }
@@ -746,11 +766,27 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         viewModel.updateStructuredFilterGroup(group)
     }
 
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestSaveCustomFilterNamed name: String,
+        group: PacketStructuredFilterGroup
+    ) {
+        do {
+            try viewModel.saveCustomFilter(name: name, group: group)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Save Filter")
+        }
+    }
+
     func packetWorkspaceViewControllerDidRequestResetQuickFilters(_ controller: PacketWorkspaceViewController) {
         viewModel.resetQuickFilters()
     }
 
     func packetWorkspaceViewControllerCanAddStructuredFilter(_ controller: PacketWorkspaceViewController) -> Bool {
+        TCPViewerLicenseService.shared.isLicenseAuthorized
+    }
+
+    func packetWorkspaceViewControllerCanSaveCustomFilter(_ controller: PacketWorkspaceViewController) -> Bool {
         TCPViewerLicenseService.shared.isLicenseAuthorized
     }
 
@@ -764,6 +800,20 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 
     fileprivate func canUsePinFeature() -> Bool {
         TCPViewerLicenseService.shared.isLicenseAuthorized
+    }
+
+    // Present persistence failures at the root so child controllers stay model-driven.
+    private func presentCustomFilterError(_ error: Error, title: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        if let window = view.window {
+            alert.beginSheetModal(for: window)
+        } else {
+            alert.runModal()
+        }
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -135,6 +135,22 @@ final class TCPViewerRootViewController: NSViewController {
         }
     }
 
+    func overrideCustomFilter(_ filterID: PacketCustomFilter.ID, group: PacketStructuredFilterGroup) {
+        do {
+            try viewModel.overrideCustomFilter(id: filterID, group: group)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Override Filter")
+        }
+    }
+
+    func duplicateCustomFilter(_ filterID: PacketCustomFilter.ID) {
+        do {
+            try viewModel.duplicateCustomFilter(id: filterID)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Duplicate Filter")
+        }
+    }
+
     func deleteCustomFilter(_ filterID: PacketCustomFilter.ID) {
         do {
             try viewModel.deleteCustomFilter(id: filterID)
@@ -776,6 +792,14 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         } catch {
             presentCustomFilterError(error, title: "Could Not Save Filter")
         }
+    }
+
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestOverrideCustomFilter filterID: PacketCustomFilter.ID,
+        group: PacketStructuredFilterGroup
+    ) {
+        overrideCustomFilter(filterID, group: group)
     }
 
     func packetWorkspaceViewControllerDidRequestResetQuickFilters(_ controller: PacketWorkspaceViewController) {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -2266,6 +2266,41 @@ struct NetworkInspectorViewModelTests {
         #expect(!viewModel.snapshot.isQuickFilterResetVisible)
     }
 
+    @Test func workspaceEmptyStateIncludesSelectedCustomFilterLabels() async throws {
+        let packet = makePacket(
+            packetNumber: 1,
+            source: .offline,
+            transportHint: .tls,
+            streamID: nil,
+            infoSummary: "TLS Client Hello",
+            layerNames: ["Ethernet", "TCP", "TLSv1.3"]
+        )
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let group = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .summary, condition: .contains, text: "abc")],
+            operator: .and
+        )
+        let savedFilter = try customFilterService.save(name: "abc", group: group)
+        let viewModel = makeOfflineViewModel(packets: [packet], customFilterService: customFilterService)
+
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/custom-filter-empty-state.pcapng"))
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == 1
+        }
+
+        viewModel.applyCustomFilter(id: savedFilter.id)
+        viewModel.toggleQuickFilter(.clientHello)
+
+        let workspaceViewModel = PacketWorkspaceViewModel()
+        workspaceViewModel.render(snapshot: viewModel.snapshot)
+
+        #expect(viewModel.snapshot.packetRows.isEmpty)
+        #expect(viewModel.snapshot.activeFilterBarLabels == ["Client Hello", "abc"])
+        #expect(workspaceViewModel.emptyTitle == "No Matching Packets")
+        #expect(workspaceViewModel.activeFilterLabels == ["Client Hello", "abc"])
+        #expect(workspaceViewModel.showsResetFiltersButton)
+    }
+
     @Test func structuredFiltersPersistAndRestoreThroughViewModel() {
         let defaults = isolatedDefaults()
         let group = PacketStructuredFilterGroup(

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -682,6 +682,99 @@ struct NetworkInspectorViewModelTests {
         #expect(!hiddenReloadedViewModel.snapshot.isStructuredFilterVisible)
     }
 
+    @Test func customFiltersLoadIntoInitialSnapshot() throws {
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let group = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .protocol, condition: .contains, text: "tcp")],
+            operator: .and
+        )
+        let savedFilter = try customFilterService.save(name: "TCP Preset", group: group)
+        let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
+            interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+        ))
+
+        let viewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: isolatedDefaults(),
+            pinService: PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json")),
+            savedPacketService: SavedPacketService(storageURL: temporaryDirectory().appendingPathComponent("Saved.json")),
+            customFilterService: customFilterService
+        )
+
+        #expect(viewModel.snapshot.customFilterItems == [
+            PacketCustomFilterItem(id: savedFilter.id, title: "TCP Preset", isSelected: false),
+        ])
+    }
+
+    @Test func applyingCustomFilterShowsStructuredFilterAndFiltersRows() async throws {
+        let tcpPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, layerNames: ["Ethernet", "TCP"])
+        let udpPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .udp, layerNames: ["Ethernet", "UDP"])
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let group = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .protocol, condition: .contains, text: "tcp")],
+            operator: .and
+        )
+        let savedFilter = try customFilterService.save(name: "TCP Only", group: group)
+        let viewModel = makeOfflineViewModel(packets: [tcpPacket, udpPacket], customFilterService: customFilterService)
+
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/custom-filter-apply.pcapng"))
+        await waitUntil {
+            viewModel.snapshot.packetRows.count == 2
+        }
+
+        viewModel.applyCustomFilter(id: savedFilter.id)
+
+        #expect(viewModel.snapshot.isStructuredFilterVisible)
+        #expect(viewModel.snapshot.structuredFilterGroup == group)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [tcpPacket.id])
+        #expect(viewModel.snapshot.customFilterItems.first?.isSelected == true)
+    }
+
+    @Test func savingCurrentStructuredFilterAddsSelectedCustomFilter() throws {
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let viewModel = makeOfflineViewModel(packets: [], customFilterService: customFilterService)
+        let group = PacketStructuredFilterGroup(
+            filters: [
+                PacketStructuredFilter(query: .summary, condition: .matchesRegex, text: "GET|POST", isEnabled: true),
+                PacketStructuredFilter(query: .destinationPort, condition: .greaterThanOrEqual, text: "443", isEnabled: false),
+            ],
+            operator: .or
+        )
+
+        viewModel.updateStructuredFilterGroup(group)
+        viewModel.setStructuredFilterVisible(true)
+        let savedFilter = try viewModel.saveCustomFilter(name: "  HTTP Methods  ", group: viewModel.snapshot.structuredFilterGroup)
+
+        #expect(customFilterService.filters().map(\.id) == [savedFilter.id])
+        #expect(viewModel.snapshot.customFilterItems == [
+            PacketCustomFilterItem(id: savedFilter.id, title: "HTTP Methods", isSelected: true),
+        ])
+    }
+
+    @Test func renamingAndDeletingCustomFilterRefreshesItemsWithoutChangingStructuredGroup() throws {
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let group = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .client, condition: .contains, text: "Safari")],
+            operator: .and
+        )
+        let savedFilter = try customFilterService.save(name: "Client", group: group)
+        let viewModel = makeOfflineViewModel(packets: [], customFilterService: customFilterService)
+
+        viewModel.applyCustomFilter(id: savedFilter.id)
+        try viewModel.renameCustomFilter(id: savedFilter.id, name: "  Browser  ")
+
+        #expect(viewModel.snapshot.structuredFilterGroup == group)
+        #expect(viewModel.snapshot.customFilterItems == [
+            PacketCustomFilterItem(id: savedFilter.id, title: "Browser", isSelected: true),
+        ])
+
+        try viewModel.deleteCustomFilter(id: savedFilter.id)
+
+        #expect(viewModel.snapshot.structuredFilterGroup == group)
+        #expect(viewModel.snapshot.customFilterItems.isEmpty)
+        #expect(viewModel.snapshot.isStructuredFilterVisible)
+    }
+
     @Test func sidebarThicknessPersistsAndFallsBackWhenInvalid() {
         let defaults = isolatedDefaults()
         let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
@@ -2439,7 +2532,8 @@ struct NetworkInspectorViewModelTests {
 
     private func makeOfflineViewModel(
         packets: [PacketSummary],
-        packetTableAsyncRebuildThreshold: Int = 5_000
+        packetTableAsyncRebuildThreshold: Int = 5_000,
+        customFilterService: PacketCustomFilterService? = nil
     ) -> NetworkInspectorViewModel {
         let openURL = URL(fileURLWithPath: "/tmp/source-list-fixture.pcapng")
         return NetworkInspectorViewModel(
@@ -2450,6 +2544,7 @@ struct NetworkInspectorViewModelTests {
             userDefaults: isolatedDefaults(),
             pinService: PacketPinService(storageURL: temporaryDirectory().appendingPathComponent("Pins.json")),
             savedPacketService: SavedPacketService(storageURL: temporaryDirectory().appendingPathComponent("Saved.json")),
+            customFilterService: customFilterService ?? PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json")),
             packetTableAsyncRebuildThreshold: packetTableAsyncRebuildThreshold
         )
     }

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -706,7 +706,7 @@ struct NetworkInspectorViewModelTests {
         ])
     }
 
-    @Test func applyingCustomFilterShowsStructuredFilterAndFiltersRows() async throws {
+    @Test func applyingCustomFilterTogglesStructuredFilterVisibilityAndRows() async throws {
         let tcpPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, layerNames: ["Ethernet", "TCP"])
         let udpPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .udp, layerNames: ["Ethernet", "UDP"])
         let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
@@ -728,6 +728,13 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.structuredFilterGroup == group)
         #expect(viewModel.snapshot.packetRows.map(\.id) == [tcpPacket.id])
         #expect(viewModel.snapshot.customFilterItems.first?.isSelected == true)
+
+        viewModel.applyCustomFilter(id: savedFilter.id)
+
+        #expect(!viewModel.snapshot.isStructuredFilterVisible)
+        #expect(viewModel.snapshot.structuredFilterGroup == group)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [tcpPacket.id, udpPacket.id])
+        #expect(viewModel.snapshot.customFilterItems.first?.isSelected == false)
     }
 
     @Test func savingCurrentStructuredFilterAddsSelectedCustomFilter() throws {
@@ -773,6 +780,53 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.structuredFilterGroup == group)
         #expect(viewModel.snapshot.customFilterItems.isEmpty)
         #expect(viewModel.snapshot.isStructuredFilterVisible)
+    }
+
+    @Test func overridingCustomFilterKeepsNameAndSelectsUpdatedGroup() throws {
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let originalGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .client, condition: .contains, text: "Safari")],
+            operator: .and
+        )
+        let replacementGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .summary, condition: .contains, text: "DNS")],
+            operator: .or
+        )
+        let savedFilter = try customFilterService.save(name: "Traffic", group: originalGroup)
+        let viewModel = makeOfflineViewModel(packets: [], customFilterService: customFilterService)
+
+        viewModel.setStructuredFilterVisible(true)
+        try viewModel.overrideCustomFilter(id: savedFilter.id, group: replacementGroup)
+
+        let updatedFilter = try #require(customFilterService.filter(id: savedFilter.id))
+        #expect(updatedFilter.name == "Traffic")
+        #expect(updatedFilter.group == replacementGroup)
+        #expect(viewModel.snapshot.structuredFilterGroup == replacementGroup)
+        #expect(viewModel.snapshot.customFilterItems == [
+            PacketCustomFilterItem(id: savedFilter.id, title: "Traffic", isSelected: true),
+        ])
+    }
+
+    @Test func duplicatingCustomFilterAddsCopyWithoutChangingStructuredGroup() throws {
+        let customFilterService = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+        let firstGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .client, condition: .contains, text: "Safari")],
+            operator: .and
+        )
+        let secondGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .summary, condition: .contains, text: "DNS")],
+            operator: .or
+        )
+        let first = try customFilterService.save(name: "Client", group: firstGroup)
+        let second = try customFilterService.save(name: "Summary", group: secondGroup)
+        let viewModel = makeOfflineViewModel(packets: [], customFilterService: customFilterService)
+
+        viewModel.applyCustomFilter(id: second.id)
+        try viewModel.duplicateCustomFilter(id: first.id)
+
+        #expect(viewModel.snapshot.structuredFilterGroup == secondGroup)
+        #expect(viewModel.snapshot.customFilterItems.map(\.title) == ["Client", "Client", "Summary"])
+        #expect(viewModel.snapshot.customFilterItems.map(\.isSelected) == [false, false, true])
     }
 
     @Test func sidebarThicknessPersistsAndFallsBackWhenInvalid() {

--- a/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
@@ -1,0 +1,110 @@
+//
+//  PacketCustomFilterServiceTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/6/26.
+//
+
+import Foundation
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct PacketCustomFilterServiceTests {
+    @Test func missingFileLoadsEmptyFilters() {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+
+        #expect(service.filters().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: storageURL.path))
+    }
+
+    @Test func savesTrimsReloadsMultipleFiltersAndAllowsDuplicateNames() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+        let firstGroup = PacketStructuredFilterGroup(
+            filters: [
+                PacketStructuredFilter(query: .protocol, condition: .contains, text: "tcp", isEnabled: true),
+                PacketStructuredFilter(query: .destinationPort, condition: .greaterThanOrEqual, text: "443", isEnabled: false),
+            ],
+            operator: .or
+        )
+        let secondGroup = PacketStructuredFilterGroup(
+            filters: [
+                PacketStructuredFilter(query: .summary, condition: .matchesRegex, text: "GET|POST", isEnabled: true),
+            ],
+            operator: .and
+        )
+
+        let first = try service.save(name: "  API Traffic  ", group: firstGroup, now: Date(timeIntervalSince1970: 10))
+        let second = try service.save(name: "API Traffic", group: secondGroup, now: Date(timeIntervalSince1970: 20))
+
+        #expect(first.name == "API Traffic")
+        #expect(second.name == "API Traffic")
+        #expect(first.id != second.id)
+
+        let reloaded = PacketCustomFilterService(storageURL: storageURL)
+        let filters = reloaded.filters()
+        #expect(filters.map(\.name) == ["API Traffic", "API Traffic"])
+        #expect(filters[0].group == firstGroup)
+        #expect(filters[0].group.operator == .or)
+        #expect(filters[0].group.filters[1].isEnabled == false)
+        #expect(filters[0].group.filters[1].text == "443")
+        #expect(filters[1].group == secondGroup)
+    }
+
+    @Test func rejectsEmptyAndTooLongNames() throws {
+        let service = PacketCustomFilterService(storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json"))
+
+        expectValidationError(.emptyName) {
+            _ = try service.save(name: "   ", group: .default)
+        }
+
+        expectValidationError(.nameTooLong(maxLength: PacketCustomFilterService.maxNameLength)) {
+            _ = try service.save(name: String(repeating: "a", count: PacketCustomFilterService.maxNameLength + 1), group: .default)
+        }
+
+        #expect(service.filters().isEmpty)
+    }
+
+    @Test func renameAndDeletePersistChanges() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+        let saved = try service.save(
+            name: "Original",
+            group: PacketStructuredFilterGroup(filters: [PacketStructuredFilter(query: .client, text: "Safari")]),
+            now: Date(timeIntervalSince1970: 10)
+        )
+
+        try service.rename(id: saved.id, name: "  Renamed  ", now: Date(timeIntervalSince1970: 30))
+
+        let renamed = try #require(PacketCustomFilterService(storageURL: storageURL).filter(id: saved.id))
+        #expect(renamed.name == "Renamed")
+        #expect(renamed.createdAt == Date(timeIntervalSince1970: 10))
+        #expect(renamed.updatedAt == Date(timeIntervalSince1970: 30))
+        #expect(renamed.group == saved.group)
+
+        try service.delete(id: saved.id)
+        #expect(PacketCustomFilterService(storageURL: storageURL).filters().isEmpty)
+    }
+
+    private func expectValidationError(
+        _ expectedError: PacketCustomFilterValidationError,
+        operation: () throws -> Void
+    ) {
+        do {
+            try operation()
+            Issue.record("Expected validation error \(expectedError).")
+        } catch let error as PacketCustomFilterValidationError {
+            #expect(error == expectedError)
+        } catch {
+            Issue.record("Expected validation error \(expectedError), got \(error).")
+        }
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
@@ -67,6 +67,19 @@ struct PacketCustomFilterServiceTests {
         #expect(service.filters().isEmpty)
     }
 
+    @Test func failedSaveDoesNotKeepUnsavedFilterInMemory() throws {
+        let blockedParentURL = temporaryDirectory().appendingPathComponent("BlockedParent")
+        try "not a directory".write(to: blockedParentURL, atomically: true, encoding: .utf8)
+        let service = PacketCustomFilterService(storageURL: blockedParentURL.appendingPathComponent("CustomFilters.json"))
+
+        do {
+            _ = try service.save(name: "Unsaved", group: .default)
+            Issue.record("Expected save to fail when the storage parent is a file.")
+        } catch {
+            #expect(service.filters().isEmpty)
+        }
+    }
+
     @Test func renameAndDeletePersistChanges() throws {
         let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
         let service = PacketCustomFilterService(storageURL: storageURL)
@@ -86,6 +99,59 @@ struct PacketCustomFilterServiceTests {
 
         try service.delete(id: saved.id)
         #expect(PacketCustomFilterService(storageURL: storageURL).filters().isEmpty)
+    }
+
+    @Test func updateGroupKeepsNameAndIdentityButPersistsNewPayload() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+        let originalGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .client, condition: .contains, text: "Safari")],
+            operator: .and
+        )
+        let replacementGroup = PacketStructuredFilterGroup(
+            filters: [
+                PacketStructuredFilter(query: .protocol, condition: .contains, text: "udp", isEnabled: true),
+                PacketStructuredFilter(query: .summary, condition: .notContains, text: "DNS", isEnabled: false),
+            ],
+            operator: .or
+        )
+        let saved = try service.save(name: "Traffic", group: originalGroup, now: Date(timeIntervalSince1970: 10))
+
+        try service.updateGroup(id: saved.id, group: replacementGroup, now: Date(timeIntervalSince1970: 40))
+
+        let updated = try #require(PacketCustomFilterService(storageURL: storageURL).filter(id: saved.id))
+        #expect(updated.id == saved.id)
+        #expect(updated.name == "Traffic")
+        #expect(updated.createdAt == Date(timeIntervalSince1970: 10))
+        #expect(updated.updatedAt == Date(timeIntervalSince1970: 40))
+        #expect(updated.group == replacementGroup)
+    }
+
+    @Test func duplicatePersistsCopyNextToSourceWithSameNameAndGroup() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+        let firstGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .protocol, condition: .contains, text: "tcp")],
+            operator: .and
+        )
+        let secondGroup = PacketStructuredFilterGroup(
+            filters: [PacketStructuredFilter(query: .summary, condition: .matchesRegex, text: "GET|POST")],
+            operator: .or
+        )
+        let first = try service.save(name: "Traffic", group: firstGroup, now: Date(timeIntervalSince1970: 10))
+        let second = try service.save(name: "Methods", group: secondGroup, now: Date(timeIntervalSince1970: 20))
+
+        let duplicated = try #require(try service.duplicate(id: first.id, now: Date(timeIntervalSince1970: 30)))
+
+        #expect(duplicated.id != first.id)
+        #expect(duplicated.name == first.name)
+        #expect(duplicated.group == first.group)
+        #expect(duplicated.createdAt == Date(timeIntervalSince1970: 30))
+        #expect(duplicated.updatedAt == Date(timeIntervalSince1970: 30))
+
+        let reloadedFilters = PacketCustomFilterService(storageURL: storageURL).filters()
+        #expect(reloadedFilters.map(\.id) == [first.id, duplicated.id, second.id])
+        #expect(reloadedFilters.map(\.name) == ["Traffic", "Traffic", "Methods"])
     }
 
     private func expectValidationError(

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -167,6 +167,94 @@ struct SidebarOutlineReloadPolicyTests {
         #expect(selectionRecorder.selectedSelection == .domain(selectedKey))
     }
 
+    @MainActor
+    @Test func deferredReloadDoesNotScrollSelectedFavoriteBackIntoView() async throws {
+        let pin = pinnedClient()
+        let controller = SidebarViewController()
+        let selectionRecorder = SidebarSelectionRecorder()
+        controller.delegate = selectionRecorder
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 260, height: 240)
+        controller.view.layoutSubtreeIfNeeded()
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithPinnedClient(pin, count: 1, domainCount: 64),
+            selectedSelection: .pinnedItem(pin.id),
+            packetMutation: .none
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let outlineScrollView = try #require(findOutlineScrollView(in: controller.view))
+        let outlineView = try #require(outlineScrollView.documentView as? NSOutlineView)
+        let selectedRow = outlineView.selectedRow
+        #expect(selectedRow >= 0)
+
+        outlineScrollView.contentView.scroll(to: NSPoint(x: 0, y: 520))
+        outlineScrollView.reflectScrolledClipView(outlineScrollView.contentView)
+        let originalY = outlineScrollView.contentView.bounds.origin.y
+        #expect(outlineView.rect(ofRow: selectedRow).maxY < originalY)
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithPinnedClient(pin, count: 2, domainCount: 65),
+            selectedSelection: .pinnedItem(pin.id),
+            packetMutation: .append(0..<1)
+        ))
+        try await Task.sleep(nanoseconds: 700_000_000)
+        await Task.yield()
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(originalY > 0)
+        #expect(abs(outlineScrollView.contentView.bounds.origin.y - originalY) <= 1)
+        #expect(outlineView.selectedRow >= 0)
+    }
+
+    @MainActor
+    @Test func deferredReloadKeepsVisibleSelectionAnchoredWhenRowsAreInsertedAbove() async throws {
+        let selectedKey = PacketSourceDomainKey(rawValue: "domain-20.example.com", isMissingDomain: false)
+        let controller = SidebarViewController()
+        let selectionRecorder = SidebarSelectionRecorder()
+        controller.delegate = selectionRecorder
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 260, height: 240)
+        controller.view.layoutSubtreeIfNeeded()
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithAppsAndDomains(appCount: 1, domainCount: 48),
+            selectedSelection: .domain(selectedKey),
+            packetMutation: .none
+        ))
+        await Task.yield()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let outlineScrollView = try #require(findOutlineScrollView(in: controller.view))
+        let outlineView = try #require(outlineScrollView.documentView as? NSOutlineView)
+        let selectedRow = outlineView.selectedRow
+        #expect(selectedRow >= 0)
+
+        let selectedOffsetY: CGFloat = 6
+        let selectedOrigin = outlineView.rect(ofRow: selectedRow).minY - selectedOffsetY
+        outlineScrollView.contentView.scroll(to: NSPoint(x: 0, y: selectedOrigin))
+        outlineScrollView.reflectScrolledClipView(outlineScrollView.contentView)
+        let originalY = outlineScrollView.contentView.bounds.origin.y
+        let originalSelectedOffset = outlineView.rect(ofRow: selectedRow).minY - originalY
+        selectionRecorder.selectedSelections.removeAll()
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithAppsAndDomains(appCount: 16, domainCount: 48),
+            selectedSelection: .domain(selectedKey),
+            packetMutation: .append(0..<1)
+        ))
+        try await Task.sleep(nanoseconds: 700_000_000)
+        await Task.yield()
+        controller.view.layoutSubtreeIfNeeded()
+
+        let updatedSelectedRow = outlineView.selectedRow
+        #expect(updatedSelectedRow > selectedRow)
+        #expect(outlineScrollView.contentView.bounds.origin.y > originalY)
+        #expect(abs((outlineView.rect(ofRow: updatedSelectedRow).minY - outlineScrollView.contentView.bounds.origin.y) - originalSelectedOffset) <= 1)
+        #expect(selectionRecorder.selectedSelections.isEmpty)
+    }
+
     private func reloadState(
         sourceListSnapshot: PacketSourceListSnapshot,
         filterText: String = "",
@@ -206,6 +294,69 @@ struct SidebarOutlineReloadPolicyTests {
         )
     }
 
+    private func snapshotWithAppsAndDomains(appCount: Int, domainCount: Int) -> PacketSourceListSnapshot {
+        PacketSourceListTreeBuilder.makeSnapshot(
+            appBuckets: (0..<appCount).map { index in
+                PacketSourceListTreeBuilder.AppBucket(identity: PacketSourceClientIdentity(
+                    key: PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App\(index)"),
+                    displayName: String(format: "Example %02d", index),
+                    iconFilePath: nil
+                ))
+            },
+            domainBuckets: domainBuckets(count: domainCount)
+        )
+    }
+
+    private func pinnedClient() -> PacketPin {
+        PacketPin(
+            id: PacketPinID(rawValue: "client:bundleIdentifier:com.example.App"),
+            kind: .client,
+            title: "Example",
+            createdAt: Date(timeIntervalSince1970: 1),
+            domain: nil,
+            ipAddress: nil,
+            clientKey: "bundleIdentifier:com.example.App",
+            clientDisplayName: "Example",
+            clientIconFilePath: nil
+        )
+    }
+
+    private func snapshotWithPinnedClient(_ pin: PacketPin, count: Int, domainCount: Int) -> PacketSourceListSnapshot {
+        var appBucket = PacketSourceListTreeBuilder.AppBucket(identity: PacketSourceClientIdentity(
+            key: PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App"),
+            displayName: "Example",
+            iconFilePath: nil
+        ))
+        for index in 0..<count {
+            appBucket.increment(
+                domainIdentity: PacketSourceDomainIdentity(
+                    key: PacketSourceDomainKey(rawValue: "favorite-\(index).example.com", isMissingDomain: false),
+                    displayName: "favorite-\(index).example.com"
+                ),
+                ipAddressIdentities: []
+            )
+        }
+
+        return PacketSourceListTreeBuilder.makeSnapshot(
+            appBuckets: [appBucket],
+            domainBuckets: (0..<domainCount).map { index in
+                let displayName = String(format: "domain-%02d.example.com", index)
+                return PacketSourceListTreeBuilder.DomainBucket(identity: PacketSourceDomainIdentity(
+                    key: PacketSourceDomainKey(rawValue: displayName, isMissingDomain: false),
+                    displayName: displayName
+                ))
+            },
+            pinnedBuckets: [
+                PacketSourceListTreeBuilder.PinnedBucket(
+                    pin: pin,
+                    packetCount: count,
+                    domainBuckets: appBucket.orderedDomainBuckets,
+                    ipAddressBuckets: []
+                ),
+            ]
+        )
+    }
+
     private func makeSnapshot(
         sourceListSnapshot: PacketSourceListSnapshot,
         selectedSelection: PacketSourceListSelection,
@@ -239,14 +390,18 @@ struct SidebarOutlineReloadPolicyTests {
     private func snapshotWithDomains(count: Int) -> PacketSourceListSnapshot {
         PacketSourceListTreeBuilder.makeSnapshot(
             appBuckets: [],
-            domainBuckets: (0..<count).map { index in
-                let displayName = String(format: "domain-%02d.example.com", index)
-                return PacketSourceListTreeBuilder.DomainBucket(identity: PacketSourceDomainIdentity(
-                    key: PacketSourceDomainKey(rawValue: displayName, isMissingDomain: false),
-                    displayName: displayName
-                ))
-            }
+            domainBuckets: domainBuckets(count: count)
         )
+    }
+
+    private func domainBuckets(count: Int) -> [PacketSourceListTreeBuilder.DomainBucket] {
+        (0..<count).map { index in
+            let displayName = String(format: "domain-%02d.example.com", index)
+            return PacketSourceListTreeBuilder.DomainBucket(identity: PacketSourceDomainIdentity(
+                key: PacketSourceDomainKey(rawValue: displayName, isMissingDomain: false),
+                displayName: displayName
+            ))
+        }
     }
 
     private func findOutlineScrollView(in view: NSView) -> NSScrollView? {
@@ -263,9 +418,11 @@ struct SidebarOutlineReloadPolicyTests {
 
 private final class SidebarSelectionRecorder: SidebarViewControllerDelegate {
     var selectedSelection: PacketSourceListSelection?
+    var selectedSelections: [PacketSourceListSelection?] = []
 
     func sidebarViewController(_ controller: SidebarViewController, didSelect selection: PacketSourceListSelection?) {
         selectedSelection = selection
+        selectedSelections.append(selection)
     }
 
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String) {}


### PR DESCRIPTION
## Summary
- Add persisted custom structured filters with save, rename, duplicate, delete, apply, and override support.
- Render custom filter buttons beside built-in quick filters, including separator styling and context menu actions.
- Move structured-filter Save into the shortcut footer row and make it open a menu with New Filter and Override options.
- Make clicking the active custom filter toggle the structured filter panel off so the saved filter no longer filters while hidden.

## Validation
- `git diff --check`
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`

AI-assisted change reviewed locally before opening this PR.
