### PR TITLE
Preserve dynamic background colors in inspector views

### DIFF
--- a/TCPViewer/Core/AppKitUIUtilities.swift
+++ b/TCPViewer/Core/AppKitUIUtilities.swift
@@ -7,6 +7,43 @@
 
 import AppKit
 
+final class TCPViewerDynamicBackgroundView: NSView {
+    var backgroundColor: NSColor {
+        didSet {
+            updateLayerBackgroundColor()
+        }
+    }
+
+    init(backgroundColor: NSColor) {
+        self.backgroundColor = backgroundColor
+        super.init(frame: .zero)
+        wantsLayer = true
+        updateLayerBackgroundColor()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        updateLayerBackgroundColor()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateLayerBackgroundColor()
+    }
+
+    private func updateLayerBackgroundColor() {
+        // Resolve dynamic NSColor values against this view's current light/dark appearance.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            layer?.backgroundColor = backgroundColor.cgColor
+        }
+    }
+}
+
 enum TCPViewerUI {
     enum PlaceholderPlacement {
         case center

--- a/TCPViewer/Features/NetworkInspector/Views/PacketHexViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketHexViewController.swift
@@ -65,9 +65,7 @@ final class PacketHexViewController: NSViewController {
     }
 
     override func loadView() {
-        view = NSView()
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
         setupStackView()
         setupByteViewControl()
         setupHexTextView()

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -633,7 +633,7 @@ final class PacketInspectorViewController: NSViewController {
     private let outlineViewController = NSViewController()
     private let stackView = NSStackView()
     private let detailContainerView = NSView()
-    private let filterBarView = NSView()
+    private let filterBarView = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
     private let filterSearchField = NSSearchField()
     private let scrollView = NSScrollView()
     private let outlineView = PacketInspectorOutlineView()
@@ -661,9 +661,7 @@ final class PacketInspectorViewController: NSViewController {
     }
 
     override func loadView() {
-        view = NSView()
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
         setupFilterBar()
         setupOutlineView()
         setupLayout()
@@ -817,8 +815,6 @@ final class PacketInspectorViewController: NSViewController {
 
     private func setupFilterBar() {
         filterBarView.translatesAutoresizingMaskIntoConstraints = false
-        filterBarView.wantsLayer = true
-        filterBarView.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
 
         filterSearchField.placeholderString = "Filter key or value"
         filterSearchField.sendsSearchStringImmediately = true

--- a/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
@@ -420,9 +420,7 @@ final class PacketStructuredFilterViewController: NSViewController {
     }
 
     override func loadView() {
-        view = NSView()
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
         setupLayout()
         rebuildRows()
     }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -120,9 +120,7 @@ final class PacketWorkspaceViewController: NSViewController {
     }
 
     override func loadView() {
-        view = NSView()
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
         setupContent()
     }
 

--- a/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
@@ -55,9 +55,7 @@ final class StatusStripViewController: NSViewController {
     )
 
     override func loadView() {
-        view = NSView()
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .windowBackgroundColor)
         setupLayout()
     }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -315,7 +315,7 @@ final class TCPViewerRootViewController: NSViewController {
         contentSplitViewController.addSplitViewItem(inspectorItem)
         self.inspectorItem = inspectorItem
 
-        mainContainerViewController.view = NSView()
+        mainContainerViewController.view = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
         mainContainerViewController.addChild(contentSplitViewController)
         mainContainerViewController.addChild(statusStripViewController)
 

--- a/TCPViewerTests/TCPViewerTests.swift
+++ b/TCPViewerTests/TCPViewerTests.swift
@@ -7,6 +7,7 @@
 
 import Testing
 import Foundation
+import AppKit
 import PcapPlusPlusCore
 @testable import TCPViewer
 
@@ -42,11 +43,33 @@ struct TCPViewerTests {
         #expect(viewModel.snapshot.displayFilterText == "protocol:tcp")
     }
 
+    @Test func dynamicBackgroundViewUpdatesLayerColorForAppearanceChanges() throws {
+        let dynamicColor = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .black : .white
+        }
+        let view = TCPViewerDynamicBackgroundView(backgroundColor: dynamicColor)
+
+        view.appearance = NSAppearance(named: .aqua)
+        view.viewDidChangeEffectiveAppearance()
+        let lightBackground = try #require(view.layer?.backgroundColor)
+
+        view.appearance = NSAppearance(named: .darkAqua)
+        view.viewDidChangeEffectiveAppearance()
+        let darkBackground = try #require(view.layer?.backgroundColor)
+
+        #expect(try brightness(of: lightBackground) > brightness(of: darkBackground))
+    }
+
     private static func makeUserDefaults() -> UserDefaults {
         let suiteName = "TCPViewerTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         return defaults
+    }
+
+    private func brightness(of color: CGColor) throws -> CGFloat {
+        let nsColor = try #require(NSColor(cgColor: color)?.usingColorSpace(.deviceRGB))
+        return nsColor.redComponent + nsColor.greenComponent + nsColor.blueComponent
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a reusable `TCPViewerDynamicBackgroundView` that re-resolves dynamic `NSColor` values when the effective appearance changes
- Replace static layer color setup in inspector and workspace containers with the dynamic background view
- Add a unit test covering light/dark appearance updates for layer-backed backgrounds

## Testing
- Added unit coverage for appearance-driven background color updates
- Not run (not requested)