### PR TITLE
Show update release notes at launch and make Factory Reset quit reliably

### DIFF
--- a/TCPViewer/App/AppDelegate.swift
+++ b/TCPViewer/App/AppDelegate.swift
@@ -27,6 +27,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var skipsNextQuitConfirmation = false
     private var isShowingRenewalRequiredAlert = false
     private var isVerifyingLicenseAtLaunch = false
+    private var didCheckForUpdatesAtLaunch = false
+    private var isTerminatingAfterFactoryReset = false
     #if DEBUG
     private var shouldOpenUntitledDocumentAfterIgnoringDebugLaunchFiles = false
     #endif
@@ -78,6 +80,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !isTerminatingAfterFactoryReset else {
+            return .terminateNow
+        }
+
         guard !isHandlingTermination else {
             return .terminateLater
         }
@@ -350,6 +356,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         item.target = updaterController
         item.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
         item.isEnabled = true
+        checkForUpdatesAtLaunchIfNeeded(using: updaterController)
     }
 
     private func findOrCreateUpdatesMenuItem(in appMenu: NSMenu) -> NSMenuItem {
@@ -382,6 +389,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         )
         updaterController = controller
         return controller
+    }
+
+    private func checkForUpdatesAtLaunchIfNeeded(using updaterController: SPUStandardUpdaterController) {
+        // Ask Sparkle once per launch so any available update shows its standard release-notes prompt.
+        guard !didCheckForUpdatesAtLaunch else {
+            return
+        }
+
+        didCheckForUpdatesAtLaunch = true
+        let updater = updaterController.updater
+        guard updater.automaticallyChecksForUpdates else {
+            return
+        }
+
+        updater.checkForUpdatesInBackground()
     }
 
     private func isSparkleConfigured() -> Bool {
@@ -533,11 +555,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             disableAutosavedWindowStateForFactoryReset()
             NSDocumentController.shared.clearRecentDocuments(nil)
             showFactoryResetCompletionAlert(resetResult, uninstallHelperTool: uninstallHelperTool)
-            skipsNextQuitConfirmation = true
+            prepareForFactoryResetTermination()
             NSApp.terminate(nil)
         case .failure(let error):
             showFactoryResetFailureAlert(error)
         }
+    }
+
+    func prepareForFactoryResetTermination() {
+        // Factory Reset already deleted app state, so the next termination must not be cancellable.
+        isTerminatingAfterFactoryReset = true
+        skipsNextQuitConfirmation = true
     }
 
     private func showFactoryResetCompletionAlert(

--- a/TCPViewer/Info.plist
+++ b/TCPViewer/Info.plist
@@ -10,6 +10,8 @@
 	</dict>
 	<key>SUFeedURL</key>
 	<string>$(TCPVIEWER_APPCAST_URL)</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 	<key>SUPublicEDKey</key>
 	<string>$(TCPVIEWER_SPARKLE_PUBLIC_ED_KEY)</string>
 	<key>TCPViewerSentryDSN</key>

--- a/TCPViewerTests/App/AppDelegateTerminationTests.swift
+++ b/TCPViewerTests/App/AppDelegateTerminationTests.swift
@@ -1,0 +1,22 @@
+//
+//  AppDelegateTerminationTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/6/26.
+//
+
+import AppKit
+import Testing
+@testable import TCPViewer
+
+@MainActor
+struct AppDelegateTerminationTests {
+    @Test func factoryResetTerminationBypassesCancellableQuitPreparation() {
+        let delegate = AppDelegate()
+
+        delegate.prepareForFactoryResetTermination()
+        let reply = delegate.applicationShouldTerminate(NSApplication.shared)
+
+        #expect(reply == .terminateNow)
+    }
+}


### PR DESCRIPTION
## Summary
- Trigger a Sparkle background update check at launch when the updater is configured so available updates surface with the standard release-notes UI.
- Enable Sparkle automatic checks by default in the app bundle Info.plist.
- Fix Factory Reset so the post-reset quit bypasses the cancellable termination prep and exits immediately.
- Add a regression test covering the Factory Reset termination path.

## Testing
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`