### PR TITLE
Investigate and harden Wireshark startup/runtime packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ TCP Viewer is a macOS packet viewer for live captures and capture files. It uses
 - macOS 15+
 - Xcode 16+
 - Git
-- CMake, Ninja, and pkg-config
-- Wireshark build dependencies
+- CMake, Ninja, Meson, pkg-config, and autotools
 
 ```bash
-brew install cmake ninja pkg-config glib libgcrypt gnutls nghttp2 brotli lz4 zstd
+brew install cmake ninja meson pkg-config autoconf automake libtool
 ```
 
 ## Setup
@@ -31,6 +30,12 @@ If you already cloned without submodules:
 git submodule update --init --recursive
 ./scripts/bootstrap-wireshark.sh
 ```
+
+`scripts/bootstrap-wireshark.sh` first runs
+`scripts/bootstrap-wireshark-deps.sh`, which builds Wireshark's bundled runtime
+libraries from source into `Vendor/.install/wireshark-deps` with macOS 15.0 as
+the deployment target. Homebrew is used only for build tools; release bundles
+must not copy Homebrew bottle dylibs from `/opt/homebrew` or `/usr/local`.
 
 Keep local signing, appcast, Sparkle, Sentry, and release values out of Git. Use ignored local files such as `Config/TCPViewer.local.xcconfig`, `.env`, shell environment variables, or Keychain-backed tools.
 

--- a/SOURCE_CODE_OFFER.md
+++ b/SOURCE_CODE_OFFER.md
@@ -6,7 +6,8 @@ any later version published by the Free Software Foundation.
 If you received a binary or object-code distribution of TCP Viewer, you may
 obtain the complete corresponding source code for TCP Viewer and bundled GPL
 components, including the pinned Wireshark source used to build `libwireshark`,
-`libwiretap`, and `libwsutil`, from the published source archive for the same
+`libwiretap`, `libwsutil`, and the pinned source archives for bundled
+non-system runtime dependencies, from the published source archive for the same
 release. Binary releases may also include other open-source runtime libraries;
 their required notices and source availability terms are tracked in
 `THIRD_PARTY_NOTICES.md` and the release bundle's `OpenSourceLicenses`

--- a/TCPViewer.xcodeproj/project.pbxproj
+++ b/TCPViewer.xcodeproj/project.pbxproj
@@ -843,14 +843,10 @@
 					"$(PROJECT_DIR)/Vendor/.build/wireshark-$(CONFIGURATION)-arm64",
 					"$(PROJECT_DIR)/Vendor/Wireshark",
 					"$(PROJECT_DIR)/Vendor/Wireshark/include",
-					"/opt/homebrew/include/glib-2.0",
-					"/opt/homebrew/lib/glib-2.0/include",
-					/opt/homebrew/opt/gettext/include,
-					/opt/homebrew/opt/pcre2/include,
-					"/usr/local/include/glib-2.0",
-					"/usr/local/lib/glib-2.0/include",
-					/usr/local/opt/gettext/include,
-					/usr/local/opt/pcre2/include,
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/include",
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/include/glib-2.0",
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/lib/glib-2.0/include",
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/include/p11-kit-1",
 				);
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -863,10 +859,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor/.install/wireshark/lib",
-					/opt/homebrew/opt/glib/lib,
-					/opt/homebrew/opt/gettext/lib,
-					/usr/local/opt/glib/lib,
-					/usr/local/opt/gettext/lib,
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/lib",
 				);
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
@@ -921,14 +914,10 @@
 					"$(PROJECT_DIR)/Vendor/.build/wireshark-$(CONFIGURATION)-arm64",
 					"$(PROJECT_DIR)/Vendor/Wireshark",
 					"$(PROJECT_DIR)/Vendor/Wireshark/include",
-					"/opt/homebrew/include/glib-2.0",
-					"/opt/homebrew/lib/glib-2.0/include",
-					/opt/homebrew/opt/gettext/include,
-					/opt/homebrew/opt/pcre2/include,
-					"/usr/local/include/glib-2.0",
-					"/usr/local/lib/glib-2.0/include",
-					/usr/local/opt/gettext/include,
-					/usr/local/opt/pcre2/include,
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/include",
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/include/glib-2.0",
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/lib/glib-2.0/include",
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/include/p11-kit-1",
 				);
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -941,10 +930,7 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Vendor/.install/wireshark/lib",
-					/opt/homebrew/opt/glib/lib,
-					/opt/homebrew/opt/gettext/lib,
-					/usr/local/opt/glib/lib,
-					/usr/local/opt/gettext/lib,
+					"$(PROJECT_DIR)/Vendor/.install/wireshark-deps/lib",
 				);
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -35,8 +35,11 @@ HexFiend provides the embedded packet hex viewer framework.
 
 ## Transitive Runtime Libraries
 
-`scripts/stage-wireshark-runtime.sh` recursively stages non-system dynamic
-libraries required by the Wireshark runtime. Before publishing a binary release,
-inspect the generated `OpenSourceLicenses/RUNTIME_LIBRARIES.txt` file inside the
-app bundle and make sure every non-system runtime library has its required
-license notice included with the release.
+`scripts/bootstrap-wireshark-deps.sh` builds Wireshark's non-system runtime
+dependency closure from pinned source archives into
+`Vendor/.install/wireshark-deps`, and `scripts/stage-wireshark-runtime.sh`
+recursively stages those repo-built dynamic libraries. Before publishing a
+binary release, inspect the generated
+`OpenSourceLicenses/RUNTIME_LIBRARIES.txt` file inside the app bundle and make
+sure every non-system runtime library has its required license notice included
+with the release.

--- a/Vendor/README.md
+++ b/Vendor/README.md
@@ -7,7 +7,12 @@
 
 `Vendor/.build/` and `Vendor/.install/` are intentionally ignored so the repository stores source pins, not generated artifacts.
 
-After `scripts/bootstrap-wireshark.sh` succeeds, `PcapPlusPlusCore.framework` bundles the staged Wireshark runtime libraries in its own `Versions/A/Frameworks` directory for Debug and Release builds:
+After `scripts/bootstrap-wireshark.sh` succeeds, `PcapPlusPlusCore.framework`
+bundles the staged Wireshark runtime libraries in its own
+`Versions/A/Frameworks` directory for Debug and Release builds. Wireshark's
+non-system runtime dependency closure is built from source by
+`scripts/bootstrap-wireshark-deps.sh` into `Vendor/.install/wireshark-deps` so
+the app does not ship Homebrew bottle dylibs tied to the release machine's OS.
 
 ```sh
 xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,6 @@
 require "fileutils"
 require "shellwords"
+require "tmpdir"
 
 default_platform(:mac)
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
@@ -268,6 +269,42 @@ def macho_uuids!(path, label)
   parse_dwarfdump_uuids!(sh("dwarfdump --uuid #{shell_escape(path)}", log: false), label)
 end
 
+def sentry_artifact_uuids!(path)
+  Dir.mktmpdir("tcpviewer-sentry-dsyms-") do |tmp_dir|
+    scan_root = path
+
+    if File.file?(path) && File.extname(path).casecmp(".zip").zero?
+      # dwarfdump cannot inspect zipped dSYMs, so scan a temporary extraction instead.
+      sh("ditto -x -k #{shell_escape(path)} #{shell_escape(tmp_dir)}", log: false)
+      scan_root = tmp_dir
+    end
+
+    dsym_paths = if File.directory?(scan_root) && File.basename(scan_root).end_with?(".dSYM")
+      [scan_root]
+    elsif File.directory?(scan_root)
+      Dir[File.join(scan_root, "**", "*.dSYM")]
+    else
+      []
+    end
+    UI.user_error!("No dSYM bundles were found in Sentry debug files artifact #{path}") if dsym_paths.empty?
+
+    dsym_paths.flat_map { |dsym_path| macho_uuids!(dsym_path, dsym_path) }.uniq.sort
+  end
+end
+
+def verify_sentry_upload_artifact!(path, required_uuids)
+  artifact_uuids = sentry_artifact_uuids!(path)
+  missing_uuids = required_uuids.map(&:upcase) - artifact_uuids
+  unless missing_uuids.empty?
+    UI.user_error!(
+      "Sentry debug files artifact is missing required UUIDs. " \
+      "missing=#{missing_uuids.join(', ')} found=#{artifact_uuids.join(', ')}"
+    )
+  end
+
+  UI.message("Verified Sentry upload artifact UUIDs: #{required_uuids.join(', ')}")
+end
+
 def app_dsym_path!(paths)
   expected_path = File.join(paths[:dsym_path], "#{APP_NAME}.app.dSYM")
   return expected_path if File.directory?(expected_path)
@@ -298,7 +335,7 @@ def verify_sentry_debug_symbols!(paths)
 end
 
 def upload_sentry_debug_files!(path, required_uuids:)
-  # Upload only when Sentry can find and process the exact app debug UUIDs.
+  # Upload only after the local artifact contains the exact app debug UUIDs.
   required_env!([
     "SENTRY_AUTH_TOKEN",
     "SENTRY_ORG_SLUG",
@@ -307,21 +344,23 @@ def upload_sentry_debug_files!(path, required_uuids:)
 
   UI.user_error!("Sentry debug files path was not found at #{path}") unless File.exist?(path)
   UI.user_error!("Missing Sentry debug UUIDs for upload verification") if required_uuids.empty?
+  verify_sentry_upload_artifact!(path, required_uuids)
 
-  uuid_args = required_uuids.flat_map { |uuid| ["--id", uuid] }
-  command = [
+  base_command = [
     "sentry-cli",
     "debug-files",
     "upload",
     "--org", ENV.fetch("SENTRY_ORG_SLUG"),
     "--project", ENV.fetch("SENTRY_PROJECT_SLUG"),
-    "--include-sources",
-    "--require-all",
-    "--wait-for", "120",
-    *uuid_args,
+    "--include-sources"
+  ]
+
+  # Keep --require-all out of the real upload; Sentry can dedupe files before its UUID lookup sees them.
+  upload_command = [
+    *base_command,
     path
   ]
-  sh(command.map { |part| shell_escape(part) }.join(" "))
+  sh(upload_command.map { |part| shell_escape(part) }.join(" "))
 end
 
 def build_release_variant!(release_type, options)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -120,6 +120,14 @@ def built_app_path!(paths)
   UI.user_error!("Built app was not found at #{paths[:exported_app_path]} or #{paths[:archived_app_path]}")
 end
 
+def verify_bundled_runtime_compatibility!(app_path)
+  sh([
+    File.join(REPO_ROOT, "scripts", "verify-bundled-runtime-compatibility.sh"),
+    app_path,
+    "15.0"
+  ].map { |part| shell_escape(part) }.join(" "))
+end
+
 def sparkle_code_paths(app_path)
   sparkle_root = File.join(app_path, "Contents", "Frameworks", "Sparkle.framework", "Versions", "B")
   [
@@ -327,6 +335,7 @@ def build_release_variant!(release_type, options)
   UI.message("Building TCP Viewer #{release_type} #{version} (#{build_number})")
   prepare_output_dir!(output_dir)
   build_mac_app!(paths, version, build_number)
+  verify_bundled_runtime_compatibility!(built_app_path!(paths))
   sentry_debug_uuids = verify_sentry_debug_symbols!(paths)
   resign_exported_app_for_notarization!(built_app_path!(paths))
   verify_developer_id_app_signature!(built_app_path!(paths))
@@ -354,6 +363,7 @@ platform :mac do
 
     sh("xcodebuild -project #{shell_escape(PROJECT_PATH)} -scheme #{shell_escape(SCHEME_NAME)} -configuration #{shell_escape(CONFIGURATION_NAME)} -showBuildSettings > /dev/null")
     sh("test -d Vendor/.install/wireshark/lib")
+    sh("test -d Vendor/.install/wireshark-deps/lib")
     developer_id_identity!
     sh("xcrun notarytool --version > /dev/null")
   end

--- a/scripts/bootstrap-wireshark-deps.sh
+++ b/scripts/bootstrap-wireshark-deps.sh
@@ -1,0 +1,366 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+BUILD_ROOT="$PROJECT_DIR/Vendor/.build/wireshark-deps"
+SOURCE_ROOT="$BUILD_ROOT/sources"
+DOWNLOAD_ROOT="$BUILD_ROOT/downloads"
+INSTALL_ROOT="$PROJECT_DIR/Vendor/.install/wireshark-deps"
+STAMP_FILE="$INSTALL_ROOT/.tcpviewer-build-stamp"
+DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-15.0}"
+ARCHITECTURES="${ARCHS:-${NATIVE_ARCH_ACTUAL:-${CURRENT_ARCH:-arm64}}}"
+CMAKE_ARCHITECTURES="$(printf '%s' "$ARCHITECTURES" | tr ' ' ';')"
+
+GLIB_VERSION=2.88.1
+PCRE2_VERSION=10.47
+GETTEXT_VERSION=1.0
+LIBGCRYPT_VERSION=1.12.2
+LIBGPG_ERROR_VERSION=1.61
+GNUTLS_VERSION=3.8.13
+GMP_VERSION=6.3.0
+NETTLE_VERSION=4.0
+LIBTASN1_VERSION=4.21.0
+LIBIDN2_VERSION=2.3.8
+LIBUNISTRING_VERSION=1.4.2
+P11_KIT_VERSION=0.26.2
+BROTLI_VERSION=1.2.0
+CARES_VERSION=1.34.6
+LZ4_VERSION=1.10.0
+NGHTTP2_VERSION=1.69.0
+NGHTTP3_VERSION=1.16.0
+SNAPPY_VERSION=1.2.2
+XXHASH_VERSION=0.8.3
+ZSTD_VERSION=1.5.7
+BUILD_REVISION=3
+
+resolve_sdkroot() {
+  if [ -n "${SDKROOT:-}" ] && [ -e "$SDKROOT" ]; then
+    printf '%s' "$SDKROOT"
+    return
+  fi
+
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun --sdk macosx --show-sdk-path 2>/dev/null || true
+  fi
+}
+
+find_tool() {
+  VARIABLE_VALUE="$1"
+  shift
+
+  if [ -n "$VARIABLE_VALUE" ]; then
+    if command -v "$VARIABLE_VALUE" >/dev/null 2>&1; then
+      command -v "$VARIABLE_VALUE"
+      return
+    fi
+    echo "$VARIABLE_VALUE"
+    return
+  fi
+
+  for CANDIDATE in "$@"; do
+    if command -v "$CANDIDATE" >/dev/null 2>&1; then
+      command -v "$CANDIDATE"
+      return
+    fi
+  done
+}
+
+SDKROOT_PATH="$(resolve_sdkroot)"
+CURRENT_STAMP_CONTENT="revision=$BUILD_REVISION;glib=$GLIB_VERSION;pcre2=$PCRE2_VERSION;gettext=$GETTEXT_VERSION;libgcrypt=$LIBGCRYPT_VERSION;libgpg-error=$LIBGPG_ERROR_VERSION;gnutls=$GNUTLS_VERSION;gmp=$GMP_VERSION;nettle=$NETTLE_VERSION;libtasn1=$LIBTASN1_VERSION;libidn2=$LIBIDN2_VERSION;libunistring=$LIBUNISTRING_VERSION;p11-kit=$P11_KIT_VERSION;brotli=$BROTLI_VERSION;c-ares=$CARES_VERSION;lz4=$LZ4_VERSION;nghttp2=$NGHTTP2_VERSION;nghttp3=$NGHTTP3_VERSION;snappy=$SNAPPY_VERSION;xxhash=$XXHASH_VERSION;zstd=$ZSTD_VERSION;archs=$CMAKE_ARCHITECTURES;deployment=$DEPLOYMENT_TARGET;sdk=$SDKROOT_PATH"
+
+has_installed_library() {
+  NAME="$1"
+  find "$INSTALL_ROOT/lib" -name "lib$NAME.*.dylib" -print -quit 2>/dev/null | grep -q .
+}
+
+if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$CURRENT_STAMP_CONTENT" ] \
+  && has_installed_library glib-2.0 \
+  && has_installed_library gnutls \
+  && has_installed_library gcrypt \
+  && has_installed_library zstd; then
+  exit 0
+fi
+
+CURL_BIN="$(find_tool "${CURL_BIN:-}" curl /usr/bin/curl)"
+CMAKE_BIN="$(find_tool "${CMAKE_BIN:-}" cmake /opt/homebrew/bin/cmake /usr/local/bin/cmake /Applications/CMake.app/Contents/bin/cmake)"
+NINJA_BIN="$(find_tool "${NINJA_BIN:-}" ninja /opt/homebrew/bin/ninja /usr/local/bin/ninja)"
+MESON_BIN="$(find_tool "${MESON_BIN:-}" meson /opt/homebrew/bin/meson /usr/local/bin/meson)"
+PKG_CONFIG_BIN="$(find_tool "${PKG_CONFIG:-}" pkg-config /opt/homebrew/bin/pkg-config /usr/local/bin/pkg-config)"
+
+if [ -z "$CURL_BIN" ]; then
+  echo "error: curl is required to download Wireshark dependency source archives." >&2
+  exit 1
+fi
+
+if [ -z "$CMAKE_BIN" ] || [ -z "$NINJA_BIN" ] || [ -z "$MESON_BIN" ] || [ -z "$PKG_CONFIG_BIN" ]; then
+  echo "error: cmake, ninja, meson, and pkg-config are required as build tools." >&2
+  echo "       Install build tools with: brew install cmake ninja meson pkg-config autoconf automake libtool" >&2
+  exit 1
+fi
+
+rm -rf "$INSTALL_ROOT"
+mkdir -p "$DOWNLOAD_ROOT" "$SOURCE_ROOT" "$INSTALL_ROOT"
+
+export MACOSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET"
+export PKG_CONFIG="$PKG_CONFIG_BIN"
+export PKG_CONFIG_PATH="$INSTALL_ROOT/lib/pkgconfig:$INSTALL_ROOT/share/pkgconfig"
+export PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH"
+export CMAKE_PREFIX_PATH="$INSTALL_ROOT"
+export PATH="$INSTALL_ROOT/bin:$PATH"
+export CC="${CC:-/usr/bin/clang}"
+export CXX="${CXX:-/usr/bin/clang++}"
+unset CPATH
+unset LIBRARY_PATH
+unset DYLD_LIBRARY_PATH
+unset DYLD_FALLBACK_LIBRARY_PATH
+
+COMMON_FLAGS="-mmacosx-version-min=$DEPLOYMENT_TARGET -Werror=unguarded-availability-new"
+if [ -n "$SDKROOT_PATH" ]; then
+  COMMON_FLAGS="-isysroot $SDKROOT_PATH $COMMON_FLAGS"
+fi
+
+export CPPFLAGS="-I$INSTALL_ROOT/include ${TCPVIEWER_WIRESHARK_DEPS_CPPFLAGS:-}"
+export CFLAGS="$COMMON_FLAGS -O2 ${TCPVIEWER_WIRESHARK_DEPS_CFLAGS:-}"
+export CXXFLAGS="$COMMON_FLAGS -O2 ${TCPVIEWER_WIRESHARK_DEPS_CXXFLAGS:-}"
+export LDFLAGS="-L$INSTALL_ROOT/lib -mmacosx-version-min=$DEPLOYMENT_TARGET ${TCPVIEWER_WIRESHARK_DEPS_LDFLAGS:-}"
+
+download_archive() {
+  NAME="$1"
+  URL="$2"
+  CHECKSUM="$3"
+  ARCHIVE_PATH="$DOWNLOAD_ROOT/$NAME"
+
+  if [ ! -f "$ARCHIVE_PATH" ]; then
+    "$CURL_BIN" --fail --location --retry 3 --output "$ARCHIVE_PATH" "$URL"
+  fi
+
+  ACTUAL_CHECKSUM="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{ print $1 }')"
+  if [ "$ACTUAL_CHECKSUM" != "$CHECKSUM" ]; then
+    echo "error: checksum mismatch for $NAME" >&2
+    echo "       expected: $CHECKSUM" >&2
+    echo "       actual:   $ACTUAL_CHECKSUM" >&2
+    exit 1
+  fi
+}
+
+extract_archive() {
+  NAME="$1"
+  ARCHIVE_NAME="$2"
+  SOURCE_DIR="$SOURCE_ROOT/$NAME"
+
+  if [ -d "$SOURCE_DIR" ]; then
+    printf '%s' "$SOURCE_DIR"
+    return
+  fi
+
+  mkdir -p "$SOURCE_DIR"
+  tar -xf "$DOWNLOAD_ROOT/$ARCHIVE_NAME" -C "$SOURCE_DIR" --strip-components 1
+  printf '%s' "$SOURCE_DIR"
+}
+
+build_autotools() {
+  NAME="$1"
+  shift
+  SOURCE_DIR="$1"
+  shift
+  BUILD_DIR="$BUILD_ROOT/build/$NAME"
+
+  rm -rf "$BUILD_DIR"
+  mkdir -p "$BUILD_DIR"
+  (
+    cd "$BUILD_DIR"
+    "$SOURCE_DIR/configure" --prefix="$INSTALL_ROOT" --disable-static --enable-shared "$@"
+    make -j"${PARALLEL_JOBS:-$(sysctl -n hw.ncpu)}"
+    make install
+  )
+}
+
+build_cmake() {
+  NAME="$1"
+  shift
+  SOURCE_DIR="$1"
+  shift
+  BUILD_DIR="$BUILD_ROOT/build/$NAME"
+
+  rm -rf "$BUILD_DIR"
+  "$CMAKE_BIN" -S "$SOURCE_DIR" -B "$BUILD_DIR" -G Ninja \
+    -DCMAKE_MAKE_PROGRAM="$NINJA_BIN" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_ROOT" \
+    -DCMAKE_OSX_ARCHITECTURES="$CMAKE_ARCHITECTURES" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET" \
+    -DCMAKE_OSX_SYSROOT="$SDKROOT_PATH" \
+    -DCMAKE_INSTALL_NAME_DIR="@rpath" \
+    -DCMAKE_PREFIX_PATH="$INSTALL_ROOT" \
+    "$@"
+  "$CMAKE_BIN" --build "$BUILD_DIR" --parallel
+  "$CMAKE_BIN" --install "$BUILD_DIR"
+}
+
+build_meson() {
+  NAME="$1"
+  shift
+  SOURCE_DIR="$1"
+  shift
+  BUILD_DIR="$BUILD_ROOT/build/$NAME"
+
+  rm -rf "$BUILD_DIR"
+  "$MESON_BIN" setup "$BUILD_DIR" "$SOURCE_DIR" \
+    --prefix "$INSTALL_ROOT" \
+    --libdir lib \
+    --buildtype release \
+    --default-library shared \
+    "$@"
+  "$MESON_BIN" compile -C "$BUILD_DIR"
+  "$MESON_BIN" install -C "$BUILD_DIR"
+}
+
+validate_pkg_config_files() {
+  FAILURE_FILE="$INSTALL_ROOT/.tcpviewer-forbidden-pkg-config-paths.txt"
+  : > "$FAILURE_FILE"
+
+  find "$INSTALL_ROOT" -name '*.pc' -print | while IFS= read -r PC_FILE; do
+    if grep -E '/opt/homebrew|/usr/local' "$PC_FILE" >/dev/null 2>&1; then
+      printf '%s\n' "$PC_FILE" >> "$FAILURE_FILE"
+    fi
+  done
+
+  if [ -s "$FAILURE_FILE" ]; then
+    echo "error: generated pkg-config files reference machine-local runtime prefixes." >&2
+    sed 's/^/       /' "$FAILURE_FILE" >&2
+    exit 1
+  fi
+}
+
+normalize_dependency_install_names() {
+  find "$INSTALL_ROOT/lib" -type f -name '*.dylib' -print | while IFS= read -r LIBRARY; do
+    INSTALL_ID="$(otool -D "$LIBRARY" 2>/dev/null | sed -n '/):$/d; 1!p' | head -n 1)"
+    case "$INSTALL_ID" in
+      "$INSTALL_ROOT"/lib/*|/usr/local/lib/*|/opt/homebrew/lib/*)
+        install_name_tool -id "@rpath/$(basename "$INSTALL_ID")" "$LIBRARY"
+        ;;
+    esac
+  done
+
+  # Normalize upstream Makefile install names before Wireshark records them while linking.
+  find "$INSTALL_ROOT/lib" -type f -name '*.dylib' -print | while IFS= read -r LIBRARY; do
+    otool -L "$LIBRARY" 2>/dev/null | sed -n '/^[[:space:]]/ { s/^[[:space:]]*//; s/ (compatibility.*$//; p; }' | while IFS= read -r DEPENDENCY; do
+      case "$DEPENDENCY" in
+        "$INSTALL_ROOT"/lib/*|/usr/local/lib/*|/opt/homebrew/lib/*)
+          install_name_tool -change "$DEPENDENCY" "@rpath/$(basename "$DEPENDENCY")" "$LIBRARY"
+          ;;
+      esac
+    done
+  done
+}
+
+download_archive "libunistring-$LIBUNISTRING_VERSION.tar.gz" "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-$LIBUNISTRING_VERSION.tar.gz" "e82664b170064e62331962126b259d452d53b227bb4a93ab20040d846fec01d8"
+build_autotools "libunistring" "$(extract_archive "libunistring-$LIBUNISTRING_VERSION" "libunistring-$LIBUNISTRING_VERSION.tar.gz")"
+
+download_archive "gettext-$GETTEXT_VERSION.tar.gz" "https://ftpmirror.gnu.org/gnu/gettext/gettext-$GETTEXT_VERSION.tar.gz" "85d99b79c981a404874c02e0342176cf75c7698e2b51fe41031cf6526d974f1a"
+GETTEXT_SOURCE_DIR="$(extract_archive "gettext-$GETTEXT_VERSION" "gettext-$GETTEXT_VERSION.tar.gz")"
+# Wireshark only needs the gettext runtime libintl library; gettext-tools builds extra UI libraries.
+build_autotools "gettext-runtime" "$GETTEXT_SOURCE_DIR/gettext-runtime" --disable-java --disable-csharp --with-libunistring-prefix="$INSTALL_ROOT"
+
+download_archive "pcre2-$PCRE2_VERSION.tar.bz2" "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.bz2" "47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7"
+build_cmake "pcre2" "$(extract_archive "pcre2-$PCRE2_VERSION" "pcre2-$PCRE2_VERSION.tar.bz2")" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DPCRE2_BUILD_TESTS=OFF \
+  -DPCRE2_BUILD_PCRE2GREP=OFF \
+  -DPCRE2_BUILD_PCRE2_8=ON \
+  -DPCRE2_BUILD_PCRE2_16=OFF \
+  -DPCRE2_BUILD_PCRE2_32=OFF
+
+download_archive "glib-$GLIB_VERSION.tar.xz" "https://download.gnome.org/sources/glib/2.88/glib-$GLIB_VERSION.tar.xz" "51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e"
+build_meson "glib" "$(extract_archive "glib-$GLIB_VERSION" "glib-$GLIB_VERSION.tar.xz")" \
+  -Dtests=false \
+  -Dinstalled_tests=false \
+  -Dintrospection=disabled \
+  -Dman-pages=disabled \
+  -Ddtrace=false \
+  -Dsystemtap=false \
+  -Dselinux=disabled \
+  -Dlibmount=disabled \
+  -Dxattr=false
+
+download_archive "libgpg-error-$LIBGPG_ERROR_VERSION.tar.bz2" "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$LIBGPG_ERROR_VERSION.tar.bz2" "7a85413f2bc354f4f8aa832b718af122e48965e9e0eb9012ee659c13c6385c93"
+build_autotools "libgpg-error" "$(extract_archive "libgpg-error-$LIBGPG_ERROR_VERSION" "libgpg-error-$LIBGPG_ERROR_VERSION.tar.bz2")"
+
+download_archive "libgcrypt-$LIBGCRYPT_VERSION.tar.bz2" "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$LIBGCRYPT_VERSION.tar.bz2" "7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e"
+build_autotools "libgcrypt" "$(extract_archive "libgcrypt-$LIBGCRYPT_VERSION" "libgcrypt-$LIBGCRYPT_VERSION.tar.bz2")" --with-libgpg-error-prefix="$INSTALL_ROOT"
+
+download_archive "gmp-$GMP_VERSION.tar.xz" "https://ftpmirror.gnu.org/gnu/gmp/gmp-$GMP_VERSION.tar.xz" "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
+build_autotools "gmp" "$(extract_archive "gmp-$GMP_VERSION" "gmp-$GMP_VERSION.tar.xz")"
+
+download_archive "nettle-$NETTLE_VERSION.tar.gz" "https://ftpmirror.gnu.org/gnu/nettle/nettle-$NETTLE_VERSION.tar.gz" "3addbc00da01846b232fb3bc453538ea5468da43033f21bb345cb1e9073f5094"
+build_autotools "nettle" "$(extract_archive "nettle-$NETTLE_VERSION" "nettle-$NETTLE_VERSION.tar.gz")" --with-lib-path="$INSTALL_ROOT/lib" --with-include-path="$INSTALL_ROOT/include"
+
+download_archive "libtasn1-$LIBTASN1_VERSION.tar.gz" "https://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-$LIBTASN1_VERSION.tar.gz" "1d8a444a223cc5464240777346e125de51d8e6abf0b8bac742ac84609167dc87"
+build_autotools "libtasn1" "$(extract_archive "libtasn1-$LIBTASN1_VERSION" "libtasn1-$LIBTASN1_VERSION.tar.gz")"
+
+download_archive "libidn2-$LIBIDN2_VERSION.tar.gz" "https://ftpmirror.gnu.org/gnu/libidn/libidn2-$LIBIDN2_VERSION.tar.gz" "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
+build_autotools "libidn2" "$(extract_archive "libidn2-$LIBIDN2_VERSION" "libidn2-$LIBIDN2_VERSION.tar.gz")" --with-libunistring-prefix="$INSTALL_ROOT" --disable-doc
+
+download_archive "p11-kit-$P11_KIT_VERSION.tar.xz" "https://github.com/p11-glue/p11-kit/releases/download/$P11_KIT_VERSION/p11-kit-$P11_KIT_VERSION.tar.xz" "09fd9f44da4813a3141e73d5e7cf7008e5660d0405f13d56c15e1da9dcecf828"
+build_meson "p11-kit" "$(extract_archive "p11-kit-$P11_KIT_VERSION" "p11-kit-$P11_KIT_VERSION.tar.xz")" \
+  -Dgtk_doc=false \
+  -Dman=false \
+  -Dnls=false \
+  -Dtrust_module=disabled \
+  -Dsystemd=disabled \
+  -Dbash_completion=disabled
+
+download_archive "gnutls-$GNUTLS_VERSION.tar.xz" "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-$GNUTLS_VERSION.tar.xz" "ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e"
+build_autotools "gnutls" "$(extract_archive "gnutls-$GNUTLS_VERSION" "gnutls-$GNUTLS_VERSION.tar.xz")" --disable-doc --disable-tests --disable-tools --with-included-unistring=no --with-p11-kit
+
+download_archive "brotli-$BROTLI_VERSION.tar.gz" "https://github.com/google/brotli/archive/refs/tags/v$BROTLI_VERSION.tar.gz" "816c96e8e8f193b40151dad7e8ff37b1221d019dbcb9c35cd3fadbfe6477dfec"
+build_cmake "brotli" "$(extract_archive "brotli-$BROTLI_VERSION" "brotli-$BROTLI_VERSION.tar.gz")" -DBUILD_SHARED_LIBS=ON -DBROTLI_DISABLE_TESTS=ON
+
+download_archive "c-ares-$CARES_VERSION.tar.gz" "https://github.com/c-ares/c-ares/releases/download/v$CARES_VERSION/c-ares-$CARES_VERSION.tar.gz" "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5"
+build_cmake "c-ares" "$(extract_archive "c-ares-$CARES_VERSION" "c-ares-$CARES_VERSION.tar.gz")" -DCARES_SHARED=ON -DCARES_STATIC=OFF -DCARES_BUILD_TOOLS=OFF -DCARES_BUILD_TESTS=OFF
+
+download_archive "lz4-$LZ4_VERSION.tar.gz" "https://github.com/lz4/lz4/archive/refs/tags/v$LZ4_VERSION.tar.gz" "537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b"
+(
+  cd "$(extract_archive "lz4-$LZ4_VERSION" "lz4-$LZ4_VERSION.tar.gz")"
+  make -C lib clean
+  make -C lib -j"${PARALLEL_JOBS:-$(sysctl -n hw.ncpu)}" PREFIX="$INSTALL_ROOT" BUILD_SHARED=yes BUILD_STATIC=no
+  make -C lib install PREFIX="$INSTALL_ROOT" BUILD_SHARED=yes BUILD_STATIC=no
+)
+
+download_archive "nghttp2-$NGHTTP2_VERSION.tar.gz" "https://github.com/nghttp2/nghttp2/releases/download/v$NGHTTP2_VERSION/nghttp2-$NGHTTP2_VERSION.tar.gz" "c866b7477cbb7512ab6863a685027adbb1bb8da8fc3bab7429ed43d3281d5aa9"
+build_autotools "nghttp2" "$(extract_archive "nghttp2-$NGHTTP2_VERSION" "nghttp2-$NGHTTP2_VERSION.tar.gz")" --enable-lib-only --without-libxml2 --without-jemalloc --without-systemd --without-cunit
+
+download_archive "nghttp3-$NGHTTP3_VERSION.tar.xz" "https://github.com/ngtcp2/nghttp3/releases/download/v$NGHTTP3_VERSION/nghttp3-$NGHTTP3_VERSION.tar.xz" "776f59a99905c9a348846807b2e5ac9bb3485fc0f8c0250ba803018d5238a16e"
+build_cmake "nghttp3" "$(extract_archive "nghttp3-$NGHTTP3_VERSION" "nghttp3-$NGHTTP3_VERSION.tar.xz")" -DENABLE_SHARED_LIB=ON -DENABLE_STATIC_LIB=OFF -DENABLE_LIB_ONLY=ON
+
+download_archive "snappy-$SNAPPY_VERSION.tar.gz" "https://github.com/google/snappy/archive/refs/tags/$SNAPPY_VERSION.tar.gz" "90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc"
+build_cmake "snappy" "$(extract_archive "snappy-$SNAPPY_VERSION" "snappy-$SNAPPY_VERSION.tar.gz")" -DBUILD_SHARED_LIBS=ON -DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF
+
+download_archive "xxhash-$XXHASH_VERSION.tar.gz" "https://github.com/Cyan4973/xxHash/archive/refs/tags/v$XXHASH_VERSION.tar.gz" "aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80"
+(
+  cd "$(extract_archive "xxhash-$XXHASH_VERSION" "xxhash-$XXHASH_VERSION.tar.gz")"
+  make clean
+  make -j"${PARALLEL_JOBS:-$(sysctl -n hw.ncpu)}" libxxhash
+  make install PREFIX="$INSTALL_ROOT" BUILD_SHARED=1 BUILD_STATIC=0
+)
+
+download_archive "zstd-$ZSTD_VERSION.tar.gz" "https://github.com/facebook/zstd/archive/refs/tags/v$ZSTD_VERSION.tar.gz" "37d7284556b20954e56e1ca85b80226768902e2edabd3b649e9e72c0c9012ee3"
+(
+  cd "$(extract_archive "zstd-$ZSTD_VERSION" "zstd-$ZSTD_VERSION.tar.gz")"
+  make -C lib clean
+  make -C lib -j"${PARALLEL_JOBS:-$(sysctl -n hw.ncpu)}" libzstd
+  make -C lib install PREFIX="$INSTALL_ROOT" BUILD_SHARED=1 BUILD_STATIC=0
+)
+
+validate_pkg_config_files
+normalize_dependency_install_names
+"$PROJECT_DIR/scripts/verify-bundled-runtime-compatibility.sh" "$INSTALL_ROOT" "$DEPLOYMENT_TARGET" --allow-prefix "$INSTALL_ROOT"
+
+mkdir -p "$(dirname "$STAMP_FILE")"
+printf '%s' "$CURRENT_STAMP_CONTENT" > "$STAMP_FILE"
+
+cat <<EOF
+Wireshark dependencies installed in $INSTALL_ROOT.
+Bundled runtime libraries are built from source for macOS $DEPLOYMENT_TARGET or newer.
+EOF

--- a/scripts/bootstrap-wireshark.sh
+++ b/scripts/bootstrap-wireshark.sh
@@ -6,6 +6,7 @@ PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 SOURCE_DIR="$PROJECT_DIR/Vendor/Wireshark"
 BUILD_ROOT="$PROJECT_DIR/Vendor/.build"
 INSTALL_ROOT="$PROJECT_DIR/Vendor/.install/wireshark"
+DEPS_INSTALL_ROOT="$PROJECT_DIR/Vendor/.install/wireshark-deps"
 PINNED_TAG="v4.6.4"
 PINNED_COMMIT="93282876538d78a2927108dd71ee0ff370aedb0a"
 REMOTE_URL="https://gitlab.com/wireshark/wireshark.git"
@@ -16,6 +17,7 @@ ARCHITECTURES="${ARCHS:-${NATIVE_ARCH_ACTUAL:-${CURRENT_ARCH:-arm64}}}"
 CMAKE_ARCHITECTURES="$(printf '%s' "$ARCHITECTURES" | tr ' ' ';')"
 BUILD_DIR="$BUILD_ROOT/wireshark-${CONFIGURATION_NAME}-$(printf '%s' "$ARCHITECTURES" | tr ' ' '_')"
 STAMP_FILE="$INSTALL_ROOT/.tcpviewer-build-stamp"
+DEPS_STAMP_FILE="$DEPS_INSTALL_ROOT/.tcpviewer-build-stamp"
 
 resolve_sdkroot() {
   if [ -n "${SDKROOT:-}" ] && [ -e "$SDKROOT" ]; then
@@ -29,7 +31,7 @@ resolve_sdkroot() {
 }
 
 SDKROOT_PATH="$(resolve_sdkroot)"
-CURRENT_STAMP_CONTENT="tag=$PINNED_TAG;commit=$PINNED_COMMIT;config=$CONFIGURATION_NAME;archs=$CMAKE_ARCHITECTURES;deployment=$DEPLOYMENT_TARGET;sdk=$SDKROOT_PATH"
+BASE_STAMP_CONTENT="tag=$PINNED_TAG;commit=$PINNED_COMMIT;config=$CONFIGURATION_NAME;archs=$CMAKE_ARCHITECTURES;deployment=$DEPLOYMENT_TARGET;sdk=$SDKROOT_PATH"
 
 cache_value() {
   KEY="$1"
@@ -41,6 +43,41 @@ cache_entry_value() {
   KEY="$1"
   CACHE_FILE="$2"
   awk -F= -v key="$KEY" 'index($1, key ":") == 1 { print $2; exit }' "$CACHE_FILE"
+}
+
+is_forbidden_runtime_cache_entry() {
+  KEY="$1"
+  VALUE="$2"
+
+  case "$KEY" in
+    *LIBRARY*|*LIBRARIES*|*INCLUDE*|*LIBDIR*|*LIBRARY_DIRS*)
+      case "$VALUE" in
+        *"/opt/homebrew/"*|*"/usr/local/"*)
+          return 0
+          ;;
+      esac
+      ;;
+  esac
+
+  return 1
+}
+
+cache_has_forbidden_runtime_path() {
+  CACHE_FILE="$1"
+
+  while IFS= read -r LINE; do
+    case "$LINE" in
+      *"="*)
+        KEY="${LINE%%:*}"
+        VALUE="${LINE#*=}"
+        if is_forbidden_runtime_cache_entry "$KEY" "$VALUE"; then
+          return 0
+        fi
+        ;;
+    esac
+  done < "$CACHE_FILE"
+
+  return 1
 }
 
 reset_mismatched_cmake_cache() {
@@ -65,6 +102,13 @@ reset_mismatched_cmake_cache() {
   # Xcode SDK paths can change after an update, and CMake keeps old .tbd paths in its cache.
   if [ -n "$CACHE_SDKROOT" ] && { [ ! -e "$CACHE_SDKROOT" ] || { [ -n "$SDKROOT_PATH" ] && [ "$CACHE_SDKROOT" != "$SDKROOT_PATH" ]; }; }; then
     echo "warning: removing stale Wireshark CMake cache for a different macOS SDK." >&2
+    rm -rf "$BUILD_DIR"
+    return
+  fi
+
+  # Existing checkouts may still cache old Homebrew runtime paths from bottle-based builds.
+  if cache_has_forbidden_runtime_path "$CACHE_FILE"; then
+    echo "warning: removing stale Wireshark CMake cache with machine-local runtime paths." >&2
     rm -rf "$BUILD_DIR"
   fi
 }
@@ -95,10 +139,45 @@ has_installed_library() {
   find "$INSTALL_ROOT/lib" -name "lib$NAME.*" -print -quit 2>/dev/null | grep -q .
 }
 
+validate_wireshark_cache_paths() {
+  CACHE_FILE="$BUILD_DIR/CMakeCache.txt"
+  FAILURE_FILE="$BUILD_DIR/tcpviewer-forbidden-runtime-paths.txt"
+
+  [ -f "$CACHE_FILE" ] || return
+  : > "$FAILURE_FILE"
+
+  while IFS= read -r LINE; do
+    case "$LINE" in
+      *"="*)
+        KEY="${LINE%%:*}"
+        VALUE="${LINE#*=}"
+        if is_forbidden_runtime_cache_entry "$KEY" "$VALUE"; then
+          printf '%s\n' "$LINE" >> "$FAILURE_FILE"
+        fi
+        ;;
+    esac
+  done < "$CACHE_FILE"
+
+  if [ -s "$FAILURE_FILE" ]; then
+    echo "error: Wireshark CMake resolved runtime headers or libraries from a machine-local prefix." >&2
+    echo "       Rebuild with scripts/bootstrap-wireshark-deps.sh so runtime deps come from $DEPS_INSTALL_ROOT." >&2
+    sed 's/^/       /' "$FAILURE_FILE" >&2
+    exit 1
+  fi
+}
+
 if ! command -v git >/dev/null 2>&1; then
   echo "error: git is required to prepare vendored Wireshark." >&2
   exit 1
 fi
+
+"$PROJECT_DIR/scripts/bootstrap-wireshark-deps.sh"
+
+if [ ! -f "$DEPS_STAMP_FILE" ]; then
+  echo "error: Wireshark dependency stamp was not created at $DEPS_STAMP_FILE." >&2
+  exit 1
+fi
+CURRENT_STAMP_CONTENT="$BASE_STAMP_CONTENT;deps=$(cat "$DEPS_STAMP_FILE")"
 
 if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$CURRENT_STAMP_CONTENT" ] \
   && has_installed_library wireshark \
@@ -109,7 +188,7 @@ fi
 
 if ! command -v pkg-config >/dev/null 2>&1; then
   echo "error: pkg-config is required for Wireshark dependency discovery." >&2
-  echo "       Install Wireshark's macOS build dependencies, for example: brew install pkg-config cmake ninja glib libgcrypt gnutls nghttp2 brotli lz4 zstd" >&2
+  echo "       Install build tools with: brew install pkg-config cmake ninja meson autoconf automake libtool" >&2
   exit 1
 fi
 
@@ -171,6 +250,28 @@ fi
 rm -rf "$INSTALL_ROOT"
 mkdir -p "$INSTALL_ROOT"
 
+export MACOSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET"
+export PKG_CONFIG_PATH="$DEPS_INSTALL_ROOT/lib/pkgconfig:$DEPS_INSTALL_ROOT/share/pkgconfig"
+export PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH"
+export CMAKE_PREFIX_PATH="$DEPS_INSTALL_ROOT"
+export PATH="$DEPS_INSTALL_ROOT/bin:$PATH"
+export CC="${CC:-/usr/bin/clang}"
+export CXX="${CXX:-/usr/bin/clang++}"
+unset CPATH
+unset LIBRARY_PATH
+unset DYLD_LIBRARY_PATH
+unset DYLD_FALLBACK_LIBRARY_PATH
+
+COMMON_FLAGS="-mmacosx-version-min=$DEPLOYMENT_TARGET -Werror=unguarded-availability-new"
+if [ -n "$SDKROOT_PATH" ]; then
+  COMMON_FLAGS="-isysroot $SDKROOT_PATH $COMMON_FLAGS"
+fi
+
+export CPPFLAGS="-I$DEPS_INSTALL_ROOT/include ${TCPVIEWER_WIRESHARK_CPPFLAGS:-}"
+export CFLAGS="$COMMON_FLAGS -O2 ${TCPVIEWER_WIRESHARK_CFLAGS:-}"
+export CXXFLAGS="$COMMON_FLAGS -O2 ${TCPVIEWER_WIRESHARK_CXXFLAGS:-}"
+export LDFLAGS="-L$DEPS_INSTALL_ROOT/lib -mmacosx-version-min=$DEPLOYMENT_TARGET ${TCPVIEWER_WIRESHARK_LDFLAGS:-}"
+
 "$CMAKE_BIN" -S "$SOURCE_DIR" -B "$BUILD_DIR" -G Ninja \
   -DCMAKE_MAKE_PROGRAM="$NINJA_BIN" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -178,6 +279,12 @@ mkdir -p "$INSTALL_ROOT"
   -DCMAKE_OSX_ARCHITECTURES="$CMAKE_ARCHITECTURES" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET" \
   -DCMAKE_OSX_SYSROOT="$SDKROOT_PATH" \
+  -DCMAKE_PREFIX_PATH="$DEPS_INSTALL_ROOT" \
+  -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/local" \
+  -DCMAKE_SYSTEM_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/local" \
+  -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE \
+  -DCMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE \
+  -DCMAKE_INSTALL_NAME_DIR="@rpath" \
   -DENABLE_APPLICATION_BUNDLE=OFF \
   -DENABLE_QT6=OFF \
   -DENABLE_QT5=OFF \
@@ -185,6 +292,8 @@ mkdir -p "$INSTALL_ROOT"
   -DENABLE_DOXYGEN=OFF \
   -DENABLE_MAN_PAGES=OFF \
   -DENABLE_PLUGINS=OFF \
+  -DENABLE_AMRNB=OFF \
+  -DENABLE_OPUS=OFF \
   -DBUILD_androiddump=OFF \
   -DBUILD_ciscodump=OFF \
   -DBUILD_capinfos=OFF \
@@ -212,6 +321,7 @@ mkdir -p "$INSTALL_ROOT"
   -DBUILD_wifidump=OFF \
   -DBUILD_wireshark=OFF
 
+validate_wireshark_cache_paths
 "$CMAKE_BIN" --build "$BUILD_DIR" --config RelWithDebInfo --target epan wiretap wsutil --parallel
 "$CMAKE_BIN" --install "$BUILD_DIR" --config RelWithDebInfo
 

--- a/scripts/bootstrap-wireshark.sh
+++ b/scripts/bootstrap-wireshark.sh
@@ -87,7 +87,16 @@ is_forbidden_runtime_cache_entry() {
   KEY="$1"
   VALUE="$2"
 
+  # CMake install/output bookkeeping is not dependency discovery.
   case "$KEY" in
+    CMAKE_INSTALL_OLDINCLUDEDIR|*_OUTPUT_PATH|*_OUTPUT_DIRECTORY)
+      return 1
+      ;;
+  esac
+
+  case "$KEY" in
+    *FIND_PACKAGE_MESSAGE_DETAILS*|pkgcfg_lib_*)
+      ;;
     *LIBRARY*|*LIBRARIES*|*INCLUDE*|*LIBDIR*|*LIBRARY_DIRS*|*LDFLAGS*|*LDFLAG*|*LINK_FLAGS*)
       ;;
     *)

--- a/scripts/bootstrap-wireshark.sh
+++ b/scripts/bootstrap-wireshark.sh
@@ -45,19 +45,66 @@ cache_entry_value() {
   awk -F= -v key="$KEY" 'index($1, key ":") == 1 { print $2; exit }' "$CACHE_FILE"
 }
 
+is_allowed_runtime_cache_path() {
+  PATH_VALUE="$1"
+
+  case "$PATH_VALUE" in
+    -I/*|-L/*)
+      PATH_VALUE="${PATH_VALUE#-?}"
+      ;;
+    -Wl,-rpath,/*)
+      PATH_VALUE="${PATH_VALUE#-Wl,-rpath,}"
+      ;;
+  esac
+
+  case "$PATH_VALUE" in
+    ""|*-NOTFOUND|*NOTFOUND)
+      return 0
+      ;;
+    "$DEPS_INSTALL_ROOT"|"$DEPS_INSTALL_ROOT"/*|/usr/lib/*|/System/Library/*)
+      return 0
+      ;;
+  esac
+
+  if [ -n "$SDKROOT_PATH" ]; then
+    case "$PATH_VALUE" in
+      "$SDKROOT_PATH"|"$SDKROOT_PATH"/*)
+        return 0
+        ;;
+    esac
+  fi
+
+  case "$PATH_VALUE" in
+    /*)
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
 is_forbidden_runtime_cache_entry() {
   KEY="$1"
   VALUE="$2"
 
   case "$KEY" in
-    *LIBRARY*|*LIBRARIES*|*INCLUDE*|*LIBDIR*|*LIBRARY_DIRS*)
-      case "$VALUE" in
-        *"/opt/homebrew/"*|*"/usr/local/"*)
-          return 0
-          ;;
-      esac
+    *LIBRARY*|*LIBRARIES*|*INCLUDE*|*LIBDIR*|*LIBRARY_DIRS*|*LDFLAGS*|*LDFLAG*|*LINK_FLAGS*)
+      ;;
+    *)
+      return 1
       ;;
   esac
+
+  OLD_IFS="$IFS"
+  IFS=';'
+  for PATH_VALUE in $VALUE; do
+    IFS="$OLD_IFS"
+    if ! is_allowed_runtime_cache_path "$PATH_VALUE"; then
+      return 0
+    fi
+    IFS=';'
+  done
+  IFS="$OLD_IFS"
 
   return 1
 }

--- a/scripts/nodejs/index.js
+++ b/scripts/nodejs/index.js
@@ -18,6 +18,8 @@ function parseArgs(argv) {
       args.type = arg.slice("--type=".length).trim().toLowerCase();
     } else if (arg.startsWith("--beta-name=")) {
       args.betaName = arg.slice("--beta-name=".length).trim();
+    } else if (arg === "--yes" || arg === "-y") {
+      args.yes = true;
     }
   }
   return args;
@@ -97,6 +99,9 @@ function buildReleaseArgs(type, args) {
   const releaseArgs = [releaseScriptPath, `--type=${type}`];
   if (args.betaName) {
     releaseArgs.push(`--beta-name=${args.betaName}`);
+  }
+  if (args.yes) {
+    releaseArgs.push("--yes");
   }
   return releaseArgs;
 }

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -99,6 +99,28 @@ export function publishReleaseToBackendEnabled(env) {
   throw new Error("TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND must be one of: 1, true, yes, on, 0, false, no, off.");
 }
 
+export function isRetryableHTTPStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+export function describeFetchError(error) {
+  const descriptions = [];
+  let current = error;
+  for (let depth = 0; current && depth < 4; depth += 1) {
+    const code = typeof current.code === "string" && current.code ? `${current.code}: ` : "";
+    const message = typeof current.message === "string" && current.message
+      ? current.message
+      : String(current);
+    const description = `${code}${message}`.trim();
+    if (description && !descriptions.includes(description)) {
+      descriptions.push(description);
+    }
+    current = current.cause;
+  }
+
+  return descriptions.join(" | ") || "Unknown fetch failure.";
+}
+
 export function normalizeReleaseBackendURL(value) {
   const rawURL = String(value ?? "").trim();
   if (!rawURL) {

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -1,6 +1,6 @@
 import { createHash, createHmac } from "node:crypto";
 
-export const minimumSystemVersion = "15.6";
+export const minimumSystemVersion = "15.0";
 export const releaseDMGAppName = "tcpviewer";
 export const emptyPayloadSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -53,6 +53,8 @@ const repoRoot = path.resolve(__dirname, "..");
 const releaseBackendPlatform = "macos";
 const r2UploadMaxAttempts = 3;
 const r2UploadConfirmationAttempts = 3;
+const r2UploadAttemptTimeoutMs = 300_000;
+const r2UploadConfirmationTimeoutMs = 30_000;
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -119,7 +121,7 @@ async function main() {
     githubRelease,
     releaseBackend
   });
-  if (!await askReleaseConfirmation()) {
+  if (!args.yes && !await askReleaseConfirmation()) {
     console.log("Release cancelled.");
     return;
   }
@@ -254,7 +256,7 @@ async function runFastlaneBuild({ env, releaseType, version, buildNumber, output
     `build_number:${buildNumber}`,
     `output_dir:${outputDir}`,
     `dmg_name:${dmgFileName}`
-  ], { env });
+  ], { env: { ...env, FASTLANE_SKIP_UPDATE_CHECK: "1" } });
 }
 
 async function verifyFinalDMG({ dmgPath }) {
@@ -374,11 +376,12 @@ async function putR2ObjectWithRetry({ url, signedHeaders, verificationHeaders, d
   for (let attempt = 1; attempt <= r2UploadMaxAttempts; attempt += 1) {
     let response;
     try {
-      response = await fetch(url, {
+      response = await curlR2Request({
         method: "PUT",
+        url,
         headers: signedHeaders,
-        body: createReadStream(dmgPath),
-        duplex: "half"
+        uploadFile: dmgPath,
+        timeoutMs: r2UploadAttemptTimeoutMs
       });
     } catch (error) {
       const message = describeFetchError(error);
@@ -393,11 +396,11 @@ async function putR2ObjectWithRetry({ url, signedHeaders, verificationHeaders, d
       continue;
     }
 
-    if (response.ok) {
+    if (isSuccessfulHTTPStatus(response.status)) {
       return;
     }
 
-    const message = `${response.status} ${await safeReadResponseText(response)}`.trim();
+    const message = `${response.status} ${response.body}`.trim();
     if (!isRetryableHTTPStatus(response.status)) {
       throw new Error(`R2 upload failed for ${objectKey}: ${message}`);
     }
@@ -422,14 +425,16 @@ async function retryR2Upload({ attempt, message, objectKey }) {
 async function r2ObjectHasExpectedSize({ url, headers, expectedSize }) {
   for (let attempt = 1; attempt <= r2UploadConfirmationAttempts; attempt += 1) {
     try {
-      const response = await fetch(url, {
+      const response = await curlR2Request({
         method: "HEAD",
-        headers
+        url,
+        headers,
+        timeoutMs: r2UploadConfirmationTimeoutMs
       });
       if (response.status === 404) {
         return false;
       }
-      if (response.ok) {
+      if (isSuccessfulHTTPStatus(response.status)) {
         return Number(response.headers.get("content-length")) === expectedSize;
       }
     } catch {
@@ -444,19 +449,84 @@ async function r2ObjectHasExpectedSize({ url, headers, expectedSize }) {
   return false;
 }
 
-async function safeReadResponseText(response) {
-  try {
-    const text = await response.text();
-    return text.trim() || response.statusText;
-  } catch (error) {
-    return describeFetchError(error);
-  }
-}
-
 function sleep(milliseconds) {
   return new Promise((resolve) => {
     setTimeout(resolve, milliseconds);
   });
+}
+
+async function curlR2Request({ method, url, headers, uploadFile = null, timeoutMs }) {
+  const args = [
+    "-sS",
+    "--max-time", String(Math.ceil(timeoutMs / 1000)),
+    "--write-out", "\n%{http_code}",
+    "--output", "-"
+  ];
+
+  if (method === "HEAD") {
+    args.push("--head");
+  } else {
+    args.push("--request", method);
+  }
+
+  if (uploadFile) {
+    args.push("--upload-file", uploadFile);
+  }
+
+  args.push(...curlHeaderArgs(headers, { skipHeaders: uploadFile ? ["content-length"] : [] }));
+  args.push(url.href);
+
+  const result = await runCommand("/usr/bin/curl", args, { capture: true });
+  return parseCurlHTTPResponse(result.stdout);
+}
+
+function curlHeaderArgs(headers, { skipHeaders = [] } = {}) {
+  const skipped = new Set(skipHeaders.map((name) => name.toLowerCase()));
+  return Object.entries(headers).flatMap(([name, value]) => {
+    if (skipped.has(name.toLowerCase())) {
+      return [];
+    }
+    return ["--header", `${name}: ${value}`];
+  });
+}
+
+function parseCurlHTTPResponse(stdout) {
+  const markerIndex = stdout.lastIndexOf("\n");
+  const status = Number(stdout.slice(markerIndex + 1).trim());
+  const body = markerIndex === -1 ? "" : stdout.slice(0, markerIndex).trim();
+  if (!Number.isInteger(status) || status < 100) {
+    throw new Error("curl did not return an HTTP status code.");
+  }
+
+  return {
+    status,
+    body,
+    headers: parseCurlHeaders(body)
+  };
+}
+
+function parseCurlHeaders(rawHeaders) {
+  const headers = new Map();
+  for (const line of rawHeaders.split(/\r?\n/)) {
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
+      continue;
+    }
+    headers.set(
+      line.slice(0, separatorIndex).trim().toLowerCase(),
+      line.slice(separatorIndex + 1).trim()
+    );
+  }
+
+  return {
+    get(name) {
+      return headers.get(name.toLowerCase()) ?? null;
+    }
+  };
+}
+
+function isSuccessfulHTTPStatus(status) {
+  return status >= 200 && status < 300;
 }
 
 function resolveReleaseBackend({ env, releaseType }) {
@@ -961,6 +1031,8 @@ function parseArgs(argv) {
       args.type = arg.slice("--type=".length).toLowerCase();
     } else if (arg.startsWith("--beta-name=")) {
       args.betaName = arg.slice("--beta-name=".length);
+    } else if (arg === "--yes" || arg === "-y") {
+      args.yes = true;
     }
   }
   return args;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -19,9 +19,11 @@ import { spawn } from "node:child_process";
 import prompts from "prompts";
 import {
   assertReleaseTitleReflectsChanges,
+  describeFetchError,
   emptyPayloadSHA256,
   findReleaseNote,
   generateAppcastXML,
+  isRetryableHTTPStatus,
   makeGitHubReleaseTagName,
   makeBetaDMGFileName,
   makeDMGFileName,
@@ -49,6 +51,8 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const releaseBackendPlatform = "macos";
+const r2UploadMaxAttempts = 3;
+const r2UploadConfirmationAttempts = 3;
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -346,17 +350,113 @@ async function uploadDMGToR2({ env, objectKey, dmgPath }) {
       "content-type": "application/x-apple-diskimage"
     }
   });
-
-  const response = await fetch(url, {
-    method: "PUT",
-    headers: signedHeaders,
-    body: createReadStream(dmgPath),
-    duplex: "half"
+  const verificationHeaders = signR2Request({
+    method: "HEAD",
+    url,
+    accessKeyId: env.TCPVIEWER_R2_ACCESS_KEY_ID,
+    secretAccessKey: env.TCPVIEWER_R2_SECRET_ACCESS_KEY,
+    payloadHash: emptyPayloadSHA256
   });
 
-  if (!response.ok) {
-    throw new Error(`R2 upload failed for ${objectKey}: ${response.status} ${await response.text()}`);
+  console.log(`Uploading DMG to R2: ${objectKey}`);
+  await putR2ObjectWithRetry({
+    url,
+    signedHeaders,
+    verificationHeaders,
+    dmgPath,
+    objectKey,
+    expectedSize: fileStat.size
+  });
+  console.log(`Uploaded DMG to R2: ${objectKey}`);
+}
+
+async function putR2ObjectWithRetry({ url, signedHeaders, verificationHeaders, dmgPath, objectKey, expectedSize }) {
+  for (let attempt = 1; attempt <= r2UploadMaxAttempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetch(url, {
+        method: "PUT",
+        headers: signedHeaders,
+        body: createReadStream(dmgPath),
+        duplex: "half"
+      });
+    } catch (error) {
+      const message = describeFetchError(error);
+      if (attempt === r2UploadMaxAttempts) {
+        if (await r2ObjectHasExpectedSize({ url, headers: verificationHeaders, expectedSize })) {
+          console.warn(`R2 upload response was lost, but ${objectKey} exists with the expected size. Continuing.`);
+          return;
+        }
+        throw new Error(`R2 upload failed for ${objectKey}: ${message}`);
+      }
+      await retryR2Upload({ attempt, message, objectKey });
+      continue;
+    }
+
+    if (response.ok) {
+      return;
+    }
+
+    const message = `${response.status} ${await safeReadResponseText(response)}`.trim();
+    if (!isRetryableHTTPStatus(response.status)) {
+      throw new Error(`R2 upload failed for ${objectKey}: ${message}`);
+    }
+
+    if (attempt === r2UploadMaxAttempts) {
+      if (await r2ObjectHasExpectedSize({ url, headers: verificationHeaders, expectedSize })) {
+        console.warn(`R2 upload ended with ${response.status}, but ${objectKey} exists with the expected size. Continuing.`);
+        return;
+      }
+      throw new Error(`R2 upload failed for ${objectKey}: ${message}`);
+    }
+
+    await retryR2Upload({ attempt, message, objectKey });
   }
+}
+
+async function retryR2Upload({ attempt, message, objectKey }) {
+  console.warn(`R2 upload attempt ${attempt}/${r2UploadMaxAttempts} failed for ${objectKey}: ${message}. Retrying...`);
+  await sleep(attempt * 1500);
+}
+
+async function r2ObjectHasExpectedSize({ url, headers, expectedSize }) {
+  for (let attempt = 1; attempt <= r2UploadConfirmationAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        method: "HEAD",
+        headers
+      });
+      if (response.status === 404) {
+        return false;
+      }
+      if (response.ok) {
+        return Number(response.headers.get("content-length")) === expectedSize;
+      }
+    } catch {
+      // A lost PUT response can race with transient network failures; retry the confirmation too.
+    }
+
+    if (attempt < r2UploadConfirmationAttempts) {
+      await sleep(attempt * 1000);
+    }
+  }
+
+  return false;
+}
+
+async function safeReadResponseText(response) {
+  try {
+    const text = await response.text();
+    return text.trim() || response.statusText;
+  } catch (error) {
+    return describeFetchError(error);
+  }
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
 }
 
 function resolveReleaseBackend({ env, releaseType }) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -29,6 +29,7 @@ import {
   makeR2ObjectKey,
   makeR2StorageObjectKey,
   mergeEnv,
+  minimumSystemVersion,
   missingRequiredEnv,
   normalizeReleaseBackendURL,
   normalizeSparklePrivateKey,
@@ -190,6 +191,13 @@ async function preflight({ env, releaseType, objectKey, settings, releaseBackend
   await requireTool("xcodebuild", ["-version"]);
   await requireTool("xcrun", ["notarytool", "--version"]);
   await access(path.join(repoRoot, "Vendor/.install/wireshark/lib"));
+  await access(path.join(repoRoot, "Vendor/.install/wireshark-deps/lib"));
+  await requireTool(path.join(repoRoot, "scripts/verify-bundled-runtime-compatibility.sh"), [
+    path.join(repoRoot, "Vendor/.install/wireshark-deps"),
+    minimumSystemVersion,
+    "--allow-prefix",
+    path.join(repoRoot, "Vendor/.install/wireshark-deps")
+  ]);
 
   if (settings.ENABLE_HARDENED_RUNTIME !== "YES") {
     throw new Error("TCPViewer Release build must enable hardened runtime.");

--- a/scripts/stage-wireshark-runtime.sh
+++ b/scripts/stage-wireshark-runtime.sh
@@ -4,9 +4,15 @@ set -eu
 
 PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 SOURCE_LIB_DIR="$PROJECT_DIR/Vendor/.install/wireshark/lib"
+DEPS_LIB_DIR="$PROJECT_DIR/Vendor/.install/wireshark-deps/lib"
 
 if [ ! -d "$SOURCE_LIB_DIR" ]; then
   echo "error: Wireshark libraries are missing at $SOURCE_LIB_DIR. Run scripts/bootstrap-wireshark.sh." >&2
+  exit 1
+fi
+
+if [ ! -d "$DEPS_LIB_DIR" ]; then
+  echo "error: Wireshark dependency libraries are missing at $DEPS_LIB_DIR. Run scripts/bootstrap-wireshark-deps.sh." >&2
   exit 1
 fi
 
@@ -25,6 +31,8 @@ COPIED_PATHS_FILE="$WORK_DIR/copied-paths.txt"
 
 mkdir -p "$DESTINATION_DIR"
 rm -f "$DESTINATION_DIR/.wireshark-runtime-staged"
+find "$DESTINATION_DIR" -maxdepth 1 -name '*.dylib' -type f -delete
+find "$DESTINATION_DIR" -maxdepth 1 -name '*.dylib' -type l -delete
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
 : > "$QUEUE_FILE"
@@ -41,10 +49,30 @@ is_system_dependency() {
   return 1
 }
 
+is_allowed_vendor_dependency() {
+  case "$1" in
+    "$SOURCE_LIB_DIR"/*|"$DEPS_LIB_DIR"/*|"$DESTINATION_DIR"/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+is_forbidden_machine_dependency() {
+  case "$1" in
+    /opt/homebrew/*|/usr/local/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
 resolve_rpath_library() {
   LIBRARY_NAME="$1"
 
-  for LIBRARY_DIR in "$SOURCE_LIB_DIR" /opt/homebrew/lib /opt/homebrew/opt/*/lib /usr/local/lib /usr/local/opt/*/lib; do
+  for LIBRARY_DIR in "$DESTINATION_DIR" "$SOURCE_LIB_DIR" "$DEPS_LIB_DIR"; do
     if [ -f "$LIBRARY_DIR/$LIBRARY_NAME" ]; then
       printf '%s\n' "$LIBRARY_DIR/$LIBRARY_NAME"
       return
@@ -129,7 +157,18 @@ queue_dependency() {
       fi
       ;;
     /*)
-      queue_library "$DEPENDENCY"
+      if is_forbidden_machine_dependency "$DEPENDENCY"; then
+        echo "error: refusing to stage machine-local Wireshark dependency: $DEPENDENCY" >&2
+        echo "       Rebuild with scripts/bootstrap-wireshark-deps.sh so runtime deps come from Vendor/.install/wireshark-deps." >&2
+        exit 1
+      fi
+
+      if is_allowed_vendor_dependency "$DEPENDENCY"; then
+        queue_library "$DEPENDENCY"
+      else
+        echo "error: refusing to stage unexpected absolute Wireshark dependency: $DEPENDENCY" >&2
+        exit 1
+      fi
       ;;
   esac
 }
@@ -153,7 +192,7 @@ copy_next_library() {
   printf '%s\n' "$LIBRARY_NAME" >> "$COPIED_NAMES_FILE"
   printf '%s\n' "$DESTINATION_PATH" >> "$COPIED_PATHS_FILE"
 
-  otool -L "$DESTINATION_PATH" | awk 'NR > 2 { print $1 }' > "$WORK_DIR/dependencies.txt"
+  otool -L "$DESTINATION_PATH" | sed -n '/^[[:space:]]/ { s/^[[:space:]]*//; s/ (compatibility.*$//; p; }' > "$WORK_DIR/dependencies.txt"
   while IFS= read -r DEPENDENCY; do
     [ -n "$DEPENDENCY" ] || continue
     queue_dependency "$DEPENDENCY" "$LIBRARY_PATH"
@@ -167,7 +206,7 @@ patch_library() {
   install_name_tool -id "@rpath/$LIBRARY_NAME" "$LIBRARY_PATH"
   install_name_tool -add_rpath "@loader_path" "$LIBRARY_PATH" 2>/dev/null || true
 
-  otool -L "$LIBRARY_PATH" | awk 'NR > 2 { print $1 }' > "$WORK_DIR/patch-dependencies.txt"
+  otool -L "$LIBRARY_PATH" | sed -n '/^[[:space:]]/ { s/^[[:space:]]*//; s/ (compatibility.*$//; p; }' > "$WORK_DIR/patch-dependencies.txt"
   while IFS= read -r DEPENDENCY; do
     [ -n "$DEPENDENCY" ] || continue
 
@@ -187,7 +226,7 @@ patch_consumer_binary() {
 
   install_name_tool -add_rpath "@loader_path/Frameworks" "$BINARY_PATH" 2>/dev/null || true
 
-  otool -L "$BINARY_PATH" | awk 'NR > 2 { print $1 }' > "$WORK_DIR/patch-consumer-dependencies.txt"
+  otool -L "$BINARY_PATH" | sed -n '/^[[:space:]]/ { s/^[[:space:]]*//; s/ (compatibility.*$//; p; }' > "$WORK_DIR/patch-consumer-dependencies.txt"
   while IFS= read -r DEPENDENCY; do
     [ -n "$DEPENDENCY" ] || continue
 

--- a/scripts/verify-bundled-runtime-compatibility.sh
+++ b/scripts/verify-bundled-runtime-compatibility.sh
@@ -48,12 +48,43 @@ version_gt() {
   ' "$1" "$2"
 }
 
-macho_minos() {
+macho_minos_values() {
   otool -l "$1" 2>/dev/null | awk '
-    /LC_BUILD_VERSION/ { in_build = 1; next }
-    in_build && /minos / { print $2; exit }
-    /LC_VERSION_MIN_MACOSX/ { in_legacy = 1; next }
-    in_legacy && /version / { print $2; exit }
+    function emit(value) {
+      if (value != "" && !seen[value]++) {
+        print value
+      }
+    }
+
+    $1 == "cmd" && $2 == "LC_BUILD_VERSION" {
+      in_build = 1
+      in_legacy = 0
+      next
+    }
+
+    $1 == "cmd" && $2 == "LC_VERSION_MIN_MACOSX" {
+      in_build = 0
+      in_legacy = 1
+      next
+    }
+
+    $1 == "cmd" {
+      in_build = 0
+      in_legacy = 0
+      next
+    }
+
+    in_build && $1 == "minos" {
+      emit($2)
+      in_build = 0
+      next
+    }
+
+    in_legacy && $1 == "version" {
+      emit($2)
+      in_legacy = 0
+      next
+    }
   '
 }
 
@@ -97,10 +128,12 @@ find "$ROOT_PATH" -type f -print | while IFS= read -r FILE_PATH; do
     continue
   fi
 
-  MINOS="$(macho_minos "$FILE_PATH")"
-  if [ -n "$MINOS" ] && version_gt "$MINOS" "$MAXIMUM_MACOS_VERSION"; then
-    printf '%s\n' "minos $MINOS > $MAXIMUM_MACOS_VERSION: $FILE_PATH" >> "$TMP_FAILURES"
-  fi
+  macho_minos_values "$FILE_PATH" | while IFS= read -r MINOS; do
+    [ -n "$MINOS" ] || continue
+    if version_gt "$MINOS" "$MAXIMUM_MACOS_VERSION"; then
+      printf '%s\n' "minos $MINOS > $MAXIMUM_MACOS_VERSION: $FILE_PATH" >> "$TMP_FAILURES"
+    fi
+  done
 
   otool -D "$FILE_PATH" 2>/dev/null | sed -n '/):$/d; 1!p' > "$TMP_SELF_IDS"
   while IFS= read -r INSTALL_ID; do

--- a/scripts/verify-bundled-runtime-compatibility.sh
+++ b/scripts/verify-bundled-runtime-compatibility.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <app-or-directory> [maximum-macos-version] [--allow-prefix <path> ...]" >&2
+  exit 2
+fi
+
+ROOT_PATH="$1"
+MAXIMUM_MACOS_VERSION="${2:-15.0}"
+shift
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+ALLOW_PREFIXES=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --allow-prefix)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "error: --allow-prefix requires a path." >&2
+        exit 2
+      fi
+      ALLOW_PREFIXES="${ALLOW_PREFIXES}
+$1"
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ ! -e "$ROOT_PATH" ]; then
+  echo "error: compatibility scan path does not exist: $ROOT_PATH" >&2
+  exit 1
+fi
+
+version_gt() {
+  /usr/bin/ruby -e '
+    def version(value)
+      value.to_s.split(".").map(&:to_i)
+    end
+    exit((version(ARGV[0]) <=> version(ARGV[1])) == 1 ? 0 : 1)
+  ' "$1" "$2"
+}
+
+macho_minos() {
+  otool -l "$1" 2>/dev/null | awk '
+    /LC_BUILD_VERSION/ { in_build = 1; next }
+    in_build && /minos / { print $2; exit }
+    /LC_VERSION_MIN_MACOSX/ { in_legacy = 1; next }
+    in_legacy && /version / { print $2; exit }
+  '
+}
+
+is_macho() {
+  otool -h "$1" >/dev/null 2>&1
+}
+
+is_allowed_prefix_path() {
+  PATH_VALUE="$1"
+
+  case "$PATH_VALUE" in
+    /usr/lib/*|/System/Library/*|@rpath/*|@loader_path/*|@executable_path/*)
+      return 0
+      ;;
+  esac
+
+  OLD_IFS="$IFS"
+  IFS='
+'
+  for PREFIX in $ALLOW_PREFIXES; do
+    [ -n "$PREFIX" ] || continue
+    case "$PATH_VALUE" in
+      "$PREFIX"/*)
+        IFS="$OLD_IFS"
+        return 0
+        ;;
+    esac
+  done
+  IFS="$OLD_IFS"
+
+  return 1
+}
+
+TMP_FAILURES="${TMPDIR:-/tmp}/tcpviewer-runtime-compatibility-$$.txt"
+TMP_SELF_IDS="${TMPDIR:-/tmp}/tcpviewer-runtime-compatibility-self-ids-$$.txt"
+trap 'rm -f "$TMP_FAILURES" "$TMP_SELF_IDS"' EXIT
+: > "$TMP_FAILURES"
+
+find "$ROOT_PATH" -type f -print | while IFS= read -r FILE_PATH; do
+  if ! is_macho "$FILE_PATH"; then
+    continue
+  fi
+
+  MINOS="$(macho_minos "$FILE_PATH")"
+  if [ -n "$MINOS" ] && version_gt "$MINOS" "$MAXIMUM_MACOS_VERSION"; then
+    printf '%s\n' "minos $MINOS > $MAXIMUM_MACOS_VERSION: $FILE_PATH" >> "$TMP_FAILURES"
+  fi
+
+  otool -D "$FILE_PATH" 2>/dev/null | sed -n '/):$/d; 1!p' > "$TMP_SELF_IDS"
+  while IFS= read -r INSTALL_ID; do
+    [ -n "$INSTALL_ID" ] || continue
+    case "$INSTALL_ID" in
+      /opt/homebrew/*|/usr/local/*)
+        printf '%s\n' "machine-local install ID $INSTALL_ID in $FILE_PATH" >> "$TMP_FAILURES"
+        ;;
+    esac
+  done < "$TMP_SELF_IDS"
+
+  otool -L "$FILE_PATH" 2>/dev/null | sed -n '/^[[:space:]]/ { s/^[[:space:]]*//; s/ (compatibility.*$//; p; }' | while IFS= read -r DEPENDENCY; do
+    [ -n "$DEPENDENCY" ] || continue
+    if grep -Fxq "$DEPENDENCY" "$TMP_SELF_IDS"; then
+      continue
+    fi
+
+    case "$DEPENDENCY" in
+      /opt/homebrew/*|/usr/local/*)
+        printf '%s\n' "machine-local dependency $DEPENDENCY referenced by $FILE_PATH" >> "$TMP_FAILURES"
+        ;;
+      /*)
+        if ! is_allowed_prefix_path "$DEPENDENCY"; then
+          printf '%s\n' "unexpected absolute dependency $DEPENDENCY referenced by $FILE_PATH" >> "$TMP_FAILURES"
+        fi
+        ;;
+    esac
+  done
+done
+
+if [ -s "$TMP_FAILURES" ]; then
+  echo "error: bundled runtime compatibility check failed:" >&2
+  sed 's/^/  - /' "$TMP_FAILURES" >&2
+  exit 1
+fi
+
+echo "Bundled runtime compatibility check passed for $ROOT_PATH."

--- a/scripts/verify-bundled-runtime-compatibility.sh
+++ b/scripts/verify-bundled-runtime-compatibility.sh
@@ -40,12 +40,37 @@ if [ ! -e "$ROOT_PATH" ]; then
 fi
 
 version_gt() {
-  /usr/bin/ruby -e '
-    def version(value)
-      value.to_s.split(".").map(&:to_i)
-    end
-    exit((version(ARGV[0]) <=> version(ARGV[1])) == 1 ? 0 : 1)
-  ' "$1" "$2"
+  VERSION_COMPARE_RESULT="$(awk -v left="$1" -v right="$2" '
+    function split_version(value, parts) {
+      count = split(value, raw_parts, ".")
+      for (i = 1; i <= 4; i += 1) {
+        parts[i] = i <= count ? raw_parts[i] + 0 : 0
+      }
+    }
+
+    BEGIN {
+      split_version(left, left_parts)
+      split_version(right, right_parts)
+
+      for (i = 1; i <= 4; i += 1) {
+        if (left_parts[i] > right_parts[i]) {
+          print "1"
+          exit
+        }
+        if (left_parts[i] < right_parts[i]) {
+          print "0"
+          exit
+        }
+      }
+
+      print "0"
+    }
+  ')" || {
+    echo "error: failed to compare macOS versions: $1 and $2" >&2
+    exit 1
+  }
+
+  [ "$VERSION_COMPARE_RESULT" = "1" ]
 }
 
 macho_minos_values() {

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -99,7 +99,7 @@ test("generates Sparkle appcast XML from structured notes", () => {
 
   assert.match(xml, /<title>Packet Inspector Launch<\/title>/);
   assert.match(xml, /<sparkle:version>42<\/sparkle:version>/);
-  assert.match(xml, /<sparkle:minimumSystemVersion>15.6<\/sparkle:minimumSystemVersion>/);
+  assert.match(xml, /<sparkle:minimumSystemVersion>15.0<\/sparkle:minimumSystemVersion>/);
   assert.match(xml, /sparkle:edSignature="abc123"/);
   assert.match(xml, /New &lt;feature&gt;/);
 });

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -3,9 +3,11 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import {
   assertReleaseTitleReflectsChanges,
+  describeFetchError,
   emptyPayloadSHA256,
   findReleaseNote,
   generateAppcastXML,
+  isRetryableHTTPStatus,
   makeBetaDMGFileName,
   makeDMGFileName,
   makeGitHubReleaseTagName,
@@ -249,6 +251,21 @@ test("validates optional release backend publishing env", () => {
     releaseBackendRequiredEnvNames
   );
   assert.deepEqual(missing, ["TCPVIEWER_RELEASE_BACKEND_SCRIPT_SECRET"]);
+});
+
+test("classifies transient release HTTP failures", () => {
+  assert.equal(isRetryableHTTPStatus(408), true);
+  assert.equal(isRetryableHTTPStatus(429), true);
+  assert.equal(isRetryableHTTPStatus(500), true);
+  assert.equal(isRetryableHTTPStatus(403), false);
+});
+
+test("describes nested fetch failures for release diagnostics", () => {
+  const error = new TypeError("fetch failed", {
+    cause: Object.assign(new Error("socket closed"), { code: "UND_ERR_SOCKET" })
+  });
+
+  assert.equal(describeFetchError(error), "fetch failed | UND_ERR_SOCKET: socket closed");
 });
 
 test("parses Sparkle signing output", () => {


### PR DESCRIPTION
## Summary
- Tighten the Wireshark bootstrap and runtime staging scripts used by TCPViewer.
- Update release tooling and Fastlane wiring to keep bundled runtime packaging consistent.
- Refresh documentation and third-party notices to match the current distribution flow.
- Add release script coverage to validate the packaging logic.

## Testing
- Added and updated unit coverage for the release helper scripts.
- Not run (not requested)