### PR TITLE
Verify and document release env and Sentry debug uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,29 @@
-// Release script values. Local Xcode app builds use Config/TCPViewer.local.xcconfig.
-TCPVIEWER_DEVELOPMENT_TEAM=
-TCPVIEWER_BUILD_KEY=
-TCPVIEWER_APPCAST_URL=
-TCPVIEWER_SPARKLE_PUBLIC_ED_KEY=
+# Copy this file to .env for local release builds. Never commit real values.
+# Use # comments only; sentry-cli does not accept // comments in .env files.
 
-// Release-only values. Keep real secrets in local .env or shell env only.
-TCPVIEWER_SPARKLE_PRIVATE_ED_KEY=
+TCPVIEWER_DEVELOPMENT_TEAM=ABCDE12345
+TCPVIEWER_BUILD_KEY=replace-with-build-key
+TCPVIEWER_APPCAST_URL=https://updates.example.com/appcast.xml
+TCPVIEWER_EXPECTED_BUNDLE_ID=com.proxyman.tcpviewer
+TCPVIEWER_SPARKLE_PUBLIC_ED_KEY=replace-with-sparkle-public-ed-key
+TCPVIEWER_SPARKLE_PRIVATE_ED_KEY=replace-with-sparkle-private-ed-key
 TCPVIEWER_SPARKLE_SIGN_UPDATE_PATH=
-TCPVIEWER_DEVELOPER_ID_APPLICATION=Developer ID Application
-TCPVIEWER_NOTARIZATION_USERNAME=
-TCPVIEWER_NOTARIZATION_ASC_PROVIDER=
-FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=
-TCPVIEWER_EXPECTED_BUNDLE_ID=
-TCPVIEWER_SENTRY_DSN=
+TCPVIEWER_DEVELOPER_ID_APPLICATION=Developer ID Application: Example LLC (ABCDE12345)
+TCPVIEWER_NOTARIZATION_USERNAME=developer@example.com
+TCPVIEWER_NOTARIZATION_ASC_PROVIDER=ABCDE12345
+FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=replace-with-app-specific-password
 
-SENTRY_AUTH_TOKEN=
-SENTRY_ORG_SLUG=
-SENTRY_PROJECT_SLUG=
+TCPVIEWER_SENTRY_DSN=replace-with-sentry-dsn
+SENTRY_AUTH_TOKEN=replace-with-sentry-auth-token
+SENTRY_ORG_SLUG=replace-with-sentry-org-slug
+SENTRY_PROJECT_SLUG=replace-with-sentry-project-slug
 
-TCPVIEWER_R2_ACCOUNT_ID=
-TCPVIEWER_R2_ACCESS_KEY_ID=
-TCPVIEWER_R2_SECRET_ACCESS_KEY=
-TCPVIEWER_R2_BUCKET=
-TCPVIEWER_R2_PUBLIC_BASE_URL=
+TCPVIEWER_R2_ACCOUNT_ID=replace-with-r2-account-id
+TCPVIEWER_R2_ACCESS_KEY_ID=replace-with-r2-access-key-id
+TCPVIEWER_R2_SECRET_ACCESS_KEY=replace-with-r2-secret-access-key
+TCPVIEWER_R2_BUCKET=replace-with-r2-bucket
+TCPVIEWER_R2_PUBLIC_BASE_URL=https://downloads.example.com
 
-// Optional production release backend publishing.
-TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND=0
-TCPVIEWER_RELEASE_BACKEND_URL=http:/$()/localhost:3000
+TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND=false
+TCPVIEWER_RELEASE_BACKEND_URL=
 TCPVIEWER_RELEASE_BACKEND_SCRIPT_SECRET=

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ bundle install
 gh auth login
 ```
 
-Create a local `.env` from `.env.example` and fill in the required release values. Never commit real secrets.
+Create a local `.env` from `.env.example` and fill in the required release values. Never commit real secrets. Keep comments in `.env` as `#` comments because `sentry-cli` does not accept `//` comments when it loads the file.
 
 For production releases, add a matching entry to `ReleaseNote.json`, then run:
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -239,7 +239,58 @@ def sentry_debug_files_path!(paths)
   UI.user_error!("Sentry debug files were not found at #{paths[:dsym_zip_path]} or #{paths[:dsym_path]}")
 end
 
-def upload_sentry_debug_files!(path)
+def app_executable_path!(app_path)
+  executable_path = File.join(app_path, "Contents", "MacOS", "TCPViewer")
+  UI.user_error!("TCP Viewer executable was not found at #{executable_path}") unless File.file?(executable_path)
+
+  executable_path
+end
+
+def parse_dwarfdump_uuids!(output, label)
+  uuids = output.lines.filter_map do |line|
+    match = line.match(/\AUUID: ([0-9A-Fa-f-]+) \([^)]+\)/)
+    match && match[1].upcase
+  end.uniq.sort
+
+  UI.user_error!("No debug UUIDs were found for #{label}") if uuids.empty?
+  uuids
+end
+
+def macho_uuids!(path, label)
+  parse_dwarfdump_uuids!(sh("dwarfdump --uuid #{shell_escape(path)}", log: false), label)
+end
+
+def app_dsym_path!(paths)
+  expected_path = File.join(paths[:dsym_path], "#{APP_NAME}.app.dSYM")
+  return expected_path if File.directory?(expected_path)
+
+  candidates = Dir[File.join(paths[:dsym_path], "*.app.dSYM")]
+  UI.user_error!("TCP Viewer app dSYM was not found at #{expected_path}") if candidates.empty?
+  UI.user_error!("Multiple app dSYM bundles were found in #{paths[:dsym_path]}: #{candidates.join(', ')}") if candidates.length > 1
+
+  candidates.first
+end
+
+def verify_sentry_debug_symbols!(paths)
+  # Match the app and dSYM UUIDs before upload so unsymbolicated releases fail early.
+  app_binary_path = app_executable_path!(built_app_path!(paths))
+  dsym_path = app_dsym_path!(paths)
+  app_uuids = macho_uuids!(app_binary_path, "TCP Viewer app executable")
+  dsym_uuids = macho_uuids!(dsym_path, "TCP Viewer app dSYM")
+
+  unless app_uuids == dsym_uuids
+    UI.user_error!(
+      "TCP Viewer app and dSYM UUIDs do not match. " \
+      "app=#{app_uuids.join(', ')} dSYM=#{dsym_uuids.join(', ')}"
+    )
+  end
+
+  UI.message("Verified TCP Viewer dSYM UUIDs: #{app_uuids.join(', ')}")
+  app_uuids
+end
+
+def upload_sentry_debug_files!(path, required_uuids:)
+  # Upload only when Sentry can find and process the exact app debug UUIDs.
   required_env!([
     "SENTRY_AUTH_TOKEN",
     "SENTRY_ORG_SLUG",
@@ -247,14 +298,22 @@ def upload_sentry_debug_files!(path)
   ])
 
   UI.user_error!("Sentry debug files path was not found at #{path}") unless File.exist?(path)
+  UI.user_error!("Missing Sentry debug UUIDs for upload verification") if required_uuids.empty?
 
-  sentry_debug_files_upload(
-    auth_token: ENV.fetch("SENTRY_AUTH_TOKEN"),
-    org_slug: ENV.fetch("SENTRY_ORG_SLUG"),
-    project_slug: ENV.fetch("SENTRY_PROJECT_SLUG"),
-    include_sources: true,
-    path: [path]
-  )
+  uuid_args = required_uuids.flat_map { |uuid| ["--id", uuid] }
+  command = [
+    "sentry-cli",
+    "debug-files",
+    "upload",
+    "--org", ENV.fetch("SENTRY_ORG_SLUG"),
+    "--project", ENV.fetch("SENTRY_PROJECT_SLUG"),
+    "--include-sources",
+    "--require-all",
+    "--wait-for", "120",
+    *uuid_args,
+    path
+  ]
+  sh(command.map { |part| shell_escape(part) }.join(" "))
 end
 
 def build_release_variant!(release_type, options)
@@ -268,13 +327,14 @@ def build_release_variant!(release_type, options)
   UI.message("Building TCP Viewer #{release_type} #{version} (#{build_number})")
   prepare_output_dir!(output_dir)
   build_mac_app!(paths, version, build_number)
+  sentry_debug_uuids = verify_sentry_debug_symbols!(paths)
   resign_exported_app_for_notarization!(built_app_path!(paths))
   verify_developer_id_app_signature!(built_app_path!(paths))
   create_dmg!(paths)
   sign_dmg!(paths[:dmg_path])
   notarize_package!(paths[:dmg_path])
   verify_dmg!(paths[:dmg_path])
-  upload_sentry_debug_files!(sentry_debug_files_path!(paths))
+  upload_sentry_debug_files!(sentry_debug_files_path!(paths), required_uuids: sentry_debug_uuids)
 end
 
 platform :mac do
@@ -329,7 +389,9 @@ platform :mac do
   lane :upload_sentry_debug_files do |options|
     path = options[:path].to_s
     UI.user_error!("Missing path") if path.strip.empty?
+    uuids = options[:uuid].to_s.split(/[\s,]+/).map(&:strip).reject(&:empty?)
+    UI.user_error!("Missing uuid. Pass uuid:<TCP Viewer app debug UUID> when uploading an existing dSYM.") if uuids.empty?
 
-    upload_sentry_debug_files!(File.expand_path(path))
+    upload_sentry_debug_files!(File.expand_path(path), required_uuids: uuids)
   end
 end

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import {
   assertReleaseTitleReflectsChanges,
@@ -207,6 +208,27 @@ test("validates release env names without leaking values", () => {
   assert.ok(missing.includes("TCPVIEWER_NOTARIZATION_USERNAME"));
   assert.ok(missing.includes("SENTRY_AUTH_TOKEN"));
   assert.ok(!missing.includes("TCPVIEWER_NOTARY_KEYCHAIN_PROFILE"));
+});
+
+test("documents required release env values with safe placeholders", () => {
+  const content = readFileSync(new URL("../.env.example", import.meta.url), "utf8");
+  const parsed = parseEnvFile(content);
+  const documentedNames = [
+    ...requiredEnvNames("production"),
+    "TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND",
+    ...releaseBackendRequiredEnvNames
+  ];
+
+  assert.doesNotMatch(content, /^\s*\/\//m);
+  for (const name of documentedNames) {
+    assert.ok(Object.hasOwn(parsed, name), `${name} should be documented in .env.example`);
+  }
+
+  for (const [name, value] of Object.entries(parsed)) {
+    if (/SECRET|PRIVATE|PASSWORD|TOKEN|KEY/i.test(name) && value) {
+      assert.match(value, /^replace-with-/);
+    }
+  }
 });
 
 test("validates optional release backend publishing env", () => {


### PR DESCRIPTION
## Summary
- Replace `.env.example` comments with valid `#` comments and safe placeholder values for release variables
- Document the `.env` comment requirement in `README.md`
- Verify app and dSYM UUIDs before uploading Sentry debug files, and require matching UUIDs on the upload lane
- Add a unit test to confirm release env documentation stays complete and sanitized

## Testing
- Not run (not requested)