### PR TITLE
[codex] Restore inspector panel width

### DIFF
--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -10,9 +10,14 @@ import Foundation
 import PcapPlusPlusCore
 import UniformTypeIdentifiers
 
+enum NetworkInspectorLayoutMetrics {
+    static let minimumInspectorThickness: CGFloat = 100
+}
+
 private struct NetworkInspectorPreferences {
     private enum Key {
         static let displayFilterText = "TCPViewer.displayFilterText"
+        static let inspectorTrailingThickness = "TCPViewer.inspectorTrailingThickness"
         static let inspectorVisible = "TCPViewer.inspectorVisible"
         static let sidebarLeadingThickness = "TCPViewer.sidebarLeadingThickness"
         static let sidebarVisible = "TCPViewer.sidebarVisible"
@@ -53,6 +58,14 @@ private struct NetworkInspectorPreferences {
         return defaults.bool(forKey: Key.structuredFilterVisible)
     }
 
+    var inspectorThickness: CGFloat? {
+        guard defaults.object(forKey: Key.inspectorTrailingThickness) != nil else {
+            return nil
+        }
+
+        return CGFloat(defaults.double(forKey: Key.inspectorTrailingThickness))
+    }
+
     var sidebarThickness: CGFloat? {
         guard defaults.object(forKey: Key.sidebarLeadingThickness) != nil else {
             return nil
@@ -67,6 +80,10 @@ private struct NetworkInspectorPreferences {
 
     func persistInspectorVisible(_ isVisible: Bool) {
         defaults.set(isVisible, forKey: Key.inspectorVisible)
+    }
+
+    func persistInspectorThickness(_ thickness: CGFloat) {
+        defaults.set(Double(thickness), forKey: Key.inspectorTrailingThickness)
     }
 
     func persistSidebarThickness(_ thickness: CGFloat) {
@@ -1710,6 +1727,28 @@ final class NetworkInspectorViewModel {
 
     func toggleInspector() {
         setInspectorVisible(!isInspectorVisible)
+    }
+
+    // Keep the last usable trailing inspector width for future launches and reopen actions.
+    func rememberInspectorThickness(_ thickness: CGFloat) {
+        guard thickness.isFinite, thickness > 0 else {
+            return
+        }
+
+        preferences.persistInspectorThickness(thickness)
+    }
+
+    // Reject invalid or tiny saved inspector widths so the root controller can keep AppKit's default.
+    func preferredInspectorThickness(for availableLength: CGFloat) -> CGFloat? {
+        guard availableLength.isFinite, availableLength > 0,
+              let thickness = preferences.inspectorThickness,
+              thickness.isFinite,
+              thickness >= NetworkInspectorLayoutMetrics.minimumInspectorThickness,
+              thickness < availableLength else {
+            return nil
+        }
+
+        return thickness
     }
 
     // Persist the sidebar's visibility so the root split view can restore it on the next launch.

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -12,6 +12,7 @@ import UniformTypeIdentifiers
 
 enum NetworkInspectorLayoutMetrics {
     static let minimumInspectorThickness: CGFloat = 100
+    static let defaultInspectorThickness: CGFloat = 360
 }
 
 private struct NetworkInspectorPreferences {
@@ -1749,6 +1750,24 @@ final class NetworkInspectorViewModel {
         }
 
         return thickness
+    }
+
+    // Use the saved inspector width when it is usable; otherwise reopen at a visible default width.
+    func restoredInspectorThickness(for availableLength: CGFloat) -> CGFloat? {
+        guard availableLength.isFinite else {
+            return nil
+        }
+
+        if let thickness = preferredInspectorThickness(for: availableLength) {
+            return thickness
+        }
+
+        let maximumThickness = availableLength - 1
+        guard maximumThickness >= NetworkInspectorLayoutMetrics.minimumInspectorThickness else {
+            return nil
+        }
+
+        return min(NetworkInspectorLayoutMetrics.defaultInspectorThickness, maximumThickness)
     }
 
     // Persist the sidebar's visibility so the root split view can restore it on the next launch.

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1732,19 +1732,20 @@ final class NetworkInspectorViewModel {
 
     // Keep the last usable trailing inspector width for future launches and reopen actions.
     func rememberInspectorThickness(_ thickness: CGFloat) {
-        guard thickness.isFinite, thickness > 0 else {
+        guard thickness.isFinite,
+              thickness > NetworkInspectorLayoutMetrics.minimumInspectorThickness else {
             return
         }
 
         preferences.persistInspectorThickness(thickness)
     }
 
-    // Reject invalid or tiny saved inspector widths so the root controller can keep AppKit's default.
+    // Reject invalid or collapse-threshold inspector widths so reopen can fall back to a visible default.
     func preferredInspectorThickness(for availableLength: CGFloat) -> CGFloat? {
         guard availableLength.isFinite, availableLength > 0,
               let thickness = preferences.inspectorThickness,
               thickness.isFinite,
-              thickness >= NetworkInspectorLayoutMetrics.minimumInspectorThickness,
+              thickness > NetworkInspectorLayoutMetrics.minimumInspectorThickness,
               thickness < availableLength else {
             return nil
         }
@@ -1763,7 +1764,7 @@ final class NetworkInspectorViewModel {
         }
 
         let maximumThickness = availableLength - 1
-        guard maximumThickness >= NetworkInspectorLayoutMetrics.minimumInspectorThickness else {
+        guard maximumThickness > NetworkInspectorLayoutMetrics.minimumInspectorThickness else {
             return nil
         }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -14,13 +14,23 @@ protocol TCPViewerRootViewControllerDelegate: AnyObject {
     func tcpviewerRootViewControllerDidRequestPaywall(_ controller: TCPViewerRootViewController)
 }
 
+private final class TCPViewerInspectorSplitViewController: NSSplitViewController {
+    var didResizeSubviews: ((Notification) -> Void)?
+
+    // Forward AppKit delegate resize events while preserving NSSplitViewController's own delegate behavior.
+    override func splitViewDidResizeSubviews(_ notification: Notification) {
+        super.splitViewDidResizeSubviews(notification)
+        didResizeSubviews?(notification)
+    }
+}
+
 final class TCPViewerRootViewController: NSViewController {
     weak var delegate: TCPViewerRootViewControllerDelegate?
 
     let viewModel: NetworkInspectorViewModel
 
     private let mainSplitViewController = NSSplitViewController()
-    private let contentSplitViewController = NSSplitViewController()
+    private let contentSplitViewController = TCPViewerInspectorSplitViewController()
     private let mainContainerViewController = NSViewController()
     private let sidebarViewController = SidebarViewController()
     private let workspaceViewController: PacketWorkspaceViewController
@@ -30,6 +40,9 @@ final class TCPViewerRootViewController: NSViewController {
     private var inspectorItem: NSSplitViewItem?
     private var appliedInspectorVisibility: Bool?
     private var needsSidebarDividerRefresh = false
+    private var needsInspectorDividerRefresh = false
+    private var isRestoringInspectorDivider = false
+    private var temporaryInspectorRestoreThickness: CGFloat?
     private var hasRenderedHelperOnboarding = false
     #if DEBUG
     private var packetSelectionCrashReproducer: TCPViewerPacketSelectionCrashReproducer?
@@ -48,6 +61,9 @@ final class TCPViewerRootViewController: NSViewController {
         self.inspectorViewController = PacketInspectorViewController(configuration: configuration)
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self
+        self.contentSplitViewController.didResizeSubviews = { [weak self] notification in
+            self?.contentSplitViewDidResizeSubviews(notification)
+        }
     }
 
     @available(*, unavailable)
@@ -80,6 +96,11 @@ final class TCPViewerRootViewController: NSViewController {
         if needsSidebarDividerRefresh, sidebarItem?.isCollapsed == false {
             needsSidebarDividerRefresh = false
             applySidebarDividerPosition()
+        }
+
+        if needsInspectorDividerRefresh, inspectorItem?.isCollapsed == false {
+            needsInspectorDividerRefresh = false
+            applyInspectorDividerPosition()
         }
     }
 
@@ -236,6 +257,7 @@ final class TCPViewerRootViewController: NSViewController {
         let inspectorItem = NSSplitViewItem(viewController: inspectorViewController)
         inspectorItem.canCollapse = true
         inspectorItem.allowsFullHeightLayout = false
+        inspectorItem.minimumThickness = NetworkInspectorLayoutMetrics.minimumInspectorThickness
         contentSplitViewController.addSplitViewItem(inspectorItem)
         self.inspectorItem = inspectorItem
 
@@ -349,10 +371,114 @@ final class TCPViewerRootViewController: NSViewController {
 
         contentSplitViewController.splitView.isVertical = true
         if visibilityChanged {
-            inspectorItem?.isCollapsed = !snapshot.isInspectorVisible
+            if !snapshot.isInspectorVisible {
+                persistCurrentInspectorThicknessIfVisible()
+                inspectorItem?.isCollapsed = true
+            } else {
+                restoreInspectorDividerAfterOpening()
+            }
         }
 
         appliedInspectorVisibility = snapshot.isInspectorVisible
+    }
+
+    // Expand the inspector without letting AppKit's intermediate resize overwrite the saved width.
+    private func restoreInspectorDividerAfterOpening() {
+        isRestoringInspectorDivider = true
+        prepareInspectorItemForExactRestore()
+        inspectorItem?.isCollapsed = false
+        applyInspectorDividerPosition()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                return
+            }
+
+            self.applyInspectorDividerPosition()
+            self.view.layoutSubtreeIfNeeded()
+            DispatchQueue.main.async { [weak self] in
+                guard let self else {
+                    return
+                }
+
+                self.applyInspectorDividerPosition()
+                self.clearTemporaryInspectorRestoreThickness()
+                self.view.layoutSubtreeIfNeeded()
+                self.applyInspectorDividerPosition()
+                self.isRestoringInspectorDivider = false
+                print("[TCPViewer] Inspector restore settled: \(self.inspectorSplitDebugDescription())")
+            }
+        }
+    }
+
+    // Lock the split item briefly so AppKit's uncollapse animation starts at the saved width.
+    private func prepareInspectorItemForExactRestore() {
+        let splitView = contentSplitViewController.splitView
+        let totalLength = splitView.bounds.width
+        guard let inspectorThickness = viewModel.preferredInspectorThickness(for: totalLength) else {
+            clearTemporaryInspectorRestoreThickness()
+            print(
+                "[TCPViewer] Inspector restore will use default width: " +
+                "\(inspectorSplitDebugDescription())"
+            )
+            return
+        }
+
+        temporaryInspectorRestoreThickness = inspectorThickness
+        inspectorItem?.minimumThickness = inspectorThickness
+        inspectorItem?.maximumThickness = inspectorThickness
+        print(
+            "[TCPViewer] Inspector restore prepared: lockedWidth=\(debugValue(inspectorThickness)) " +
+            "\(inspectorSplitDebugDescription())"
+        )
+    }
+
+    private func clearTemporaryInspectorRestoreThickness() {
+        guard temporaryInspectorRestoreThickness != nil else {
+            return
+        }
+
+        temporaryInspectorRestoreThickness = nil
+        inspectorItem?.minimumThickness = NetworkInspectorLayoutMetrics.minimumInspectorThickness
+        inspectorItem?.maximumThickness = NSSplitViewItem.unspecifiedDimension
+    }
+
+    // Reapply the saved trailing divider position once the split view has a real width.
+    private func applyInspectorDividerPosition() {
+        let splitView = contentSplitViewController.splitView
+        guard splitView.dividerThickness.isFinite else {
+            print("[TCPViewer] Inspector restore skipped: invalid divider thickness. \(inspectorSplitDebugDescription())")
+            return
+        }
+
+        splitView.layoutSubtreeIfNeeded()
+        let totalLength = splitView.bounds.width
+        guard totalLength > 0 else {
+            needsInspectorDividerRefresh = true
+            print("[TCPViewer] Inspector restore deferred: split width is \(debugValue(totalLength))")
+            return
+        }
+
+        guard let inspectorThickness = viewModel.preferredInspectorThickness(for: totalLength) else {
+            print("[TCPViewer] Inspector restore skipped: no valid saved width. \(inspectorSplitDebugDescription())")
+            return
+        }
+
+        let dividerPosition = totalLength - splitView.dividerThickness - inspectorThickness
+        guard dividerPosition.isFinite, dividerPosition > 0 else {
+            print(
+                "[TCPViewer] Inspector restore skipped: invalid divider=\(debugValue(dividerPosition)) " +
+                "savedWidth=\(debugValue(inspectorThickness)) \(inspectorSplitDebugDescription())"
+            )
+            return
+        }
+
+        print(
+            "[TCPViewer] Inspector restore applying: savedWidth=\(debugValue(inspectorThickness)) " +
+            "restoreDivider=\(debugValue(dividerPosition)) subviews=\(splitView.subviews.count) " +
+            "\(inspectorSplitDebugDescription())"
+        )
+        splitView.setPosition(dividerPosition, ofDividerAt: 0)
+        print("[TCPViewer] Inspector restore applied: \(inspectorSplitDebugDescription())")
     }
 
     private func configureSplitViewObservation() {
@@ -370,6 +496,70 @@ final class TCPViewerRootViewController: NSViewController {
         }
 
         persistCurrentSidebarLayout()
+    }
+
+    private func contentSplitViewDidResizeSubviews(_ notification: Notification) {
+        guard notification.object as? NSSplitView === contentSplitViewController.splitView else {
+            return
+        }
+
+        print(
+            "[TCPViewer] Inspector delegate didResizeSubviews: restoring=\(isRestoringInspectorDivider) " +
+            "\(inspectorSplitDebugDescription())"
+        )
+        guard !isRestoringInspectorDivider else {
+            return
+        }
+
+        persistCurrentInspectorLayout()
+    }
+
+    // Persist the trailing split state after manual drags and AppKit-driven collapses.
+    private func persistCurrentInspectorLayout() {
+        let isVisible = inspectorItem?.isCollapsed == false
+        viewModel.setInspectorVisible(isVisible)
+        persistCurrentInspectorThicknessIfVisible()
+    }
+
+    // Persist only visible inspector sizes so collapsing the pane never stores a broken zero value.
+    private func persistCurrentInspectorThicknessIfVisible() {
+        guard let thickness = currentInspectorThickness() else {
+            return
+        }
+
+        print("[TCPViewer] Inspector persist width: width=\(debugValue(thickness)) \(inspectorSplitDebugDescription())")
+        viewModel.rememberInspectorThickness(thickness)
+    }
+
+    // Read the live inspector width from AppKit's trailing split item when it is on screen.
+    private func currentInspectorThickness() -> CGFloat? {
+        guard let inspectorView = inspectorItem?.viewController.view,
+              inspectorView.superview != nil,
+              inspectorItem?.isCollapsed == false else {
+            return nil
+        }
+
+        let thickness = inspectorView.frame.width
+        guard thickness.isFinite, thickness > 0 else {
+            return nil
+        }
+
+        return thickness
+    }
+
+    private func inspectorSplitDebugDescription() -> String {
+        let splitView = contentSplitViewController.splitView
+        let dividerPosition = splitView.subviews.first?.frame.maxX
+        let inspectorWidth = inspectorItem?.viewController.view.frame.width
+        return "total=\(debugValue(splitView.bounds.width)) divider=\(debugValue(dividerPosition)) inspectorWidth=\(debugValue(inspectorWidth)) collapsed=\(inspectorItem?.isCollapsed == true)"
+    }
+
+    private func debugValue(_ value: CGFloat?) -> String {
+        guard let value, value.isFinite else {
+            return "nil"
+        }
+
+        return String(format: "%.2f", Double(value))
     }
 
     // Persist the leading split state after manual drags and AppKit-driven collapses.

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -413,11 +413,10 @@ final class TCPViewerRootViewController: NSViewController {
     // Lock the split item briefly so AppKit's uncollapse animation starts at the saved width.
     private func prepareInspectorItemForExactRestore() {
         let splitView = contentSplitViewController.splitView
-        let totalLength = splitView.bounds.width
-        guard let inspectorThickness = viewModel.preferredInspectorThickness(for: totalLength) else {
+        guard let inspectorThickness = inspectorRestoreThickness(for: splitView) else {
             clearTemporaryInspectorRestoreThickness()
             print(
-                "[TCPViewer] Inspector restore will use default width: " +
+                "[TCPViewer] Inspector restore skipped: no usable width. " +
                 "\(inspectorSplitDebugDescription())"
             )
             return
@@ -427,7 +426,7 @@ final class TCPViewerRootViewController: NSViewController {
         inspectorItem?.minimumThickness = inspectorThickness
         inspectorItem?.maximumThickness = inspectorThickness
         print(
-            "[TCPViewer] Inspector restore prepared: lockedWidth=\(debugValue(inspectorThickness)) " +
+            "[TCPViewer] Inspector restore prepared: targetWidth=\(debugValue(inspectorThickness)) " +
             "\(inspectorSplitDebugDescription())"
         )
     }
@@ -458,8 +457,8 @@ final class TCPViewerRootViewController: NSViewController {
             return
         }
 
-        guard let inspectorThickness = viewModel.preferredInspectorThickness(for: totalLength) else {
-            print("[TCPViewer] Inspector restore skipped: no valid saved width. \(inspectorSplitDebugDescription())")
+        guard let inspectorThickness = inspectorRestoreThickness(for: splitView) else {
+            print("[TCPViewer] Inspector restore skipped: no usable width. \(inspectorSplitDebugDescription())")
             return
         }
 
@@ -467,18 +466,23 @@ final class TCPViewerRootViewController: NSViewController {
         guard dividerPosition.isFinite, dividerPosition > 0 else {
             print(
                 "[TCPViewer] Inspector restore skipped: invalid divider=\(debugValue(dividerPosition)) " +
-                "savedWidth=\(debugValue(inspectorThickness)) \(inspectorSplitDebugDescription())"
+                "targetWidth=\(debugValue(inspectorThickness)) \(inspectorSplitDebugDescription())"
             )
             return
         }
 
         print(
-            "[TCPViewer] Inspector restore applying: savedWidth=\(debugValue(inspectorThickness)) " +
+            "[TCPViewer] Inspector restore applying: targetWidth=\(debugValue(inspectorThickness)) " +
             "restoreDivider=\(debugValue(dividerPosition)) subviews=\(splitView.subviews.count) " +
             "\(inspectorSplitDebugDescription())"
         )
         splitView.setPosition(dividerPosition, ofDividerAt: 0)
         print("[TCPViewer] Inspector restore applied: \(inspectorSplitDebugDescription())")
+    }
+
+    private func inspectorRestoreThickness(for splitView: NSSplitView) -> CGFloat? {
+        let availableLength = splitView.bounds.width - splitView.dividerThickness
+        return viewModel.restoredInspectorThickness(for: availableLength)
     }
 
     private func configureSplitViewObservation() {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -875,18 +875,23 @@ struct NetworkInspectorViewModelTests {
         )
 
         #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 360)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 360)
 
         reloadedViewModel.rememberInspectorThickness(10_000)
 
         #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == nil)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 360)
 
         reloadedViewModel.rememberInspectorThickness(99)
 
         #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == nil)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 360)
 
         reloadedViewModel.rememberInspectorThickness(100)
 
         #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 100)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 100)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 100) == nil)
     }
 
     @Test func packetRowsAppendIncrementallyForMatchingLiveBatches() async {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -857,6 +857,38 @@ struct NetworkInspectorViewModelTests {
         #expect(reloadedViewModel.preferredSidebarThickness(for: 800) == nil)
     }
 
+    @Test func inspectorThicknessPersistsAndFallsBackWhenInvalid() {
+        let defaults = isolatedDefaults()
+        let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
+            interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+        ))
+        let viewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        viewModel.rememberInspectorThickness(360)
+
+        let reloadedViewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 360)
+
+        reloadedViewModel.rememberInspectorThickness(10_000)
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == nil)
+
+        reloadedViewModel.rememberInspectorThickness(99)
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == nil)
+
+        reloadedViewModel.rememberInspectorThickness(100)
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 100)
+    }
+
     @Test func packetRowsAppendIncrementallyForMatchingLiveBatches() async {
         let packets = [
             makePacket(packetNumber: 1, source: .live, transportHint: .tcp),

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -889,9 +889,14 @@ struct NetworkInspectorViewModelTests {
 
         reloadedViewModel.rememberInspectorThickness(100)
 
-        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 100)
-        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 100)
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == nil)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 360)
         #expect(reloadedViewModel.restoredInspectorThickness(for: 100) == nil)
+
+        reloadedViewModel.rememberInspectorThickness(101)
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 101)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 101)
     }
 
     @Test func packetRowsAppendIncrementallyForMatchingLiveBatches() async {


### PR DESCRIPTION
## Summary
- Persist and restore the right inspector split width when the toolbar closes and reopens the panel.
- Avoid saving AppKit's intermediate uncollapse width while restore is in progress.
- Treat saved inspector widths below 100px as invalid so the panel reopens at the default usable width instead of becoming nearly impossible to resize.

## Root Cause
AppKit briefly reports intermediate split-view states while uncollapsing the trailing inspector. Those resize callbacks could overwrite the previously saved width, and tiny persisted widths were still considered valid restore targets.

## Validation
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' -only-testing:TCPViewerTests/NetworkInspectorViewModelTests/inspectorThicknessPersistsAndFallsBackWhenInvalid`\n- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`\n- `git diff --check`\n\n## Disclosure\nThis PR was substantially assisted by AI and should be reviewed by a maintainer before merge.