### PR TITLE
Fix initial inspector split sizing in right mode

### DIFF
--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -15,6 +15,7 @@ private enum TCPViewerToolbarItemMetadata: String, CaseIterable {
     case status = "Status"
     case trial = "Trial"
     case share = "Share"
+    case inspectorBottom = "InspectorBottom"
     case inspector = "Inspector"
     case flexibleSpace
 
@@ -132,6 +133,7 @@ protocol TCPViewerToolbarDataSourceDelegate: AnyObject {
     func tcpviewerToolbarDataSourceDidRequestClearAllPackets(_ dataSource: TCPViewerToolbarDataSource)
     func tcpviewerToolbarDataSource(_ dataSource: TCPViewerToolbarDataSource, didRequestExport format: CaptureFileFormat)
     func tcpviewerToolbarDataSourceDidToggleInspector(_ dataSource: TCPViewerToolbarDataSource)
+    func tcpviewerToolbarDataSourceDidToggleBottomInspector(_ dataSource: TCPViewerToolbarDataSource)
     func tcpviewerToolbarDataSourceDidRequestHelperToolScreen(_ dataSource: TCPViewerToolbarDataSource)
     func tcpviewerToolbarDataSourceDidRequestPaywall(_ dataSource: TCPViewerToolbarDataSource)
 }
@@ -158,6 +160,7 @@ final class TCPViewerToolbarDataSource: NSObject {
     )
     private let sharePopup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 42, height: 30), pullsDown: true)
     private let inspectorButton = NSButton(frame: NSRect(x: 0, y: 0, width: 34, height: 30))
+    private let inspectorBottomButton = NSButton(frame: NSRect(x: 0, y: 0, width: 34, height: 30))
     private var interfacePopupWidthConstraint: NSLayoutConstraint?
     private var isTrialButtonRequired = !TCPViewerLicenseService.shared.isLicenseAuthorized
 
@@ -192,6 +195,7 @@ final class TCPViewerToolbarDataSource: NSObject {
         identifiers += [
             TCPViewerToolbarItemMetadata.flexibleSpace.identifier,
             TCPViewerToolbarItemMetadata.share.identifier,
+            TCPViewerToolbarItemMetadata.inspectorBottom.identifier,
             TCPViewerToolbarItemMetadata.inspector.identifier,
         ]
 
@@ -199,7 +203,7 @@ final class TCPViewerToolbarDataSource: NSObject {
     }
 
     override init() {
-        self.toolbar = NSToolbar(identifier: "TCPViewer.MainToolbar.v4")
+        self.toolbar = NSToolbar(identifier: "TCPViewer.MainToolbar.v6")
         super.init()
         configureToolbar()
         configureToolbarViews()
@@ -241,6 +245,7 @@ final class TCPViewerToolbarDataSource: NSObject {
         constrainToolbarView(trialButton, width: TCPViewerToolbarLayout.trialButtonWidth, height: 30)
         constrainToolbarView(sharePopup, width: 42, height: 30)
         constrainToolbarView(inspectorButton, width: 34, height: 30)
+        constrainToolbarView(inspectorBottomButton, width: 34, height: 30)
 
         interfacePopup.target = self
         interfacePopup.action = #selector(interfaceChanged(_:))
@@ -297,7 +302,17 @@ final class TCPViewerToolbarDataSource: NSObject {
         inspectorButton.image = TCPViewerUI.image("sidebar.trailing")
         inspectorButton.imagePosition = .imageOnly
         inspectorButton.title = ""
-        inspectorButton.toolTip = "Toggle Inspector"
+        inspectorButton.toolTip = "Toggle Right Inspector"
+
+        inspectorBottomButton.target = self
+        inspectorBottomButton.action = #selector(inspectorBottomButtonPressed(_:))
+        inspectorBottomButton.setButtonType(.toggle)
+        inspectorBottomButton.bezelStyle = .texturedRounded
+        inspectorBottomButton.controlSize = .regular
+        inspectorBottomButton.image = TCPViewerUI.image("rectangle.bottomthird.inset.filled")
+        inspectorBottomButton.imagePosition = .imageOnly
+        inspectorBottomButton.title = ""
+        inspectorBottomButton.toolTip = "Toggle Bottom Inspector"
 
         statusView.onOpenHelperToolScreen = { [weak self] in
             guard let self else {
@@ -475,7 +490,8 @@ final class TCPViewerToolbarDataSource: NSObject {
     }
 
     private func renderInspectorButton() {
-        inspectorButton.state = viewModel.isInspectorVisible ? .on : .off
+        inspectorButton.state = viewModel.isTrailingInspectorVisible ? .on : .off
+        inspectorBottomButton.state = viewModel.isBottomInspectorVisible ? .on : .off
     }
 
     private func syncTrialToolbarItem() {
@@ -541,6 +557,10 @@ final class TCPViewerToolbarDataSource: NSObject {
 
     @objc private func inspectorButtonPressed(_ sender: NSButton) {
         delegate?.tcpviewerToolbarDataSourceDidToggleInspector(self)
+    }
+
+    @objc private func inspectorBottomButtonPressed(_ sender: NSButton) {
+        delegate?.tcpviewerToolbarDataSourceDidToggleBottomInspector(self)
     }
 }
 
@@ -608,8 +628,13 @@ extension TCPViewerToolbarDataSource: NSToolbarDelegate {
             item.visibilityPriority = .high
         case TCPViewerToolbarItemMetadata.inspector.identifier:
             item.label = "Inspector"
-            item.paletteLabel = "Toggle Inspector"
+            item.paletteLabel = "Toggle Right Inspector"
             item.view = inspectorButton
+            item.visibilityPriority = .high
+        case TCPViewerToolbarItemMetadata.inspectorBottom.identifier:
+            item.label = "Bottom Inspector"
+            item.paletteLabel = "Toggle Bottom Inspector"
+            item.view = inspectorBottomButton
             item.visibilityPriority = .high
         default:
             return nil
@@ -635,6 +660,7 @@ private final class TCPViewerToolbarViewModel {
     private(set) var canSaveAs = false
     private(set) var canExport = false
     private(set) var isInspectorVisible = true
+    private(set) var inspectorPlacement: NetworkInspectorPlacement = .trailing
     private(set) var statusText = "TCP Viewer | Idle"
     private(set) var emphasizedText: String?
     private(set) var statusTint = NSColor.secondaryLabelColor
@@ -660,6 +686,7 @@ private final class TCPViewerToolbarViewModel {
         canSaveAs = snapshot.base.documentState.canSaveAs
         canExport = snapshot.totalPacketCount > 0 && snapshot.base.loadState.progress.phase != .loading
         isInspectorVisible = snapshot.isInspectorVisible
+        inspectorPlacement = snapshot.inspectorPlacement
         helperError = Self.helperError(for: viewModel.networkHelperToolSnapshot)
         isShowingHelperError = helperError != nil
         if let helperError {
@@ -687,6 +714,14 @@ private final class TCPViewerToolbarViewModel {
 
         return interface.id.caseInsensitiveCompare(activeInterfaceID) == .orderedSame ||
             interface.technicalName.caseInsensitiveCompare(activeInterfaceID) == .orderedSame
+    }
+
+    var isTrailingInspectorVisible: Bool {
+        isInspectorVisible && inspectorPlacement == .trailing
+    }
+
+    var isBottomInspectorVisible: Bool {
+        isInspectorVisible && inspectorPlacement == .bottom
     }
 
     private static func tint(for snapshot: NetworkInspectorSnapshot) -> NSColor {

--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -236,7 +236,11 @@ extension TCPViewerWindowController: TCPViewerToolbarDataSourceDelegate {
     }
 
     func tcpviewerToolbarDataSourceDidToggleInspector(_ dataSource: TCPViewerToolbarDataSource) {
-        rootViewController.toggleInspector()
+        rootViewController.toggleInspector(placement: .trailing)
+    }
+
+    func tcpviewerToolbarDataSourceDidToggleBottomInspector(_ dataSource: TCPViewerToolbarDataSource) {
+        rootViewController.toggleInspector(placement: .bottom)
     }
 
     func tcpviewerToolbarDataSourceDidRequestHelperToolScreen(_ dataSource: TCPViewerToolbarDataSource) {

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -505,6 +505,7 @@ enum PacketTableUpdatePlanner {
 
 enum NetworkInspectorPlacement: String, Equatable {
     case trailing
+    case bottom
 }
 
 struct NetworkInspectorSnapshot: Equatable {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -18,6 +18,8 @@ enum NetworkInspectorLayoutMetrics {
 private struct NetworkInspectorPreferences {
     private enum Key {
         static let displayFilterText = "TCPViewer.displayFilterText"
+        static let inspectorBottomThickness = "TCPViewer.inspectorBottomThickness"
+        static let inspectorPlacement = "TCPViewer.inspectorPlacement"
         static let inspectorTrailingThickness = "TCPViewer.inspectorTrailingThickness"
         static let inspectorVisible = "TCPViewer.inspectorVisible"
         static let sidebarLeadingThickness = "TCPViewer.sidebarLeadingThickness"
@@ -33,6 +35,14 @@ private struct NetworkInspectorPreferences {
 
     var displayFilterText: String {
         defaults.string(forKey: Key.displayFilterText) ?? ""
+    }
+
+    var inspectorPlacement: NetworkInspectorPlacement {
+        guard let rawValue = defaults.string(forKey: Key.inspectorPlacement) else {
+            return .trailing
+        }
+
+        return NetworkInspectorPlacement(rawValue: rawValue) ?? .trailing
     }
 
     var isInspectorVisible: Bool {
@@ -59,12 +69,13 @@ private struct NetworkInspectorPreferences {
         return defaults.bool(forKey: Key.structuredFilterVisible)
     }
 
-    var inspectorThickness: CGFloat? {
-        guard defaults.object(forKey: Key.inspectorTrailingThickness) != nil else {
+    func inspectorThickness(for placement: NetworkInspectorPlacement) -> CGFloat? {
+        let key = inspectorThicknessKey(for: placement)
+        guard defaults.object(forKey: key) != nil else {
             return nil
         }
 
-        return CGFloat(defaults.double(forKey: Key.inspectorTrailingThickness))
+        return CGFloat(defaults.double(forKey: key))
     }
 
     var sidebarThickness: CGFloat? {
@@ -79,12 +90,16 @@ private struct NetworkInspectorPreferences {
         defaults.set(text, forKey: Key.displayFilterText)
     }
 
+    func persistInspectorPlacement(_ placement: NetworkInspectorPlacement) {
+        defaults.set(placement.rawValue, forKey: Key.inspectorPlacement)
+    }
+
     func persistInspectorVisible(_ isVisible: Bool) {
         defaults.set(isVisible, forKey: Key.inspectorVisible)
     }
 
-    func persistInspectorThickness(_ thickness: CGFloat) {
-        defaults.set(Double(thickness), forKey: Key.inspectorTrailingThickness)
+    func persistInspectorThickness(_ thickness: CGFloat, placement: NetworkInspectorPlacement) {
+        defaults.set(Double(thickness), forKey: inspectorThicknessKey(for: placement))
     }
 
     func persistSidebarThickness(_ thickness: CGFloat) {
@@ -97,6 +112,15 @@ private struct NetworkInspectorPreferences {
 
     func persistStructuredFilterVisible(_ isVisible: Bool) {
         defaults.set(isVisible, forKey: Key.structuredFilterVisible)
+    }
+
+    private func inspectorThicknessKey(for placement: NetworkInspectorPlacement) -> String {
+        switch placement {
+        case .trailing:
+            return Key.inspectorTrailingThickness
+        case .bottom:
+            return Key.inspectorBottomThickness
+        }
     }
 }
 
@@ -960,7 +984,7 @@ final class NetworkInspectorViewModel {
         self.packetExportService = packetExportService ?? PacketExportService(defaults: userDefaults)
         self.packetTableAsyncRebuildThreshold = max(1, packetTableAsyncRebuildThreshold)
         self.packetTableFilterBuildHook = packetTableFilterBuildHook
-        self.inspectorPlacement = .trailing
+        self.inspectorPlacement = preferences.inspectorPlacement
         self.isInspectorVisible = preferences.isInspectorVisible
         self.isStructuredFilterVisible = preferences.isStructuredFilterVisible
         self.displayFilterText = preferences.displayFilterText
@@ -1727,23 +1751,40 @@ final class NetworkInspectorViewModel {
     }
 
     func toggleInspector() {
-        setInspectorVisible(!isInspectorVisible)
+        toggleInspector(placement: inspectorPlacement)
     }
 
-    // Keep the last usable trailing inspector width for future launches and reopen actions.
-    func rememberInspectorThickness(_ thickness: CGFloat) {
+    func toggleInspector(placement: NetworkInspectorPlacement) {
+        if isInspectorVisible, inspectorPlacement == placement {
+            setInspectorVisible(false)
+            return
+        }
+
+        inspectorPlacement = placement
+        isInspectorVisible = true
+        preferences.persistInspectorPlacement(placement)
+        preferences.persistInspectorVisible(true)
+        rebuildSnapshot()
+    }
+
+    // Keep the last usable inspector size for its placement so reopen actions restore the same edge.
+    func rememberInspectorThickness(_ thickness: CGFloat, placement: NetworkInspectorPlacement? = nil) {
         guard thickness.isFinite,
               thickness > NetworkInspectorLayoutMetrics.minimumInspectorThickness else {
             return
         }
 
-        preferences.persistInspectorThickness(thickness)
+        preferences.persistInspectorThickness(thickness, placement: placement ?? inspectorPlacement)
     }
 
-    // Reject invalid or collapse-threshold inspector widths so reopen can fall back to a visible default.
-    func preferredInspectorThickness(for availableLength: CGFloat) -> CGFloat? {
+    // Reject invalid or collapse-threshold sizes so reopen can fall back to a visible default.
+    func preferredInspectorThickness(
+        for availableLength: CGFloat,
+        placement: NetworkInspectorPlacement? = nil
+    ) -> CGFloat? {
+        let placement = placement ?? inspectorPlacement
         guard availableLength.isFinite, availableLength > 0,
-              let thickness = preferences.inspectorThickness,
+              let thickness = preferences.inspectorThickness(for: placement),
               thickness.isFinite,
               thickness > NetworkInspectorLayoutMetrics.minimumInspectorThickness,
               thickness < availableLength else {
@@ -1753,13 +1794,16 @@ final class NetworkInspectorViewModel {
         return thickness
     }
 
-    // Use the saved inspector width when it is usable; otherwise reopen at a visible default width.
-    func restoredInspectorThickness(for availableLength: CGFloat) -> CGFloat? {
+    // Use the saved inspector size when it is usable; otherwise reopen at a visible default size.
+    func restoredInspectorThickness(
+        for availableLength: CGFloat,
+        placement: NetworkInspectorPlacement? = nil
+    ) -> CGFloat? {
         guard availableLength.isFinite else {
             return nil
         }
 
-        if let thickness = preferredInspectorThickness(for: availableLength) {
+        if let thickness = preferredInspectorThickness(for: availableLength, placement: placement) {
             return thickness
         }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -617,9 +617,10 @@ final class PacketInspectorViewController: NSViewController {
     private enum Metrics {
         static let rowHeight: CGFloat = 20
         static let cellIdentifier = NSUserInterfaceItemIdentifier("PacketInspectorCell")
-        static let hexPanelHeight: CGFloat = 180
         static let minimumHexPanelHeight: CGFloat = 120
         static let filterBarHeight: CGFloat = 34
+        static let summaryPaneFraction: CGFloat = 0.70
+        static let hexPaneFraction: CGFloat = 0.30
     }
 
     weak var delegate: PacketInspectorViewControllerDelegate?
@@ -628,15 +629,23 @@ final class PacketInspectorViewController: NSViewController {
     private let viewModel = PacketInspectorTreeViewModel()
     private let expansionState = PacketInspectorOutlineExpansionState()
     private let hexViewController: PacketHexViewController
+    private let detailSplitViewController = NSSplitViewController()
+    private let outlineViewController = NSViewController()
     private let stackView = NSStackView()
+    private let detailContainerView = NSView()
     private let filterBarView = NSView()
     private let filterSearchField = NSSearchField()
     private let scrollView = NSScrollView()
     private let outlineView = PacketInspectorOutlineView()
     private let detailColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("detail"))
+    private var outlineItem: NSSplitViewItem?
+    private var hexItem: NSSplitViewItem?
     private var emptyStateView: NSView?
     private var emptyStateMessage: String?
     private var latestInspectionState: PacketInspectionState?
+    private var appliedPlacement: NetworkInspectorPlacement?
+    private var pendingDefaultDetailDividerPlacement: NetworkInspectorPlacement?
+    private var isShowingPacketDetail = false
     private var isApplyingSelection = false
     private var isApplyingExpansionState = false
 
@@ -660,15 +669,126 @@ final class PacketInspectorViewController: NSViewController {
         setupLayout()
     }
 
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        applyPendingDefaultDetailDividerPosition()
+    }
+
     // Render the current packet inspection tree as a single Wireshark-style outline.
     func render(snapshot: NetworkInspectorSnapshot) {
         let inspectionState = snapshot.base.inspectionState
         latestInspectionState = inspectionState
+        let didRevealPacketDetail = updateContentVisibility(for: inspectionState)
+        applyPlacement(
+            snapshot.inspectorPlacement,
+            resetsDefaultDivider: true,
+            forcesDefaultDivider: didRevealPacketDetail
+        )
         let renderChange = viewModel.render(inspectionState: inspectionState, filterText: filterSearchField.stringValue)
         hexViewController.render(inspectionState: inspectionState)
-        updateContentVisibility(for: inspectionState)
 
         applyTreeRenderChange(renderChange, inspectionState: inspectionState)
+    }
+
+    // Switch the outline/hex split to match the outer inspector placement.
+    func applyPlacement(_ placement: NetworkInspectorPlacement) {
+        applyPlacement(placement, resetsDefaultDivider: true, forcesDefaultDivider: false)
+    }
+
+    private func applyPlacement(
+        _ placement: NetworkInspectorPlacement,
+        resetsDefaultDivider: Bool,
+        forcesDefaultDivider: Bool
+    ) {
+        guard let outlineItem, let hexItem else {
+            return
+        }
+
+        let placementChanged = appliedPlacement != placement
+        detailSplitViewController.splitView.isVertical = placement == .bottom
+        outlineItem.preferredThicknessFraction = Metrics.summaryPaneFraction
+        hexItem.preferredThicknessFraction = Metrics.hexPaneFraction
+
+        let targetItems = [outlineItem, hexItem]
+        let orderChanged = !splitItems(detailSplitViewController.splitViewItems, match: targetItems)
+        if orderChanged {
+            for item in detailSplitViewController.splitViewItems.reversed() {
+                detailSplitViewController.removeSplitViewItem(item)
+            }
+            for (index, item) in targetItems.enumerated() {
+                detailSplitViewController.insertSplitViewItem(item, at: index)
+            }
+        }
+
+        appliedPlacement = placement
+        guard resetsDefaultDivider else {
+            pendingDefaultDetailDividerPlacement = placement
+            return
+        }
+
+        if forcesDefaultDivider || placementChanged || orderChanged {
+            scheduleDefaultDetailDividerPosition(for: placement)
+        } else if pendingDefaultDetailDividerPlacement != nil {
+            applyPendingDefaultDetailDividerPosition(afterLayingOut: true)
+        }
+    }
+
+    private func splitItems(_ lhs: [NSSplitViewItem], match rhs: [NSSplitViewItem]) -> Bool {
+        guard lhs.count == rhs.count else {
+            return false
+        }
+
+        return zip(lhs, rhs).allSatisfy { $0 === $1 }
+    }
+
+    private func scheduleDefaultDetailDividerPosition(for placement: NetworkInspectorPlacement) {
+        pendingDefaultDetailDividerPlacement = placement
+        applyPendingDefaultDetailDividerPosition(afterLayingOut: true)
+        DispatchQueue.main.async { [weak self] in
+            self?.applyPendingDefaultDetailDividerPosition(afterLayingOut: true)
+        }
+    }
+
+    private func applyPendingDefaultDetailDividerPosition(afterLayingOut shouldLayout: Bool = false) {
+        if shouldLayout {
+            view.layoutSubtreeIfNeeded()
+        }
+
+        guard let placement = pendingDefaultDetailDividerPlacement,
+              applyDefaultDetailDividerPosition(for: placement) else {
+            return
+        }
+
+        pendingDefaultDetailDividerPlacement = nil
+    }
+
+    @discardableResult
+    private func applyDefaultDetailDividerPosition(for placement: NetworkInspectorPlacement) -> Bool {
+        let splitView = detailSplitViewController.splitView
+        splitView.layoutSubtreeIfNeeded()
+        let totalLength = splitView.isVertical ? splitView.bounds.width : splitView.bounds.height
+        let availableLength = totalLength - splitView.dividerThickness
+        guard splitView.subviews.count >= 2,
+              hasSettledDetailSplitLayout(),
+              availableLength.isFinite,
+              availableLength > 0 else {
+            return false
+        }
+
+        splitView.setPosition((availableLength * Metrics.summaryPaneFraction).rounded(), ofDividerAt: 0)
+        return true
+    }
+
+    private func hasSettledDetailSplitLayout() -> Bool {
+        let detailFrame = detailSplitViewController.view.convert(detailSplitViewController.view.bounds, to: stackView)
+        let expectedDetailHeight = stackView.bounds.height - filterBarView.bounds.height
+        guard stackView.bounds.width > 0,
+              expectedDetailHeight > 0 else {
+            return false
+        }
+
+        return abs(detailFrame.width - stackView.bounds.width) <= 1 &&
+            abs(detailFrame.height - expectedDetailHeight) <= 1
     }
 
     private func applyTreeRenderChange(
@@ -748,36 +868,58 @@ final class PacketInspectorViewController: NSViewController {
     }
 
     private func setupLayout() {
-        addChild(hexViewController)
+        outlineViewController.view = scrollView
+        let outlineItem = NSSplitViewItem(viewController: outlineViewController)
+        outlineItem.minimumThickness = 160
+        let hexItem = NSSplitViewItem(viewController: hexViewController)
+        hexItem.minimumThickness = Metrics.minimumHexPanelHeight
+        self.outlineItem = outlineItem
+        self.hexItem = hexItem
+
+        addChild(detailSplitViewController)
+        // Keep the split layout slot stable while the empty state hides the inspector content.
+        detailContainerView.translatesAutoresizingMaskIntoConstraints = false
+        detailContainerView.addSubview(detailSplitViewController.view)
+        detailSplitViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         stackView.orientation = .vertical
+        stackView.alignment = .width
         stackView.spacing = 0
         stackView.edgeInsets = NSEdgeInsetsZero
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addArrangedSubview(filterBarView)
-        stackView.addArrangedSubview(scrollView)
-        stackView.addArrangedSubview(hexViewController.view)
-
-        scrollView.setContentHuggingPriority(.defaultLow, for: .vertical)
-        hexViewController.view.setContentHuggingPriority(.defaultHigh, for: .vertical)
-
-        let hexHeight = hexViewController.view.heightAnchor.constraint(equalToConstant: Metrics.hexPanelHeight)
-        hexHeight.priority = .defaultHigh
+        stackView.addArrangedSubview(detailContainerView)
+        filterBarView.setContentHuggingPriority(.required, for: .vertical)
+        filterBarView.setContentCompressionResistancePriority(.required, for: .vertical)
+        detailContainerView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        detailContainerView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        applyPlacement(.trailing, resetsDefaultDivider: false, forcesDefaultDivider: false)
 
         view.addSubview(stackView)
         NSLayoutConstraint.activate([
+            filterBarView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            detailContainerView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            detailContainerView.heightAnchor.constraint(equalTo: stackView.heightAnchor, constant: -Metrics.filterBarHeight),
+            detailSplitViewController.view.leadingAnchor.constraint(equalTo: detailContainerView.leadingAnchor),
+            detailSplitViewController.view.trailingAnchor.constraint(equalTo: detailContainerView.trailingAnchor),
+            detailSplitViewController.view.topAnchor.constraint(equalTo: detailContainerView.topAnchor),
+            detailSplitViewController.view.bottomAnchor.constraint(equalTo: detailContainerView.bottomAnchor),
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            hexHeight,
-            hexViewController.view.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.minimumHexPanelHeight),
         ])
     }
 
     // Swap between the launch empty state and packet-detail controls.
-    private func updateContentVisibility(for inspectionState: PacketInspectionState) {
+    @discardableResult
+    private func updateContentVisibility(for inspectionState: PacketInspectionState) -> Bool {
         let shouldShowEmptyState = inspectionState.selectedPacketID == nil
+        let shouldShowPacketDetail = !shouldShowEmptyState
+        let didRevealPacketDetail = shouldShowPacketDetail && !isShowingPacketDetail
+        isShowingPacketDetail = shouldShowPacketDetail
+
+        detailSplitViewController.view.isHidden = shouldShowEmptyState
         scrollView.isHidden = shouldShowEmptyState
         outlineView.isHidden = shouldShowEmptyState
         hexViewController.view.isHidden = shouldShowEmptyState
@@ -787,6 +929,8 @@ final class PacketInspectorViewController: NSViewController {
         } else {
             hideEmptyState()
         }
+
+        return didRevealPacketDetail
     }
 
     // Focus the always-visible filter field without changing the active query.

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -37,8 +37,10 @@ final class TCPViewerRootViewController: NSViewController {
     private let inspectorViewController: PacketInspectorViewController
     private let statusStripViewController = StatusStripViewController()
     private var sidebarItem: NSSplitViewItem?
+    private var workspaceItem: NSSplitViewItem?
     private var inspectorItem: NSSplitViewItem?
     private var appliedInspectorVisibility: Bool?
+    private var appliedInspectorPlacement: NetworkInspectorPlacement?
     private var needsSidebarDividerRefresh = false
     private var needsInspectorDividerRefresh = false
     private var isRestoringInspectorDivider = false
@@ -100,7 +102,7 @@ final class TCPViewerRootViewController: NSViewController {
 
         if needsInspectorDividerRefresh, inspectorItem?.isCollapsed == false {
             needsInspectorDividerRefresh = false
-            applyInspectorDividerPosition()
+            applyInspectorDividerPosition(placement: appliedInspectorPlacement ?? viewModel.snapshot.inspectorPlacement)
         }
     }
 
@@ -138,6 +140,10 @@ final class TCPViewerRootViewController: NSViewController {
 
     func toggleInspector() {
         viewModel.toggleInspector()
+    }
+
+    func toggleInspector(placement: NetworkInspectorPlacement) {
+        viewModel.toggleInspector(placement: placement)
     }
 
     func toggleQuickFilter(_ filterID: PacketQuickFilterID) {
@@ -241,7 +247,7 @@ final class TCPViewerRootViewController: NSViewController {
     }
 
     private func setupChildControllers() {
-        // Build the two-level split layout: sidebar | (table | inspector).
+        // Build the two-level split layout: sidebar | (workspace + inspector).
         sidebarViewController.delegate = self
         workspaceViewController.delegate = self
         inspectorViewController.delegate = self
@@ -253,6 +259,7 @@ final class TCPViewerRootViewController: NSViewController {
         // Keep the table and inspector inside the main container split.
         let workspaceItem = NSSplitViewItem(contentListWithViewController: workspaceViewController)
         contentSplitViewController.addSplitViewItem(workspaceItem)
+        self.workspaceItem = workspaceItem
 
         let inspectorItem = NSSplitViewItem(viewController: inspectorViewController)
         inspectorItem.canCollapse = true
@@ -365,58 +372,104 @@ final class TCPViewerRootViewController: NSViewController {
         splitView.setPosition(sidebarThickness, ofDividerAt: 0)
     }
 
-    // Keep the inspector in the right-side split item and only update collapse state when needed.
+    // Keep inspector placement and collapse state in sync with toolbar/view-model state.
     private func applyInspectorLayout(_ snapshot: NetworkInspectorSnapshot) {
+        let placementChanged = appliedInspectorPlacement != snapshot.inspectorPlacement
         let visibilityChanged = appliedInspectorVisibility != snapshot.isInspectorVisible
+        let previousPlacement = appliedInspectorPlacement ?? snapshot.inspectorPlacement
 
-        contentSplitViewController.splitView.isVertical = true
+        if placementChanged, appliedInspectorVisibility == true {
+            persistCurrentInspectorThicknessIfVisible(placement: previousPlacement)
+        }
+
+        if placementChanged {
+            isRestoringInspectorDivider = true
+            configureInspectorPlacement(snapshot.inspectorPlacement)
+        }
+        inspectorViewController.applyPlacement(snapshot.inspectorPlacement)
+
+        appliedInspectorPlacement = snapshot.inspectorPlacement
         if visibilityChanged {
             if !snapshot.isInspectorVisible {
-                persistCurrentInspectorThicknessIfVisible()
+                persistCurrentInspectorThicknessIfVisible(placement: snapshot.inspectorPlacement)
                 inspectorItem?.isCollapsed = true
             } else {
-                restoreInspectorDividerAfterOpening()
+                restoreInspectorDividerAfterOpening(placement: snapshot.inspectorPlacement)
             }
+        } else if placementChanged, snapshot.isInspectorVisible {
+            restoreInspectorDividerAfterOpening(placement: snapshot.inspectorPlacement)
+        } else if placementChanged {
+            clearTemporaryInspectorRestoreThickness()
+            isRestoringInspectorDivider = false
         }
 
         appliedInspectorVisibility = snapshot.isInspectorVisible
     }
 
-    // Expand the inspector without letting AppKit's intermediate resize overwrite the saved width.
-    private func restoreInspectorDividerAfterOpening() {
+    private func configureInspectorPlacement(_ placement: NetworkInspectorPlacement) {
+        guard let workspaceItem, let inspectorItem else {
+            return
+        }
+
+        contentSplitViewController.splitView.isVertical = placement == .trailing
+
+        // Keep workspace first; this split view is flipped, so the second item renders at the bottom.
+        let targetItems = [workspaceItem, inspectorItem]
+        guard !splitItems(contentSplitViewController.splitViewItems, match: targetItems) else {
+            return
+        }
+
+        for item in contentSplitViewController.splitViewItems.reversed() {
+            contentSplitViewController.removeSplitViewItem(item)
+        }
+        for (index, item) in targetItems.enumerated() {
+            contentSplitViewController.insertSplitViewItem(item, at: index)
+        }
+    }
+
+    private func splitItems(_ lhs: [NSSplitViewItem], match rhs: [NSSplitViewItem]) -> Bool {
+        guard lhs.count == rhs.count else {
+            return false
+        }
+
+        return zip(lhs, rhs).allSatisfy { $0 === $1 }
+    }
+
+    // Expand the inspector without letting AppKit's intermediate resize overwrite the saved size.
+    private func restoreInspectorDividerAfterOpening(placement: NetworkInspectorPlacement) {
         isRestoringInspectorDivider = true
-        prepareInspectorItemForExactRestore()
+        prepareInspectorItemForExactRestore(placement: placement)
         inspectorItem?.isCollapsed = false
-        applyInspectorDividerPosition()
+        applyInspectorDividerPosition(placement: placement)
         DispatchQueue.main.async { [weak self] in
             guard let self else {
                 return
             }
 
-            self.applyInspectorDividerPosition()
+            self.applyInspectorDividerPosition(placement: placement)
             self.view.layoutSubtreeIfNeeded()
             DispatchQueue.main.async { [weak self] in
                 guard let self else {
                     return
                 }
 
-                self.applyInspectorDividerPosition()
+                self.applyInspectorDividerPosition(placement: placement)
                 self.clearTemporaryInspectorRestoreThickness()
                 self.view.layoutSubtreeIfNeeded()
-                self.applyInspectorDividerPosition()
+                self.applyInspectorDividerPosition(placement: placement)
                 self.isRestoringInspectorDivider = false
                 print("[TCPViewer] Inspector restore settled: \(self.inspectorSplitDebugDescription())")
             }
         }
     }
 
-    // Lock the split item briefly so AppKit's uncollapse animation starts at the saved width.
-    private func prepareInspectorItemForExactRestore() {
+    // Lock the split item briefly so AppKit's uncollapse animation starts at the saved size.
+    private func prepareInspectorItemForExactRestore(placement: NetworkInspectorPlacement) {
         let splitView = contentSplitViewController.splitView
-        guard let inspectorThickness = inspectorRestoreThickness(for: splitView) else {
+        guard let inspectorThickness = inspectorRestoreThickness(for: splitView, placement: placement) else {
             clearTemporaryInspectorRestoreThickness()
             print(
-                "[TCPViewer] Inspector restore skipped: no usable width. " +
+                "[TCPViewer] Inspector restore skipped: no usable size. " +
                 "\(inspectorSplitDebugDescription())"
             )
             return
@@ -426,7 +479,7 @@ final class TCPViewerRootViewController: NSViewController {
         inspectorItem?.minimumThickness = inspectorThickness
         inspectorItem?.maximumThickness = inspectorThickness
         print(
-            "[TCPViewer] Inspector restore prepared: targetWidth=\(debugValue(inspectorThickness)) " +
+            "[TCPViewer] Inspector restore prepared: targetSize=\(debugValue(inspectorThickness)) " +
             "\(inspectorSplitDebugDescription())"
         )
     }
@@ -441,8 +494,8 @@ final class TCPViewerRootViewController: NSViewController {
         inspectorItem?.maximumThickness = NSSplitViewItem.unspecifiedDimension
     }
 
-    // Reapply the saved trailing divider position once the split view has a real width.
-    private func applyInspectorDividerPosition() {
+    // Reapply the saved divider position once the split view has a real size.
+    private func applyInspectorDividerPosition(placement: NetworkInspectorPlacement) {
         let splitView = contentSplitViewController.splitView
         guard splitView.dividerThickness.isFinite else {
             print("[TCPViewer] Inspector restore skipped: invalid divider thickness. \(inspectorSplitDebugDescription())")
@@ -450,15 +503,15 @@ final class TCPViewerRootViewController: NSViewController {
         }
 
         splitView.layoutSubtreeIfNeeded()
-        let totalLength = splitView.bounds.width
+        let totalLength = inspectorSplitLength(splitView, placement: placement)
         guard totalLength > 0 else {
             needsInspectorDividerRefresh = true
-            print("[TCPViewer] Inspector restore deferred: split width is \(debugValue(totalLength))")
+            print("[TCPViewer] Inspector restore deferred: split size is \(debugValue(totalLength))")
             return
         }
 
-        guard let inspectorThickness = inspectorRestoreThickness(for: splitView) else {
-            print("[TCPViewer] Inspector restore skipped: no usable width. \(inspectorSplitDebugDescription())")
+        guard let inspectorThickness = inspectorRestoreThickness(for: splitView, placement: placement) else {
+            print("[TCPViewer] Inspector restore skipped: no usable size. \(inspectorSplitDebugDescription())")
             return
         }
 
@@ -466,13 +519,13 @@ final class TCPViewerRootViewController: NSViewController {
         guard dividerPosition.isFinite, dividerPosition > 0 else {
             print(
                 "[TCPViewer] Inspector restore skipped: invalid divider=\(debugValue(dividerPosition)) " +
-                "targetWidth=\(debugValue(inspectorThickness)) \(inspectorSplitDebugDescription())"
+                "targetSize=\(debugValue(inspectorThickness)) \(inspectorSplitDebugDescription())"
             )
             return
         }
 
         print(
-            "[TCPViewer] Inspector restore applying: targetWidth=\(debugValue(inspectorThickness)) " +
+            "[TCPViewer] Inspector restore applying: targetSize=\(debugValue(inspectorThickness)) " +
             "restoreDivider=\(debugValue(dividerPosition)) subviews=\(splitView.subviews.count) " +
             "\(inspectorSplitDebugDescription())"
         )
@@ -480,9 +533,18 @@ final class TCPViewerRootViewController: NSViewController {
         print("[TCPViewer] Inspector restore applied: \(inspectorSplitDebugDescription())")
     }
 
-    private func inspectorRestoreThickness(for splitView: NSSplitView) -> CGFloat? {
-        let availableLength = splitView.bounds.width - splitView.dividerThickness
-        return viewModel.restoredInspectorThickness(for: availableLength)
+    private func inspectorRestoreThickness(for splitView: NSSplitView, placement: NetworkInspectorPlacement) -> CGFloat? {
+        let availableLength = inspectorSplitLength(splitView, placement: placement) - splitView.dividerThickness
+        return viewModel.restoredInspectorThickness(for: availableLength, placement: placement)
+    }
+
+    private func inspectorSplitLength(_ splitView: NSSplitView, placement: NetworkInspectorPlacement) -> CGFloat {
+        switch placement {
+        case .trailing:
+            return splitView.bounds.width
+        case .bottom:
+            return splitView.bounds.height
+        }
     }
 
     private func configureSplitViewObservation() {
@@ -518,7 +580,7 @@ final class TCPViewerRootViewController: NSViewController {
         persistCurrentInspectorLayout()
     }
 
-    // Persist the trailing split state after manual drags and AppKit-driven collapses.
+    // Persist the inspector split state after manual drags and AppKit-driven collapses.
     private func persistCurrentInspectorLayout() {
         let isVisible = inspectorItem?.isCollapsed == false
         viewModel.setInspectorVisible(isVisible)
@@ -526,24 +588,31 @@ final class TCPViewerRootViewController: NSViewController {
     }
 
     // Persist only visible inspector sizes so collapsing the pane never stores a broken zero value.
-    private func persistCurrentInspectorThicknessIfVisible() {
-        guard let thickness = currentInspectorThickness() else {
+    private func persistCurrentInspectorThicknessIfVisible(placement: NetworkInspectorPlacement? = nil) {
+        let placement = placement ?? appliedInspectorPlacement ?? viewModel.snapshot.inspectorPlacement
+        guard let thickness = currentInspectorThickness(placement: placement) else {
             return
         }
 
-        print("[TCPViewer] Inspector persist width: width=\(debugValue(thickness)) \(inspectorSplitDebugDescription())")
-        viewModel.rememberInspectorThickness(thickness)
+        print("[TCPViewer] Inspector persist size: size=\(debugValue(thickness)) \(inspectorSplitDebugDescription())")
+        viewModel.rememberInspectorThickness(thickness, placement: placement)
     }
 
-    // Read the live inspector width from AppKit's trailing split item when it is on screen.
-    private func currentInspectorThickness() -> CGFloat? {
+    // Read the live inspector size from AppKit's split item when it is on screen.
+    private func currentInspectorThickness(placement: NetworkInspectorPlacement) -> CGFloat? {
         guard let inspectorView = inspectorItem?.viewController.view,
               inspectorView.superview != nil,
               inspectorItem?.isCollapsed == false else {
             return nil
         }
 
-        let thickness = inspectorView.frame.width
+        let thickness: CGFloat
+        switch placement {
+        case .trailing:
+            thickness = inspectorView.frame.width
+        case .bottom:
+            thickness = inspectorView.frame.height
+        }
         guard thickness.isFinite, thickness > 0 else {
             return nil
         }
@@ -553,9 +622,16 @@ final class TCPViewerRootViewController: NSViewController {
 
     private func inspectorSplitDebugDescription() -> String {
         let splitView = contentSplitViewController.splitView
-        let dividerPosition = splitView.subviews.first?.frame.maxX
-        let inspectorWidth = inspectorItem?.viewController.view.frame.width
-        return "total=\(debugValue(splitView.bounds.width)) divider=\(debugValue(dividerPosition)) inspectorWidth=\(debugValue(inspectorWidth)) collapsed=\(inspectorItem?.isCollapsed == true)"
+        let placement = appliedInspectorPlacement ?? viewModel.snapshot.inspectorPlacement
+        let dividerPosition: CGFloat?
+        switch placement {
+        case .trailing:
+            dividerPosition = splitView.subviews.first?.frame.maxX
+        case .bottom:
+            dividerPosition = splitView.subviews.first?.frame.maxY
+        }
+        let inspectorSize = currentInspectorThickness(placement: placement)
+        return "placement=\(placement.rawValue) total=\(debugValue(inspectorSplitLength(splitView, placement: placement))) divider=\(debugValue(dividerPosition)) inspectorSize=\(debugValue(inspectorSize)) collapsed=\(inspectorItem?.isCollapsed == true)"
     }
 
     private func debugValue(_ value: CGFloat?) -> String {
@@ -923,6 +999,23 @@ extension TCPViewerRootViewController {
         )
         packetSelectionCrashReproducer = reproducer
         reproducer.start()
+    }
+}
+#endif
+
+#if DEBUG
+extension TCPViewerRootViewController {
+    // Expose split geometry to unit tests without depending on nested AppKit view discovery.
+    var inspectorSplitViewForTesting: NSSplitView {
+        contentSplitViewController.splitView
+    }
+
+    var workspaceViewForTesting: NSView? {
+        workspaceItem?.viewController.view
+    }
+
+    var inspectorViewForTesting: NSView? {
+        inspectorItem?.viewController.view
     }
 }
 #endif

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -625,6 +625,127 @@ struct NetworkInspectorViewModelTests {
         #expect(hiddenReloadedViewModel.snapshot.isInspectorVisible)
     }
 
+    @Test func inspectorPlacementTogglesCloseActivePlacementAndSwitchVisiblePlacement() {
+        let defaults = isolatedDefaults()
+        let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
+            interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+        ))
+        let viewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        #expect(viewModel.snapshot.inspectorPlacement == .trailing)
+        #expect(viewModel.snapshot.isInspectorVisible)
+
+        viewModel.toggleInspector(placement: .trailing)
+        #expect(viewModel.snapshot.inspectorPlacement == .trailing)
+        #expect(!viewModel.snapshot.isInspectorVisible)
+
+        viewModel.toggleInspector(placement: .bottom)
+        #expect(viewModel.snapshot.inspectorPlacement == .bottom)
+        #expect(viewModel.snapshot.isInspectorVisible)
+
+        viewModel.toggleInspector(placement: .trailing)
+        #expect(viewModel.snapshot.inspectorPlacement == .trailing)
+        #expect(viewModel.snapshot.isInspectorVisible)
+
+        viewModel.toggleInspector(placement: .trailing)
+        #expect(viewModel.snapshot.inspectorPlacement == .trailing)
+        #expect(!viewModel.snapshot.isInspectorVisible)
+    }
+
+    @Test func bottomInspectorPlacementPersistsAcrossReloads() {
+        let defaults = isolatedDefaults()
+        let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
+            interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+        ))
+        let viewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        viewModel.toggleInspector(placement: .bottom)
+
+        let reloadedViewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        #expect(reloadedViewModel.snapshot.inspectorPlacement == .bottom)
+        #expect(reloadedViewModel.snapshot.isInspectorVisible)
+
+        reloadedViewModel.toggleInspector(placement: .bottom)
+
+        let hiddenReloadedViewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        #expect(hiddenReloadedViewModel.snapshot.inspectorPlacement == .bottom)
+        #expect(!hiddenReloadedViewModel.snapshot.isInspectorVisible)
+    }
+
+    @Test func bottomInspectorPlacementLaysOutInspectorBelowWorkspace() async throws {
+        let packet = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let document = InspectorFakeDocument(
+            url: URL(fileURLWithPath: "/tmp/root-bottom-inspector.pcapng"),
+            packets: [packet]
+        )
+        let defaults = isolatedDefaults()
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: defaults
+        )
+        let controller = TCPViewerRootViewController(
+            viewModel: viewModel,
+            configuration: AppConfiguration(defaults: defaults)
+        )
+
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 1_200, height: 800)
+        controller.view.layoutSubtreeIfNeeded()
+
+        await viewModel.openDocument(at: document.currentURL())
+        await waitUntil {
+            viewModel.snapshot.packetRows.map(\.id) == [packet.id]
+        }
+
+        viewModel.selectPacket(packet.id)
+        await waitUntil {
+            viewModel.snapshot.base.inspectionState.inspection?.packetID == packet.id
+        }
+
+        viewModel.toggleInspector(placement: .bottom)
+        controller.view.layoutSubtreeIfNeeded()
+        await waitUntil {
+            guard let workspaceView = controller.workspaceViewForTesting,
+                  let inspectorView = controller.inspectorViewForTesting else {
+                return false
+            }
+
+            let splitView = controller.inspectorSplitViewForTesting
+            let inspectorFrame = inspectorView.convert(inspectorView.bounds, to: splitView)
+            let workspaceFrame = workspaceView.convert(workspaceView.bounds, to: splitView)
+            return !splitView.isVertical &&
+                inspectorFrame.height > 0 &&
+                workspaceFrame.height > 0 &&
+                frame(inspectorFrame, isVisuallyBelow: workspaceFrame, in: splitView)
+        }
+
+        let splitView = controller.inspectorSplitViewForTesting
+        let workspaceView = try #require(controller.workspaceViewForTesting)
+        let inspectorView = try #require(controller.inspectorViewForTesting)
+        let inspectorFrame = inspectorView.convert(inspectorView.bounds, to: splitView)
+        let workspaceFrame = workspaceView.convert(workspaceView.bounds, to: splitView)
+
+        #expect(!splitView.isVertical)
+        #expect(frame(inspectorFrame, isVisuallyBelow: workspaceFrame, in: splitView))
+    }
+
     @Test func sidebarVisibilityPersistsAcrossReloads() {
         let defaults = isolatedDefaults()
         let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
@@ -897,6 +1018,39 @@ struct NetworkInspectorViewModelTests {
 
         #expect(reloadedViewModel.preferredInspectorThickness(for: 900) == 101)
         #expect(reloadedViewModel.restoredInspectorThickness(for: 900) == 101)
+    }
+
+    @Test func bottomInspectorThicknessPersistsAndFallsBackWhenInvalid() {
+        let defaults = isolatedDefaults()
+        let services = TCPViewerServiceRegistry(core: InspectorFakeCore(
+            interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+        ))
+        let viewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        viewModel.rememberInspectorThickness(420, placement: .trailing)
+        viewModel.rememberInspectorThickness(260, placement: .bottom)
+
+        let reloadedViewModel = NetworkInspectorViewModel(
+            services: services,
+            userDefaults: defaults
+        )
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900, placement: .trailing) == 420)
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900, placement: .bottom) == 260)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900, placement: .bottom) == 260)
+
+        reloadedViewModel.rememberInspectorThickness(10_000, placement: .bottom)
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900, placement: .bottom) == nil)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 900, placement: .bottom) == 360)
+
+        reloadedViewModel.rememberInspectorThickness(100, placement: .bottom)
+
+        #expect(reloadedViewModel.preferredInspectorThickness(for: 900, placement: .bottom) == nil)
+        #expect(reloadedViewModel.restoredInspectorThickness(for: 100, placement: .bottom) == nil)
     }
 
     @Test func packetRowsAppendIncrementallyForMatchingLiveBatches() async {
@@ -2890,6 +3044,15 @@ private func allSubviews<T: NSView>(ofType type: T.Type, in view: NSView) -> [T]
     return view.subviews.reduce(current) { result, subview in
         result + allSubviews(ofType: type, in: subview)
     }
+}
+
+private func frame(_ lowerFrame: NSRect, isVisuallyBelow upperFrame: NSRect, in view: NSView) -> Bool {
+    let tolerance: CGFloat = 1
+    if view.isFlipped {
+        return lowerFrame.minY >= upperFrame.maxY - tolerance
+    }
+
+    return lowerFrame.maxY <= upperFrame.minY + tolerance
 }
 
 private final class PacketFilterBuildGate: @unchecked Sendable {

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
@@ -108,6 +108,67 @@ struct PacketInspectorTreeViewModelTests {
     }
 
     @MainActor
+    @Test func rightPlacementLaysOutOutlineAboveHexView() throws {
+        let packet = makePacket()
+        let controller = PacketInspectorViewController(configuration: AppConfiguration(defaults: isolatedDefaults()))
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 500, height: 500)
+
+        controller.render(snapshot: makeSnapshot(
+            packet: packet,
+            inspectionState: loadedInspectionState(packet: packet, inspection: makeFrameInspection(for: packet)),
+            inspectorPlacement: .trailing
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let splitView = try #require(findInspectorDetailSplitView(in: controller.view))
+        let outlinePane = try #require(splitView.subviews.first { firstSubview(ofType: NSOutlineView.self, in: $0) != nil })
+        let hexPane = try #require(splitView.subviews.first { firstSubview(ofType: HFTextView.self, in: $0) != nil })
+        let splitFrame = splitView.convert(splitView.bounds, to: controller.view)
+        let outlineFrame = outlinePane.convert(outlinePane.bounds, to: splitView)
+        let hexFrame = hexPane.convert(hexPane.bounds, to: splitView)
+        let availableHeight = splitView.bounds.height - splitView.dividerThickness
+
+        #expect(!splitView.isVertical)
+        #expect(frame(outlineFrame, isVisuallyAbove: hexFrame, in: splitView))
+        #expect(abs(splitFrame.width - controller.view.bounds.width) <= 1)
+        #expect(abs(splitFrame.height - (controller.view.bounds.height - 34)) <= 1)
+        #expect(abs(outlineFrame.height - availableHeight * 0.70) <= 2)
+        #expect(abs(hexFrame.height - availableHeight * 0.30) <= 2)
+    }
+
+    @MainActor
+    @Test func bottomPlacementLaysOutOutlineBesideHexView() throws {
+        let packet = makePacket()
+        let controller = PacketInspectorViewController(configuration: AppConfiguration(defaults: isolatedDefaults()))
+        controller.loadViewIfNeeded()
+        controller.view.frame = NSRect(x: 0, y: 0, width: 700, height: 360)
+
+        controller.render(snapshot: makeSnapshot(
+            packet: packet,
+            inspectionState: loadedInspectionState(packet: packet, inspection: makeFrameInspection(for: packet)),
+            inspectorPlacement: .bottom
+        ))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let splitView = try #require(findInspectorDetailSplitView(in: controller.view))
+        let outlinePane = try #require(splitView.subviews.first { firstSubview(ofType: NSOutlineView.self, in: $0) != nil })
+        let hexPane = try #require(splitView.subviews.first { firstSubview(ofType: HFTextView.self, in: $0) != nil })
+        let splitFrame = splitView.convert(splitView.bounds, to: controller.view)
+        let outlineFrame = outlinePane.convert(outlinePane.bounds, to: splitView)
+        let hexFrame = hexPane.convert(hexPane.bounds, to: splitView)
+        let availableWidth = splitView.bounds.width - splitView.dividerThickness
+
+        #expect(splitView.isVertical)
+        #expect(outlinePane.frame.minX < hexPane.frame.minX)
+        #expect(abs(splitFrame.width - controller.view.bounds.width) <= 1)
+        #expect(abs(outlineFrame.minX - splitView.bounds.minX) <= 1)
+        #expect(abs(hexFrame.maxX - splitView.bounds.maxX) <= 1)
+        #expect(abs(outlineFrame.width - availableWidth * 0.70) <= 2)
+        #expect(abs(hexFrame.width - availableWidth * 0.30) <= 2)
+    }
+
+    @MainActor
     @Test func inspectorContextMenuIncludesFilterCommandForRows() throws {
         let packet = makePacket()
         let controller = PacketInspectorViewController(configuration: AppConfiguration(defaults: isolatedDefaults()))
@@ -746,7 +807,11 @@ struct PacketInspectorTreeViewModelTests {
         #expect(abs(outlineScrollView.contentView.bounds.origin.y - originalY) <= 1)
     }
 
-    private func makeSnapshot(packet: PacketSummary? = nil, inspectionState: PacketInspectionState) -> NetworkInspectorSnapshot {
+    private func makeSnapshot(
+        packet: PacketSummary? = nil,
+        inspectionState: PacketInspectionState,
+        inspectorPlacement: NetworkInspectorPlacement = .trailing
+    ) -> NetworkInspectorSnapshot {
         var base = TCPViewerWindowSnapshot.foundation
         if let packet {
             base.packetIngestState.replace(with: [packet], source: packet.source)
@@ -775,6 +840,7 @@ struct PacketInspectorTreeViewModelTests {
             sourceListFilterText: "",
             workspaceMode: .packets,
             inspectorTab: .summary,
+            inspectorPlacement: inspectorPlacement,
             isInspectorVisible: true,
             displayFilterText: "",
             packetTableContent: tableContent
@@ -806,11 +872,27 @@ struct PacketInspectorTreeViewModelTests {
         allSubviews(ofType: NSScrollView.self, in: view).first { $0.documentView is NSOutlineView }
     }
 
+    private func findInspectorDetailSplitView(in view: NSView) -> NSSplitView? {
+        allSubviews(ofType: NSSplitView.self, in: view).first { splitView in
+            splitView.subviews.contains { firstSubview(ofType: NSOutlineView.self, in: $0) != nil } &&
+                splitView.subviews.contains { firstSubview(ofType: HFTextView.self, in: $0) != nil }
+        }
+    }
+
     private func allSubviews<T: NSView>(ofType type: T.Type, in view: NSView) -> [T] {
         let current = (view as? T).map { [$0] } ?? []
         return view.subviews.reduce(current) { result, subview in
             result + allSubviews(ofType: type, in: subview)
         }
+    }
+
+    private func frame(_ upperFrame: NSRect, isVisuallyAbove lowerFrame: NSRect, in view: NSView) -> Bool {
+        let tolerance: CGFloat = 1
+        if view.isFlipped {
+            return upperFrame.maxY <= lowerFrame.minY + tolerance
+        }
+
+        return upperFrame.minY >= lowerFrame.maxY - tolerance
     }
 
     private func hasTopConstraint(from view: NSView, to layoutGuide: NSLayoutGuide, in container: NSView) -> Bool {


### PR DESCRIPTION
## Summary
- Keep the packet detail split view in a stable content container so the empty state no longer collapses the right-side inspector layout on first packet selection.
- Force the default divider once when packet details first appear so right mode starts at a 70/30 summary-to-hex ratio.
- Add regression coverage for right-mode full-height layout and the expected 70/30 split.

## Testing
- Full macOS test suite passed.
- Project build passed.