### PR TITLE
[codex] Add inspector context menu copy actions

### DIFF
--- a/TCPViewer/App/AppDelegate.swift
+++ b/TCPViewer/App/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         wireAboutMenu()
         wirePreferencesMenu()
         wireUpdatesMenu()
+        wireClearAllPacketsMenu()
         wireFilterMenu()
         wireHelpMenu()
         verifyLicenseAtLaunch()
@@ -531,6 +532,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let insertionIndex = editMenu.items.firstIndex { $0.title == "Find" } ?? editMenu.items.count
         editMenu.insertItem(item, at: insertionIndex)
+    }
+
+    private func wireClearAllPacketsMenu() {
+        guard let editMenu = NSApp.mainMenu?.items.first(where: { $0.title == "Edit" })?.submenu else {
+            return
+        }
+
+        if let existingItem = editMenu.items.first(where: { $0.action == #selector(TCPViewerWindowController.clearAllPackets(_:)) }) {
+            configureClearAllPacketsMenuItem(existingItem)
+            return
+        }
+
+        let item = NSMenuItem(
+            title: "Clear All Packets",
+            action: #selector(TCPViewerWindowController.clearAllPackets(_:)),
+            keyEquivalent: "k"
+        )
+        configureClearAllPacketsMenuItem(item)
+
+        let insertionIndex = editMenu.items.firstIndex { $0.title == "Find" } ?? editMenu.items.count
+        editMenu.insertItem(item, at: insertionIndex)
+    }
+
+    private func configureClearAllPacketsMenuItem(_ item: NSMenuItem) {
+        item.title = "Clear All Packets"
+        item.target = nil
+        item.action = #selector(TCPViewerWindowController.clearAllPackets(_:))
+        item.keyEquivalent = "k"
+        item.keyEquivalentModifierMask = [.command]
     }
 
     private func configureFilterMenuItem(_ item: NSMenuItem) {

--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -179,7 +179,7 @@ final class TCPViewerToolbarDataSource: NSObject {
         clearAllButton.controlSize = .regular
         clearAllButton.image = TCPViewerUI.image("trash")
         clearAllButton.imagePosition = .imageOnly
-        clearAllButton.toolTip = "Clear All Packets"
+        clearAllButton.toolTip = "Clear All Packets (⌘K)"
 
         trialButton.target = self
         trialButton.action = #selector(trialButtonPressed(_:))

--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -97,6 +97,10 @@ final class TCPViewerWindowController: NSWindowController {
         rootViewController.focusSidebarFilter()
     }
 
+    @IBAction func clearAllPackets(_ sender: Any?) {
+        rootViewController.clearAllPackets()
+    }
+
     private func setupToolbar() {
         toolbarDataSource.delegate = self
         window?.toolbar = toolbarDataSource.toolbar
@@ -228,7 +232,7 @@ extension TCPViewerWindowController: TCPViewerToolbarDataSourceDelegate {
     }
 
     func tcpviewerToolbarDataSourceDidRequestClearAllPackets(_ dataSource: TCPViewerToolbarDataSource) {
-        rootViewController.clearAllPackets()
+        clearAllPackets(dataSource)
     }
 
     func tcpviewerToolbarDataSourceDidRequestExportSession(_ dataSource: TCPViewerToolbarDataSource) {
@@ -287,5 +291,17 @@ extension TCPViewerWindowController: PacketQuickFilterViewControllerDelegate {
 
     func packetQuickFilterViewControllerDidRequestReset(_ controller: PacketQuickFilterViewController) {
         rootViewController.resetQuickFilters()
+    }
+}
+
+extension TCPViewerWindowController: NSMenuItemValidation {
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard menuItem.action == #selector(clearAllPackets(_:)) else {
+            return true
+        }
+
+        // Keep the keyboard command disabled whenever the toolbar clear button is disabled.
+        let snapshot = rootViewController.viewModel.snapshot
+        return snapshot.totalPacketCount > 0 && !snapshot.base.loadState.canCancel
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/PacketInspectorByteCopyService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketInspectorByteCopyService.swift
@@ -184,7 +184,15 @@ struct PacketInspectorByteCopyService {
     }
 
     private static func mergedRanges(_ ranges: [PacketByteRange]) -> [PacketByteRange] {
-        ranges.reduce(into: []) { result, range in
+        // Child rows may be displayed in protocol order rather than byte-offset order, so sort before coalescing.
+        let sortedRanges = ranges.sorted { lhs, rhs in
+            if lhs.sourceID == rhs.sourceID {
+                return lhs.offset < rhs.offset
+            }
+            return lhs.sourceID < rhs.sourceID
+        }
+
+        return sortedRanges.reduce(into: []) { result, range in
             guard let previous = result.last,
                   previous.sourceID == range.sourceID,
                   range.offset <= previous.upperBound else {

--- a/TCPViewer/Features/NetworkInspector/Services/PacketInspectorByteCopyService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketInspectorByteCopyService.swift
@@ -1,0 +1,368 @@
+//
+//  PacketInspectorByteCopyService.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/7/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+
+enum PacketInspectorByteCopyFormat: String, CaseIterable, Sendable {
+    case hexASCIIDump
+    case hexDump
+    case utf8Text
+    case asciiText
+    case hexStream
+    case base64String
+    case mimeData
+    case cString
+    case goLiteral
+    case cArray
+
+    var menuTitle: String {
+        switch self {
+        case .hexASCIIDump:
+            return "Copy Bytes as Hex + ASCII Dump"
+        case .hexDump:
+            return "...as Hex Dump"
+        case .utf8Text:
+            return "...as UTF-8 Text"
+        case .asciiText:
+            return "...as ASCII Text"
+        case .hexStream:
+            return "...as a Hex Stream"
+        case .base64String:
+            return "...as a Base64 String"
+        case .mimeData:
+            return "...as MIME Data"
+        case .cString:
+            return "...as C String"
+        case .goLiteral:
+            return "...as Go literal"
+        case .cArray:
+            return "...as C Array"
+        }
+    }
+
+    var toolTip: String {
+        switch self {
+        case .hexASCIIDump:
+            return "Copy selected packet-detail bytes as offset, hex, and ASCII columns."
+        case .hexDump:
+            return "Copy selected packet-detail bytes as offset and hex columns."
+        case .utf8Text:
+            return "Copy selected packet-detail bytes decoded as UTF-8 text."
+        case .asciiText:
+            return "Copy selected packet-detail bytes as printable ASCII text."
+        case .hexStream:
+            return "Copy selected packet-detail bytes as unpunctuated hex."
+        case .base64String:
+            return "Copy selected packet-detail bytes as Base64."
+        case .mimeData:
+            return "Copy selected packet-detail bytes as MIME application/octet-stream data."
+        case .cString:
+            return "Copy selected packet-detail bytes as a C string literal."
+        case .goLiteral:
+            return "Copy selected packet-detail bytes as a Go string literal."
+        case .cArray:
+            return "Copy selected packet-detail bytes as a C byte array."
+        }
+    }
+}
+
+struct PacketInspectorByteCopySlice: Equatable {
+    let itemID: String
+    let sourceID: String
+    let offset: Int
+    let bytes: Data
+}
+
+struct PacketInspectorByteCopyService {
+    // Report availability separately so menus can disable byte formats without formatting data eagerly.
+    func canCopyBytes(from items: [PacketInspectorTreeItem], inspection: PacketInspection?) -> Bool {
+        !byteSlices(from: items, inspection: inspection).isEmpty
+    }
+
+    // Format the selected byte slices using Wireshark-inspired copy variants.
+    func copyText(
+        format: PacketInspectorByteCopyFormat,
+        inspection: PacketInspection?,
+        items: [PacketInspectorTreeItem]
+    ) -> String {
+        let slices = byteSlices(from: items, inspection: inspection)
+        guard !slices.isEmpty else {
+            return ""
+        }
+
+        switch format {
+        case .hexASCIIDump:
+            return joinedSections(slices) { Self.hexDump($0, includesASCII: true) }
+        case .hexDump:
+            return joinedSections(slices) { Self.hexDump($0, includesASCII: false) }
+        case .utf8Text:
+            return joinedLines(slices) { String(decoding: $0.bytes, as: UTF8.self) }
+        case .asciiText:
+            return joinedLines(slices) { Self.asciiText(from: $0.bytes) }
+        case .hexStream:
+            return joinedLines(slices) { Self.hexStream(from: $0.bytes) }
+        case .base64String:
+            return joinedLines(slices) { $0.bytes.base64EncodedString() }
+        case .mimeData:
+            return joinedSections(slices) { Self.mimeData(from: $0.bytes) }
+        case .cString:
+            return joinedSections(slices) { Self.cString(from: $0.bytes) }
+        case .goLiteral:
+            return joinedSections(slices) { Self.goLiteral(from: $0.bytes) }
+        case .cArray:
+            return cArrays(from: slices)
+        }
+    }
+
+    func byteSlices(from items: [PacketInspectorTreeItem], inspection: PacketInspection?) -> [PacketInspectorByteCopySlice] {
+        guard let inspection else {
+            return []
+        }
+
+        let byteViews = Self.byteViewMap(for: inspection)
+        return items.flatMap { item in
+            byteRanges(for: item).compactMap { range in
+                guard let bytes = Self.bytes(for: range, in: byteViews) else {
+                    return nil
+                }
+
+                return PacketInspectorByteCopySlice(
+                    itemID: item.id,
+                    sourceID: range.sourceID,
+                    offset: range.offset,
+                    bytes: bytes
+                )
+            }
+        }
+    }
+
+    private func byteRanges(for item: PacketInspectorTreeItem) -> [PacketByteRange] {
+        if let byteRange = item.byteRange {
+            return [byteRange]
+        }
+
+        return Self.mergedRanges(Self.descendantByteRanges(in: item))
+    }
+
+    private static func byteViewMap(for inspection: PacketInspection) -> [String: Data] {
+        var map: [String: Data] = ["frame": inspection.rawBytes]
+        for byteView in inspection.byteViews {
+            map[byteView.id] = byteView.bytes
+        }
+        return map
+    }
+
+    private static func bytes(for range: PacketByteRange, in byteViews: [String: Data]) -> Data? {
+        guard range.offset >= 0,
+              range.length > 0,
+              let sourceBytes = byteViews[range.sourceID],
+              range.offset < sourceBytes.count else {
+            return nil
+        }
+
+        let boundedLength = min(range.length, sourceBytes.count - range.offset)
+        guard boundedLength > 0 else {
+            return nil
+        }
+
+        return sourceBytes.subdata(in: range.offset..<(range.offset + boundedLength))
+    }
+
+    private static func descendantByteRanges(in item: PacketInspectorTreeItem) -> [PacketByteRange] {
+        item.children.flatMap { child -> [PacketByteRange] in
+            if let byteRange = child.byteRange {
+                return [byteRange]
+            }
+
+            return descendantByteRanges(in: child)
+        }
+    }
+
+    private static func mergedRanges(_ ranges: [PacketByteRange]) -> [PacketByteRange] {
+        ranges.reduce(into: []) { result, range in
+            guard let previous = result.last,
+                  previous.sourceID == range.sourceID,
+                  range.offset <= previous.upperBound else {
+                result.append(range)
+                return
+            }
+
+            let upperBound = max(previous.upperBound, range.upperBound)
+            result[result.count - 1] = PacketByteRange(
+                offset: previous.offset,
+                length: upperBound - previous.offset,
+                sourceID: previous.sourceID
+            )
+        }
+    }
+
+    private func joinedLines(
+        _ slices: [PacketInspectorByteCopySlice],
+        transform: (PacketInspectorByteCopySlice) -> String
+    ) -> String {
+        slices.map(transform).joined(separator: "\n")
+    }
+
+    private func joinedSections(
+        _ slices: [PacketInspectorByteCopySlice],
+        transform: (PacketInspectorByteCopySlice) -> String
+    ) -> String {
+        slices.map(transform).joined(separator: "\n\n")
+    }
+
+    private static func hexDump(_ slice: PacketInspectorByteCopySlice, includesASCII: Bool) -> String {
+        let bytes = Array(slice.bytes)
+        let rows = stride(from: 0, to: bytes.count, by: 16).map { rowStart in
+            let rowBytes = Array(bytes[rowStart..<min(rowStart + 16, bytes.count)])
+            let offset = String(format: "%04x", slice.offset + rowStart)
+            let hex = rowBytes
+                .map { String(format: "%02x", Int($0)) }
+                .joined(separator: " ")
+
+            guard includesASCII else {
+                return "\(offset)  \(hex)"
+            }
+
+            let paddedHex = hex.padding(toLength: 47, withPad: " ", startingAt: 0)
+            return "\(offset)  \(paddedHex)  \(asciiColumn(from: rowBytes))"
+        }
+
+        return rows.joined(separator: "\n")
+    }
+
+    private static func hexStream(from data: Data) -> String {
+        data.map { String(format: "%02x", Int($0)) }.joined()
+    }
+
+    private static func asciiText(from data: Data) -> String {
+        data.map { byte in
+            if byte == 0x09 || byte == 0x0a || byte == 0x0d {
+                return String(UnicodeScalar(Int(byte))!)
+            }
+            guard let scalar = printableASCIIScalar(for: byte) else {
+                return "."
+            }
+            return String(scalar)
+        }.joined()
+    }
+
+    private static func asciiColumn(from bytes: [UInt8]) -> String {
+        bytes.map { byte in
+            guard let scalar = printableASCIIScalar(for: byte) else {
+                return "."
+            }
+            return String(scalar)
+        }.joined()
+    }
+
+    private static func printableASCIIScalar(for byte: UInt8) -> UnicodeScalar? {
+        guard byte >= 0x20, byte <= 0x7e else {
+            return nil
+        }
+        return UnicodeScalar(Int(byte))
+    }
+
+    private static func mimeData(from data: Data) -> String {
+        [
+            "Content-Type: application/octet-stream",
+            "Content-Transfer-Encoding: base64",
+            "",
+            wrappedBase64(data.base64EncodedString()),
+        ].joined(separator: "\n")
+    }
+
+    private static func wrappedBase64(_ value: String) -> String {
+        stride(from: 0, to: value.count, by: 76).map { start in
+            let lower = value.index(value.startIndex, offsetBy: start)
+            let upper = value.index(lower, offsetBy: min(76, value.distance(from: lower, to: value.endIndex)))
+            return String(value[lower..<upper])
+        }.joined(separator: "\n")
+    }
+
+    private static func cString(from data: Data) -> String {
+        var output = "\""
+        var previousWasHexEscape = false
+
+        for byte in data {
+            if let escaped = commonStringEscape(for: byte) {
+                output += escaped
+                previousWasHexEscape = false
+            } else if let scalar = printableASCIIScalar(for: byte), byte != 0x22, byte != 0x5c {
+                if previousWasHexEscape && isHexDigit(byte) {
+                    output += "\" \""
+                }
+                output += String(scalar)
+                previousWasHexEscape = false
+            } else {
+                output += "\\x\(String(format: "%02x", Int(byte)))"
+                previousWasHexEscape = true
+            }
+        }
+
+        return output + "\""
+    }
+
+    private static func goLiteral(from data: Data) -> String {
+        var output = "\""
+        for byte in data {
+            if let escaped = commonStringEscape(for: byte) {
+                output += escaped
+            } else if let scalar = printableASCIIScalar(for: byte), byte != 0x22, byte != 0x5c {
+                output += String(scalar)
+            } else {
+                output += "\\x\(String(format: "%02x", Int(byte)))"
+            }
+        }
+        return output + "\""
+    }
+
+    private static func commonStringEscape(for byte: UInt8) -> String? {
+        switch byte {
+        case 0x09:
+            return "\\t"
+        case 0x0a:
+            return "\\n"
+        case 0x0d:
+            return "\\r"
+        case 0x22:
+            return "\\\""
+        case 0x5c:
+            return "\\\\"
+        default:
+            return nil
+        }
+    }
+
+    private static func isHexDigit(_ byte: UInt8) -> Bool {
+        (byte >= 0x30 && byte <= 0x39) ||
+            (byte >= 0x41 && byte <= 0x46) ||
+            (byte >= 0x61 && byte <= 0x66)
+    }
+
+    private func cArrays(from slices: [PacketInspectorByteCopySlice]) -> String {
+        let multipleSlices = slices.count > 1
+        return slices.enumerated().map { index, slice in
+            let name = multipleSlices ? "packet_bytes_\(index + 1)" : "packet_bytes"
+            return Self.cArray(from: slice.bytes, name: name)
+        }.joined(separator: "\n\n")
+    }
+
+    private static func cArray(from data: Data, name: String) -> String {
+        let bytes = Array(data)
+        guard !bytes.isEmpty else {
+            return "unsigned char \(name)[] = {};"
+        }
+
+        let rows = stride(from: 0, to: bytes.count, by: 12).map { rowStart in
+            let rowBytes = Array(bytes[rowStart..<min(rowStart + 12, bytes.count)])
+            return "    " + rowBytes.map { String(format: "0x%02x", Int($0)) }.joined(separator: ", ")
+        }
+
+        return "unsigned char \(name)[] = {\n\(rows.joined(separator: ",\n"))\n};"
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -223,7 +223,7 @@ enum PacketSourceListCopyPolicy {
             return nil
         }
 
-        // Limit copying to real app/domain rows so placeholder IP buckets are not mislabeled.
+        // Limit copying to concrete app/domain/IP rows so group placeholders are not mislabeled.
         switch selection {
         case .app, .fileApp:
             return PacketSourceListCopyAction(menuTitle: "Copy App Name", value: value)
@@ -231,6 +231,8 @@ enum PacketSourceListCopyPolicy {
             return PacketSourceListCopyAction(menuTitle: "Copy App Name", value: value)
         case .pinnedItem(let pinID) where pinID.rawValue.hasPrefix("domain:"):
             return PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: value)
+        case .pinnedItem(let pinID) where pinID.rawValue.hasPrefix("ip:"):
+            return PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: value)
         case .appDomain(_, let key),
                 .domain(let key),
                 .fileAppDomain(_, _, let key),
@@ -240,6 +242,12 @@ enum PacketSourceListCopyPolicy {
                 return nil
             }
             return PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: value)
+        case .appIPAddress,
+                .fileAppIPAddress,
+                .fileIPAddress,
+                .pinnedItemIPAddress,
+                .ipAddress:
+            return PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: value)
         default:
             return nil
         }

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -210,6 +210,43 @@ enum PacketSourceListDeletionAction: Equatable, Sendable {
     }
 }
 
+struct PacketSourceListCopyAction: Equatable, Sendable {
+    let menuTitle: String
+    let value: String
+}
+
+enum PacketSourceListCopyPolicy {
+    static func action(for item: PacketSourceListItem?) -> PacketSourceListCopyAction? {
+        guard let item,
+              let value = trimmed(item.title),
+              let selection = item.selection else {
+            return nil
+        }
+
+        // Limit copying to real app/domain rows so placeholder IP buckets are not mislabeled.
+        switch selection {
+        case .app, .fileApp:
+            return PacketSourceListCopyAction(menuTitle: "Copy App Name", value: value)
+        case .appDomain(_, let key),
+                .domain(let key),
+                .fileAppDomain(_, _, let key),
+                .fileDomain(_, let key),
+                .pinnedItemDomain(_, let key):
+            guard !key.isMissingDomain else {
+                return nil
+            }
+            return PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: value)
+        default:
+            return nil
+        }
+    }
+
+    private static func trimmed(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
 enum PacketSourceListExportPolicy {
     static func selection(for item: PacketSourceListItem?) -> PacketSourceListSelection? {
         guard let item,

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -227,6 +227,10 @@ enum PacketSourceListCopyPolicy {
         switch selection {
         case .app, .fileApp:
             return PacketSourceListCopyAction(menuTitle: "Copy App Name", value: value)
+        case .pinnedItem(let pinID) where pinID.rawValue.hasPrefix("client:"):
+            return PacketSourceListCopyAction(menuTitle: "Copy App Name", value: value)
+        case .pinnedItem(let pinID) where pinID.rawValue.hasPrefix("domain:"):
+            return PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: value)
         case .appDomain(_, let key),
                 .domain(let key),
                 .fileAppDomain(_, _, let key),

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -216,6 +216,17 @@ final class PacketInspectorTreeViewModel {
         return copyRowsForSelection(from: unfilteredRootItems, level: 0, selectedIDs: selectedIDs, copiedItemIDs: &copiedItemIDs)
     }
 
+    // Return selected packet-detail subtrees once, in source order, for byte-oriented copy formats.
+    func copyItems(forSelectionIDs selectionIDs: [String]) -> [PacketInspectorTreeItem] {
+        let selectedIDs = Set(selectionIDs)
+        guard !selectedIDs.isEmpty else {
+            return []
+        }
+
+        var copiedItemIDs: Set<String> = []
+        return copyItemsForSelection(from: unfilteredRootItems, selectedIDs: selectedIDs, copiedItemIDs: &copiedItemIDs)
+    }
+
     private func makeRootItems(from inspectionState: PacketInspectionState) -> [PacketInspectorTreeItem] {
         if inspectionState.isLoading, inspectionState.currentInspection == nil {
             return [messageItem(id: "loading", message: inspectionState.statusMessage)]
@@ -361,6 +372,42 @@ final class PacketInspectorTreeViewModel {
         }
 
         return rows
+    }
+
+    // Walk all roots so multi-selection order follows the original packet-detail tree.
+    private func copyItemsForSelection(
+        from items: [PacketInspectorTreeItem],
+        selectedIDs: Set<String>,
+        copiedItemIDs: inout Set<String>
+    ) -> [PacketInspectorTreeItem] {
+        var copiedItems: [PacketInspectorTreeItem] = []
+        for item in items {
+            if let selectionID = item.selectionID, selectedIDs.contains(selectionID) {
+                if copiedItemIDs.insert(item.id).inserted {
+                    collectItemIDs(from: item, into: &copiedItemIDs)
+                    copiedItems.append(item)
+                }
+            } else {
+                copiedItems.append(contentsOf: copyItemsForSelection(
+                    from: item.children,
+                    selectedIDs: selectedIDs,
+                    copiedItemIDs: &copiedItemIDs
+                ))
+            }
+        }
+
+        return copiedItems
+    }
+
+    // Mark descendants so selecting a parent and child does not copy duplicate bytes or row text.
+    private func collectItemIDs(
+        from item: PacketInspectorTreeItem,
+        into copiedItemIDs: inout Set<String>
+    ) {
+        for child in item.children {
+            copiedItemIDs.insert(child.id)
+            collectItemIDs(from: child, into: &copiedItemIDs)
+        }
     }
 
     private func validSelectedNodeID(from inspectionState: PacketInspectionState) -> String? {
@@ -627,6 +674,7 @@ final class PacketInspectorViewController: NSViewController {
 
     private let configuration: AppConfiguration
     private let viewModel = PacketInspectorTreeViewModel()
+    private let byteCopyService = PacketInspectorByteCopyService()
     private let expansionState = PacketInspectorOutlineExpansionState()
     private let hexViewController: PacketHexViewController
     private let detailSplitViewController = NSSplitViewController()
@@ -1101,6 +1149,10 @@ final class PacketInspectorViewController: NSViewController {
         }
     }
 
+    private func selectedCopyItems() -> [PacketInspectorTreeItem] {
+        viewModel.copyItems(forSelectionIDs: selectedCopySelectionIDs())
+    }
+
     // Write inspector copy rows to the system pasteboard as plain text.
     private func copyRowsToPasteboard(_ rows: [PacketInspectorCopyRow]) {
         let text = PacketInspectorCopyFormatter.text(for: rows)
@@ -1120,12 +1172,105 @@ final class PacketInspectorViewController: NSViewController {
         copyRowsToPasteboard(viewModel.copyRowsForAllDetails())
     }
 
+    // Copy bytes from selected packet-detail nodes using their packet byte ranges.
+    private func copySelectedBytesToPasteboard(format: PacketInspectorByteCopyFormat) {
+        let text = byteCopyService.copyText(
+            format: format,
+            inspection: latestInspectionState?.currentInspection,
+            items: selectedCopyItems()
+        )
+        guard !text.isEmpty else {
+            return
+        }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    private func hasSelectedBytes() -> Bool {
+        byteCopyService.canCopyBytes(
+            from: selectedCopyItems(),
+            inspection: latestInspectionState?.currentInspection
+        )
+    }
+
+    // Report whether the visible detail tree has rows that can expand or collapse.
+    private func hasExpandableInspectorRows() -> Bool {
+        viewModel.rootItems.contains(where: hasExpandableInspectorRows(in:))
+    }
+
+    private func hasExpandableInspectorRows(in item: PacketInspectorTreeItem) -> Bool {
+        !item.children.isEmpty || item.children.contains(where: hasExpandableInspectorRows(in:))
+    }
+
+    // Expand every visible detail node and persist that choice for matching packet-detail IDs.
+    private func expandAllInspectorRows() {
+        isApplyingExpansionState = true
+        defer { isApplyingExpansionState = false }
+
+        for item in viewModel.rootItems {
+            expandAllInspectorRows(in: item)
+        }
+    }
+
+    private func expandAllInspectorRows(in item: PacketInspectorTreeItem) {
+        guard !item.children.isEmpty else {
+            return
+        }
+
+        expansionState.recordExpanded(item: item)
+        outlineView.expandItem(item)
+        for child in item.children {
+            expandAllInspectorRows(in: child)
+        }
+    }
+
+    // Collapse every visible detail node while recording children so future reloads stay collapsed.
+    private func collapseAllInspectorRows() {
+        isApplyingExpansionState = true
+        defer { isApplyingExpansionState = false }
+
+        for item in viewModel.rootItems {
+            collapseAllInspectorRows(in: item)
+        }
+    }
+
+    private func collapseAllInspectorRows(in item: PacketInspectorTreeItem) {
+        guard !item.children.isEmpty else {
+            return
+        }
+
+        for child in item.children {
+            collapseAllInspectorRows(in: child)
+        }
+        expansionState.recordCollapsed(item: item)
+        outlineView.collapseItem(item)
+    }
+
     @objc private func copySelectedRowsFromMenu(_ sender: Any?) {
         copySelectedRowsToPasteboard()
     }
 
     @objc private func copyAllRowsFromMenu(_ sender: Any?) {
         copyAllRowsToPasteboard()
+    }
+
+    @objc private func copySelectedBytesFromMenu(_ sender: Any?) {
+        guard let menuItem = sender as? NSMenuItem,
+              let rawValue = menuItem.representedObject as? String,
+              let format = PacketInspectorByteCopyFormat(rawValue: rawValue) else {
+            return
+        }
+
+        copySelectedBytesToPasteboard(format: format)
+    }
+
+    @objc private func expandAllRowsFromMenu(_ sender: Any?) {
+        expandAllInspectorRows()
+    }
+
+    @objc private func collapseAllRowsFromMenu(_ sender: Any?) {
+        collapseAllInspectorRows()
     }
 
     @objc private func showFilterFromMenu(_ sender: Any?) {
@@ -1316,27 +1461,32 @@ extension PacketInspectorViewController: NSMenuDelegate {
 
         menu.removeAllItems()
         let hasSelectedRows = !selectedCopySelectionIDs().isEmpty
-        let copyItem = NSMenuItem(
-            title: "Copy",
-            action: #selector(copySelectedRowsFromMenu(_:)),
-            keyEquivalent: "c"
-        )
-        copyItem.target = self
-        copyItem.isEnabled = hasSelectedRows
-        copyItem.toolTip = "Copy the selected inspector rows."
-        copyItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy")
-        menu.addItem(copyItem)
+        let hasSelectedByteRanges = hasSelectedBytes()
+        let hasExpandableRows = hasExpandableInspectorRows()
+        menu.addItem(copySubmenuItem(hasSelectedRows: hasSelectedRows, hasSelectedByteRanges: hasSelectedByteRanges))
+        menu.addItem(.separator())
 
-        let copyAllItem = NSMenuItem(
-            title: "Copy All",
-            action: #selector(copyAllRowsFromMenu(_:)),
+        let expandAllItem = NSMenuItem(
+            title: "Expand All",
+            action: #selector(expandAllRowsFromMenu(_:)),
             keyEquivalent: ""
         )
-        copyAllItem.target = self
-        copyAllItem.isEnabled = viewModel.hasCopyableDetails()
-        copyAllItem.toolTip = "Copy all packet detail rows."
-        copyAllItem.image = NSImage(systemSymbolName: "doc.on.doc.fill", accessibilityDescription: "Copy All")
-        menu.addItem(copyAllItem)
+        expandAllItem.target = self
+        expandAllItem.isEnabled = hasExpandableRows
+        expandAllItem.toolTip = "Expand all packet detail rows."
+        expandAllItem.image = NSImage(systemSymbolName: "arrow.down.right.and.arrow.up.left", accessibilityDescription: "Expand All")
+        menu.addItem(expandAllItem)
+
+        let collapseAllItem = NSMenuItem(
+            title: "Collapse All",
+            action: #selector(collapseAllRowsFromMenu(_:)),
+            keyEquivalent: ""
+        )
+        collapseAllItem.target = self
+        collapseAllItem.isEnabled = hasExpandableRows
+        collapseAllItem.toolTip = "Collapse all packet detail rows."
+        collapseAllItem.image = NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Collapse All")
+        menu.addItem(collapseAllItem)
         menu.addItem(.separator())
 
         let filterItem = NSMenuItem(
@@ -1349,5 +1499,53 @@ extension PacketInspectorViewController: NSMenuDelegate {
         filterItem.toolTip = "Focus the inspector filter."
         filterItem.image = NSImage(systemSymbolName: "line.3.horizontal.decrease.circle", accessibilityDescription: "Filter")
         menu.addItem(filterItem)
+    }
+
+    private func copySubmenuItem(hasSelectedRows: Bool, hasSelectedByteRanges: Bool) -> NSMenuItem {
+        let menuItem = NSMenuItem(title: "Copy", action: nil, keyEquivalent: "")
+        let submenu = NSMenu(title: "Copy")
+        submenu.autoenablesItems = false
+
+        let selectedTreeItem = NSMenuItem(
+            title: "Selected Tree Items",
+            action: #selector(copySelectedRowsFromMenu(_:)),
+            keyEquivalent: "c"
+        )
+        selectedTreeItem.target = self
+        selectedTreeItem.isEnabled = hasSelectedRows
+        selectedTreeItem.toolTip = "Copy the selected inspector rows."
+        selectedTreeItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Selected Tree Items")
+        submenu.addItem(selectedTreeItem)
+
+        let allTreeItem = NSMenuItem(
+            title: "All Tree Items",
+            action: #selector(copyAllRowsFromMenu(_:)),
+            keyEquivalent: ""
+        )
+        allTreeItem.target = self
+        allTreeItem.isEnabled = viewModel.hasCopyableDetails()
+        allTreeItem.toolTip = "Copy all packet detail rows."
+        allTreeItem.image = NSImage(systemSymbolName: "doc.on.doc.fill", accessibilityDescription: "All Tree Items")
+        submenu.addItem(allTreeItem)
+        submenu.addItem(.separator())
+
+        for format in PacketInspectorByteCopyFormat.allCases {
+            let item = NSMenuItem(
+                title: format.menuTitle,
+                action: #selector(copySelectedBytesFromMenu(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = format.rawValue
+            item.isEnabled = hasSelectedByteRanges
+            item.toolTip = format.toolTip
+            submenu.addItem(item)
+        }
+
+        menuItem.submenu = submenu
+        menuItem.isEnabled = hasSelectedRows || viewModel.hasCopyableDetails()
+        menuItem.toolTip = "Choose how to copy packet detail rows or bytes."
+        menuItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy")
+        return menuItem
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -664,6 +664,10 @@ final class SidebarViewController: NSViewController {
         PacketSourceListFinderPolicy.fileURL(for: contextSourceItem() ?? selectedSourceItem())
     }
 
+    private func selectedCopyAction() -> PacketSourceListCopyAction? {
+        PacketSourceListCopyPolicy.action(for: contextSourceItem() ?? selectedSourceItem())
+    }
+
     private func selectedPinTargets() -> [PacketSourceListPinTarget] {
         PacketSourceListPinPolicy.targets(for: selectedSourceItems())
     }
@@ -725,6 +729,16 @@ final class SidebarViewController: NSViewController {
         }
 
         NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    @objc private func copySelectedSourceListItemName(_ sender: Any?) {
+        guard let copyAction = selectedCopyAction() else {
+            return
+        }
+
+        // Resolve at click time so right-click context rows copy the intended node.
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(copyAction.value, forType: .string)
     }
 
     @objc private func exportSelectedSourceListItemAsPcap(_ sender: Any?) {
@@ -894,17 +908,31 @@ extension SidebarViewController: NSSearchFieldDelegate {
 extension SidebarViewController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         updateSelectionFromCurrentMenuEvent()
+        let copyAction = selectedCopyAction()
         let pinTargets = selectedPinTargets()
         let action = selectedDeletionAction()
         let exportSelection = selectedExportSelection()
         let finderURL = selectedFinderURL()
 
         menu.removeAllItems()
-        guard !pinTargets.isEmpty || action.isEnabled || exportSelection != nil || finderURL != nil else {
+        guard copyAction != nil || !pinTargets.isEmpty || action.isEnabled || exportSelection != nil || finderURL != nil else {
             return
         }
 
+        if let copyAction {
+            let copyItem = NSMenuItem(title: copyAction.menuTitle, action: #selector(copySelectedSourceListItemName(_:)), keyEquivalent: "")
+            copyItem.target = self
+            copyItem.isEnabled = true
+            copyItem.toolTip = "Copy the selected source-list name."
+            copyItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: copyAction.menuTitle)
+            menu.addItem(copyItem)
+        }
+
         if !pinTargets.isEmpty {
+            if copyAction != nil {
+                menu.addItem(.separator())
+            }
+
             let pinItem = NSMenuItem(title: "Pin", action: #selector(pinSelectedSourceListItems(_:)), keyEquivalent: "")
             pinItem.target = self
             pinItem.isEnabled = true
@@ -913,7 +941,7 @@ extension SidebarViewController: NSMenuDelegate {
         }
 
         if exportSelection != nil {
-            if !pinTargets.isEmpty {
+            if copyAction != nil || !pinTargets.isEmpty {
                 menu.addItem(.separator())
             }
 
@@ -933,7 +961,7 @@ extension SidebarViewController: NSMenuDelegate {
         }
 
         if finderURL != nil {
-            if !pinTargets.isEmpty || exportSelection != nil {
+            if copyAction != nil || !pinTargets.isEmpty || exportSelection != nil {
                 menu.addItem(.separator())
             }
 
@@ -946,7 +974,7 @@ extension SidebarViewController: NSMenuDelegate {
         }
 
         if action.isEnabled {
-            if !pinTargets.isEmpty || exportSelection != nil || finderURL != nil {
+            if copyAction != nil || !pinTargets.isEmpty || exportSelection != nil || finderURL != nil {
                 menu.addItem(.separator())
             }
 

--- a/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
@@ -42,7 +42,7 @@ final class StatusStripViewController: NSViewController {
     private let viewModel = StatusStripViewModel()
     private let cancelButton = NSButton(title: "Cancel Load", target: nil, action: nil)
     private let clearButton = NSButton(title: "Clear", target: nil, action: nil)
-    private let filterButton = NSButton(title: "Filter", target: nil, action: nil)
+    private let filterButton = NSButton(title: "Filter ⌘F", target: nil, action: nil)
     private let totalLabel = TCPViewerUI.label(
         "",
         font: .monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
@@ -99,7 +99,7 @@ final class StatusStripViewController: NSViewController {
         filterButton.controlSize = .small
         filterButton.image = TCPViewerUI.image("line.3.horizontal.decrease.circle")
         filterButton.imagePosition = .imageLeading
-        filterButton.toolTip = "Show or hide packet filters"
+        filterButton.toolTip = "Show or hide packet filters (⌘F)"
 
         totalLabel.alignment = .center
         totalLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -105,6 +105,18 @@ struct WindowControllerTests {
         #expect(otherMenu.items.first { $0.representedObject as? String == "awdl0" }?.isEnabled == false)
     }
 
+    @Test func clearAllToolbarButtonTooltipShowsShortcut() throws {
+        let dataSource = TCPViewerToolbarDataSource()
+
+        let item = try #require(dataSource.toolbar(
+            dataSource.toolbar,
+            itemForItemIdentifier: NSToolbarItem.Identifier("TCPViewer.ClearAll"),
+            willBeInsertedIntoToolbar: true
+        ))
+        let button = try #require(item.view as? NSButton)
+        #expect(button.toolTip == "Clear All Packets (⌘K)")
+    }
+
     @Test func interfacePopupWidthIncludesSelectedIcon() {
         let interfaces = [makeInterface(id: "en0", displayName: "Wi-Fi (en0)")]
         let plainPopup = NSPopUpButton(frame: .zero, pullsDown: false)

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -633,6 +633,18 @@ struct NetworkInspectorViewModelTests {
         #expect(!labels.contains("Stopped"))
     }
 
+    @Test func statusStripFilterButtonShowsShortcut() throws {
+        let controller = StatusStripViewController()
+
+        controller.loadViewIfNeeded()
+
+        let filterButton = try #require(allSubviews(ofType: NSButton.self, in: controller.view).first { button in
+            button.title.contains("Filter")
+        })
+        #expect(filterButton.title == "Filter ⌘F")
+        #expect(filterButton.toolTip == "Show or hide packet filters (⌘F)")
+    }
+
     @Test func statusStripRendersProcessAndCapturedTrafficMetrics() {
         let viewModel = StatusStripViewModel()
         let metrics = TCPViewerStatusMetricsSnapshot(

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorByteCopyServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorByteCopyServiceTests.swift
@@ -77,6 +77,21 @@ struct PacketInspectorByteCopyServiceTests {
         #expect(service.copyText(format: .hexStream, inspection: inspection, items: [tcpItem]) == "12345678")
     }
 
+    @Test func parentWithoutByteRangeMergesChildrenInByteOffsetOrder() {
+        let inspection = makeInspection(rawBytes: Data([0xaa, 0xbb, 0xcc, 0xdd]))
+        let optionsItem = makeItem(
+            id: "tcp.options",
+            name: "Options",
+            kind: .field,
+            children: [
+                makeItem(id: "tcp.options.late", name: "Late Option", byteRange: PacketByteRange(offset: 2, length: 2)),
+                makeItem(id: "tcp.options.early", name: "Early Option", byteRange: PacketByteRange(offset: 0, length: 2)),
+            ]
+        )
+
+        #expect(service.copyText(format: .hexStream, inspection: inspection, items: [optionsItem]) == "aabbccdd")
+    }
+
     @Test func invalidRangesAreIgnoredAndValidRangesAreClipped() {
         let inspection = makeInspection(rawBytes: Data([0x01, 0x02, 0x03, 0x04]))
         let clippedItem = makeItem(id: "valid", name: "Valid", byteRange: PacketByteRange(offset: 2, length: 20))

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorByteCopyServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorByteCopyServiceTests.swift
@@ -1,0 +1,147 @@
+//
+//  PacketInspectorByteCopyServiceTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/7/26.
+//
+
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+struct PacketInspectorByteCopyServiceTests {
+    private let service = PacketInspectorByteCopyService()
+
+    @Test func hexDumpFormatsUseSelectedProtocolByteRange() {
+        let bytes = Data((0x30...0x3f).map(UInt8.init))
+        let inspection = makeInspection(rawBytes: bytes)
+        let ipv4Item = makeItem(
+            id: "ipv4",
+            name: "IPv4",
+            kind: .layer,
+            byteRange: PacketByteRange(offset: 0, length: bytes.count)
+        )
+
+        let hexASCII = service.copyText(format: .hexASCIIDump, inspection: inspection, items: [ipv4Item])
+        let hexOnly = service.copyText(format: .hexDump, inspection: inspection, items: [ipv4Item])
+
+        #expect(hexASCII == "0000  30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?")
+        #expect(hexOnly == "0000  30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f")
+    }
+
+    @Test func textFormatsDecodeUTF8AndPreservePrintableASCII() {
+        let bytes = Data("Hello, café\n".utf8)
+        let inspection = makeInspection(rawBytes: bytes)
+        let payloadItem = makeItem(
+            id: "tcp.payload",
+            name: "TCP Payload",
+            byteRange: PacketByteRange(offset: 0, length: bytes.count)
+        )
+
+        #expect(service.copyText(format: .utf8Text, inspection: inspection, items: [payloadItem]) == "Hello, café\n")
+        #expect(service.copyText(format: .asciiText, inspection: inspection, items: [payloadItem]) == "Hello, caf..\n")
+    }
+
+    @Test func multipleSelectionsStaySeparatedAndUseAlternateByteViews() {
+        let inspection = makeInspection(
+            rawBytes: Data([0x01, 0x02, 0x03, 0x04]),
+            byteViews: [
+                PacketByteView(id: "frame", label: "Frame", bytes: Data([0x01, 0x02, 0x03, 0x04])),
+                PacketByteView(id: "reassembled-tcp", label: "Reassembled TCP", bytes: Data([0xaa, 0xbb, 0xcc, 0xdd])),
+            ]
+        )
+        let frameItem = makeItem(id: "frame.bytes", name: "Frame Bytes", byteRange: PacketByteRange(offset: 0, length: 2))
+        let tcpItem = makeItem(
+            id: "tcp.reassembled",
+            name: "Reassembled TCP",
+            byteRange: PacketByteRange(offset: 1, length: 2, sourceID: "reassembled-tcp")
+        )
+
+        #expect(service.copyText(format: .hexStream, inspection: inspection, items: [frameItem, tcpItem]) == "0102\nbbcc")
+        #expect(service.copyText(format: .base64String, inspection: inspection, items: [frameItem, tcpItem]) == "AQI=\nu8w=")
+    }
+
+    @Test func parentWithoutByteRangeCopiesMergedChildRanges() {
+        let inspection = makeInspection(rawBytes: Data([0x00, 0x01, 0x12, 0x34, 0x56, 0x78]))
+        let tcpItem = makeItem(
+            id: "tcp",
+            name: "TCP",
+            kind: .layer,
+            children: [
+                makeItem(id: "tcp.srcport", name: "Source Port", byteRange: PacketByteRange(offset: 2, length: 2)),
+                makeItem(id: "tcp.dstport", name: "Destination Port", byteRange: PacketByteRange(offset: 4, length: 2)),
+            ]
+        )
+
+        #expect(service.copyText(format: .hexStream, inspection: inspection, items: [tcpItem]) == "12345678")
+    }
+
+    @Test func invalidRangesAreIgnoredAndValidRangesAreClipped() {
+        let inspection = makeInspection(rawBytes: Data([0x01, 0x02, 0x03, 0x04]))
+        let clippedItem = makeItem(id: "valid", name: "Valid", byteRange: PacketByteRange(offset: 2, length: 20))
+        let outOfBoundsItem = makeItem(id: "out", name: "Out", byteRange: PacketByteRange(offset: 4, length: 1))
+        let missingSourceItem = makeItem(
+            id: "missing",
+            name: "Missing Source",
+            byteRange: PacketByteRange(offset: 0, length: 1, sourceID: "missing")
+        )
+        let negativeItem = makeItem(id: "negative", name: "Negative", byteRange: PacketByteRange(offset: -1, length: 1))
+
+        #expect(service.copyText(format: .hexStream, inspection: inspection, items: [clippedItem]) == "0304")
+        #expect(service.copyText(format: .hexStream, inspection: inspection, items: [outOfBoundsItem, missingSourceItem, negativeItem]).isEmpty)
+        #expect(!service.canCopyBytes(from: [outOfBoundsItem, missingSourceItem, negativeItem], inspection: inspection))
+        #expect(!service.canCopyBytes(from: [clippedItem], inspection: nil))
+    }
+
+    @Test func languageAndMIMEFormatsEscapeBinaryBytesSafely() {
+        let bytes = Data([0x48, 0x65, 0x00, 0x30, 0x0f, 0x41, 0x22, 0x5c, 0x0a])
+        let inspection = makeInspection(rawBytes: bytes)
+        let item = makeItem(id: "payload", name: "Payload", byteRange: PacketByteRange(offset: 0, length: bytes.count))
+
+        #expect(service.copyText(format: .cString, inspection: inspection, items: [item]) == "\"He\\x00\" \"0\\x0f\" \"A\\\"\\\\\\n\"")
+        #expect(service.copyText(format: .goLiteral, inspection: inspection, items: [item]) == "\"He\\x000\\x0fA\\\"\\\\\\n\"")
+        #expect(service.copyText(format: .cArray, inspection: inspection, items: [item]) == """
+        unsigned char packet_bytes[] = {
+            0x48, 0x65, 0x00, 0x30, 0x0f, 0x41, 0x22, 0x5c, 0x0a
+        };
+        """)
+        #expect(service.copyText(format: .mimeData, inspection: inspection, items: [item]) == """
+        Content-Type: application/octet-stream
+        Content-Transfer-Encoding: base64
+
+        SGUAMA9BIlwK
+        """)
+    }
+
+    private func makeInspection(
+        rawBytes: Data,
+        byteViews: [PacketByteView]? = nil
+    ) -> PacketInspection {
+        PacketInspection(
+            packetID: 1,
+            packetNumber: 1,
+            rawBytes: rawBytes,
+            byteViews: byteViews,
+            detailNodes: [],
+            decodeStatus: PacketDecodeStatus(kind: .complete)
+        )
+    }
+
+    private func makeItem(
+        id: String,
+        name: String,
+        kind: PacketInspectorTreeItemKind = .field,
+        byteRange: PacketByteRange? = nil,
+        children: [PacketInspectorTreeItem] = []
+    ) -> PacketInspectorTreeItem {
+        PacketInspectorTreeItem(
+            id: id,
+            nodeID: id,
+            name: name,
+            kind: kind,
+            byteRange: byteRange,
+            children: children
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
@@ -169,13 +169,13 @@ struct PacketInspectorTreeViewModelTests {
     }
 
     @MainActor
-    @Test func inspectorContextMenuIncludesFilterCommandForRows() throws {
+    @Test func inspectorContextMenuIncludesCopySubmenuExpandAndCollapseCommands() throws {
         let packet = makePacket()
         let controller = PacketInspectorViewController(configuration: AppConfiguration(defaults: isolatedDefaults()))
         controller.loadViewIfNeeded()
         controller.render(snapshot: makeSnapshot(
             packet: packet,
-            inspectionState: loadedInspectionState(packet: packet, inspection: makeFrameInspection(for: packet))
+            inspectionState: loadedInspectionState(packet: packet, inspection: makeNestedInspection(for: packet))
         ))
 
         let outlineView = try #require(firstSubview(ofType: NSOutlineView.self, in: controller.view))
@@ -184,20 +184,81 @@ struct PacketInspectorTreeViewModelTests {
 
         controller.menuNeedsUpdate(menu)
 
-        #expect(menu.items.count == 4)
+        #expect(menu.items.count == 6)
         let copyItem = menu.items[0]
-        let copyAllItem = menu.items[1]
-        let separatorItem = menu.items[2]
-        let filterItem = menu.items[3]
+        let separatorItem = menu.items[1]
+        let expandAllItem = menu.items[2]
+        let collapseAllItem = menu.items[3]
+        let secondSeparatorItem = menu.items[4]
+        let filterItem = menu.items[5]
+        let copySubmenu = try #require(copyItem.submenu)
+        let copySubmenuTitles = copySubmenu.items.map(\.title)
 
         #expect(copyItem.title == "Copy")
         #expect(copyItem.isEnabled)
-        #expect(copyAllItem.title == "Copy All")
-        #expect(copyAllItem.isEnabled)
+        #expect(copySubmenuTitles == [
+            "Selected Tree Items",
+            "All Tree Items",
+            "",
+            "Copy Bytes as Hex + ASCII Dump",
+            "...as Hex Dump",
+            "...as UTF-8 Text",
+            "...as ASCII Text",
+            "...as a Hex Stream",
+            "...as a Base64 String",
+            "...as MIME Data",
+            "...as C String",
+            "...as Go literal",
+            "...as C Array",
+        ])
+        #expect(copySubmenu.items[0].isEnabled)
+        #expect(copySubmenu.items[1].isEnabled)
+        #expect(copySubmenu.items[2].isSeparatorItem)
+        let byteCopyItemsEnabled = copySubmenu.items.dropFirst(3).allSatisfy { $0.isEnabled }
+        #expect(byteCopyItemsEnabled)
         #expect(separatorItem.isSeparatorItem)
+        #expect(expandAllItem.title == "Expand All")
+        #expect(expandAllItem.isEnabled)
+        #expect(collapseAllItem.title == "Collapse All")
+        #expect(collapseAllItem.isEnabled)
+        #expect(secondSeparatorItem.isSeparatorItem)
         #expect(filterItem.title == "Filter")
         #expect(filterItem.isEnabled)
         #expect(filterItem.keyEquivalent.isEmpty)
+    }
+
+    @MainActor
+    @Test func inspectorContextMenuExpandsAndCollapsesAllRows() throws {
+        let packet = makePacket()
+        let controller = PacketInspectorViewController(configuration: AppConfiguration(defaults: isolatedDefaults()))
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: makeSnapshot(
+            packet: packet,
+            inspectionState: loadedInspectionState(packet: packet, inspection: makeNestedInspection(for: packet))
+        ))
+
+        let outlineView = try #require(firstSubview(ofType: NSOutlineView.self, in: controller.view))
+        let menu = try #require(outlineView.menu)
+        controller.menuNeedsUpdate(menu)
+        let expandAllItem = try #require(menu.items.first { $0.title == "Expand All" })
+        let collapseAllItem = try #require(menu.items.first { $0.title == "Collapse All" })
+        let expandAction = try #require(expandAllItem.action)
+        let collapseAction = try #require(collapseAllItem.action)
+
+        #expect(outlineView.numberOfRows == 2)
+        #expect(NSApp.sendAction(expandAction, to: expandAllItem.target, from: expandAllItem))
+
+        let expandedRoot = try #require(outlineView.item(atRow: 0) as? PacketInspectorTreeItem)
+        let expandedChild = try #require(outlineView.item(atRow: 1) as? PacketInspectorTreeItem)
+        #expect(outlineView.numberOfRows == 3)
+        #expect(outlineView.isItemExpanded(expandedRoot))
+        #expect(outlineView.isItemExpanded(expandedChild))
+
+        #expect(NSApp.sendAction(collapseAction, to: collapseAllItem.target, from: collapseAllItem))
+
+        let collapsedRoot = try #require(outlineView.item(atRow: 0) as? PacketInspectorTreeItem)
+        #expect(outlineView.numberOfRows == 1)
+        #expect(!outlineView.isItemExpanded(collapsedRoot))
     }
 
     @MainActor
@@ -1010,12 +1071,19 @@ struct PacketInspectorTreeViewModelTests {
                     name: "Frame",
                     value: "Packet \(packet.packetNumber)",
                     kind: .layer,
+                    byteRange: PacketByteRange(offset: 0, length: 2),
                     children: [
                         PacketDetailNode(
                             id: "frame.flags",
                             name: "Flags",
+                            byteRange: PacketByteRange(offset: 0, length: 1),
                             children: [
-                                PacketDetailNode(id: "frame.flags.df", name: "Don't Fragment", value: "Set"),
+                                PacketDetailNode(
+                                    id: "frame.flags.df",
+                                    name: "Don't Fragment",
+                                    value: "Set",
+                                    byteRange: PacketByteRange(offset: 0, length: 1, bitOffset: 1, bitLength: 1, hasBitRange: true)
+                                ),
                             ]
                         ),
                     ]

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -305,22 +305,27 @@ struct PacketSourceListServiceTests {
     @Test func copyPolicyBuildsSingleAppOrDomainCopyAction() throws {
         let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
         let clientPin = makeClientPin(displayName: "Example", key: "bundleIdentifier:com.example.app")
+        let domainPin = makeDomainPin("api.example.com")
         var state = PacketIngestState.empty
         state.append([
             makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: client),
             makePacket(packetNumber: 2, sniDomainName: nil, client: client),
         ], source: .live)
 
-        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [clientPin])
+        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [clientPin, domainPin])
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
         let domainKey = PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false)
         let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
 
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .app(appKey))) ==
             PacketSourceListCopyAction(menuTitle: "Copy App Name", value: "Example"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItem(clientPin.id))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy App Name", value: "Example"))
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .appDomain(appKey, domainKey))) ==
             PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .domain(domainKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItem(domainPin.id))) ==
             PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItemDomain(clientPin.id, domainKey))) ==
             PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -302,6 +302,33 @@ struct PacketSourceListServiceTests {
         #expect(PacketSourceListFinderPolicy.fileURL(for: relativeAppItem) == nil)
     }
 
+    @Test func copyPolicyBuildsSingleAppOrDomainCopyAction() throws {
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let clientPin = makeClientPin(displayName: "Example", key: "bundleIdentifier:com.example.app")
+        var state = PacketIngestState.empty
+        state.append([
+            makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: client),
+            makePacket(packetNumber: 2, sniDomainName: nil, client: client),
+        ], source: .live)
+
+        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [clientPin])
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
+        let domainKey = PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false)
+        let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
+
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .app(appKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy App Name", value: "Example"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .appDomain(appKey, domainKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .domain(domainKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItemDomain(clientPin.id, domainKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .apps)) == nil)
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .domain(.ipAddresses))) == nil)
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .ipAddress(ipKey))) == nil)
+    }
+
     @Test func pinPolicyExtractsOnlyAppAndRealDomainTargets() throws {
         let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
         var state = PacketIngestState.empty

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -302,20 +302,24 @@ struct PacketSourceListServiceTests {
         #expect(PacketSourceListFinderPolicy.fileURL(for: relativeAppItem) == nil)
     }
 
-    @Test func copyPolicyBuildsSingleAppOrDomainCopyAction() throws {
+    @Test func copyPolicyBuildsSingleAppDomainOrIPAddressCopyAction() throws {
         let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
         let clientPin = makeClientPin(displayName: "Example", key: "bundleIdentifier:com.example.app")
         let domainPin = makeDomainPin("api.example.com")
+        let ipPin = makeIPPin("10.0.0.2")
         var state = PacketIngestState.empty
         state.append([
             makePacket(packetNumber: 1, sniDomainName: "api.example.com", client: client),
             makePacket(packetNumber: 2, sniDomainName: nil, client: client),
         ], source: .live)
 
-        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [clientPin, domainPin])
+        let snapshot = PacketSourceListService().snapshot(for: state, pinnedItems: [clientPin, domainPin, ipPin])
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.app")
         let domainKey = PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false)
         let ipKey = PacketSourceIPAddressKey(rawValue: "10.0.0.2")
+        let fileID = ImportedCaptureFileID(rawValue: "/captures/a.pcap")
+        let fileIPAddressItem = copyTestItem(title: "10.0.0.2", selection: .fileIPAddress(fileID, ipKey))
+        let fileAppIPAddressItem = copyTestItem(title: "10.0.0.2", selection: .fileAppIPAddress(fileID, appKey, ipKey))
 
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .app(appKey))) ==
             PacketSourceListCopyAction(menuTitle: "Copy App Name", value: "Example"))
@@ -329,9 +333,20 @@ struct PacketSourceListServiceTests {
             PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItemDomain(clientPin.id, domainKey))) ==
             PacketSourceListCopyAction(menuTitle: "Copy Domain Name", value: "api.example.com"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .appIPAddress(appKey, ipKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: "10.0.0.2"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItem(ipPin.id))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: "10.0.0.2"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .pinnedItemIPAddress(clientPin.id, ipKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: "10.0.0.2"))
+        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .ipAddress(ipKey))) ==
+            PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: "10.0.0.2"))
+        #expect(PacketSourceListCopyPolicy.action(for: fileIPAddressItem) ==
+            PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: "10.0.0.2"))
+        #expect(PacketSourceListCopyPolicy.action(for: fileAppIPAddressItem) ==
+            PacketSourceListCopyAction(menuTitle: "Copy IP Address", value: "10.0.0.2"))
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .apps)) == nil)
         #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .domain(.ipAddresses))) == nil)
-        #expect(PacketSourceListCopyPolicy.action(for: snapshot.item(for: .ipAddress(ipKey))) == nil)
     }
 
     @Test func pinPolicyExtractsOnlyAppAndRealDomainTargets() throws {
@@ -624,6 +639,19 @@ struct PacketSourceListServiceTests {
         try #require(snapshot.firstItem { $0.id == PacketSourceListTreeBuilder.filesGroupID })
     }
 
+    private func copyTestItem(title: String, selection: PacketSourceListSelection) -> PacketSourceListItem {
+        PacketSourceListItem(
+            id: "copy-test:\(title)",
+            title: title,
+            systemImageName: nil,
+            iconFilePath: nil,
+            count: 1,
+            kind: .domain,
+            selection: selection,
+            children: []
+        )
+    }
+
     private func makeDomainPin(_ domain: String) -> PacketPin {
         PacketPin(
             id: PacketPinID(rawValue: "domain:\(domain)"),
@@ -632,6 +660,20 @@ struct PacketSourceListServiceTests {
             createdAt: Date(timeIntervalSince1970: 10),
             domain: domain,
             ipAddress: nil,
+            clientKey: nil,
+            clientDisplayName: nil,
+            clientIconFilePath: nil
+        )
+    }
+
+    private func makeIPPin(_ ipAddress: String) -> PacketPin {
+        PacketPin(
+            id: PacketPinID(rawValue: "ip:\(ipAddress)"),
+            kind: .ip,
+            title: ipAddress,
+            createdAt: Date(timeIntervalSince1970: 10),
+            domain: nil,
+            ipAddress: ipAddress,
             clientKey: nil,
             clientDisplayName: nil,
             clientIconFilePath: nil

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -150,7 +150,7 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
-    @Test func sidebarContextMenuPlacesShowInFinderAboveDelete() throws {
+    @Test func sidebarContextMenuPlacesCopyAndShowInFinderAboveDelete() throws {
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
         let controller = SidebarViewController()
         controller.loadViewIfNeeded()
@@ -167,11 +167,35 @@ struct SidebarOutlineReloadPolicyTests {
         controller.menuNeedsUpdate(menu)
 
         let nonSeparatorTitles = menu.items.filter { !$0.isSeparatorItem }.map(\.title)
-        #expect(nonSeparatorTitles == ["Pin", "Export", "Show in Finder…", "Delete"])
+        #expect(nonSeparatorTitles == ["Copy App Name", "Pin", "Export", "Show in Finder…", "Delete"])
+        let copyIndex = try #require(menu.items.firstIndex { $0.title == "Copy App Name" })
+        #expect(menu.items[copyIndex + 1].isSeparatorItem)
         let finderIndex = try #require(menu.items.firstIndex { $0.title == "Show in Finder…" })
         let deleteIndex = try #require(menu.items.firstIndex { $0.title == "Delete" })
         #expect(deleteIndex == finderIndex + 2)
         #expect(menu.items[finderIndex + 1].isSeparatorItem)
+    }
+
+    @MainActor
+    @Test func sidebarContextMenuUsesDomainCopyTitleForDomainRows() throws {
+        let domainKey = PacketSourceDomainKey(rawValue: "example.com", isMissingDomain: false)
+        let controller = SidebarViewController()
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithDomain(),
+            selectedSelection: .domain(domainKey),
+            packetMutation: .none
+        ))
+
+        let outlineView = try #require(findOutlineScrollView(in: controller.view)?.documentView as? NSOutlineView)
+        let menu = try #require(outlineView.menu)
+        #expect(outlineView.selectedRow >= 0)
+
+        controller.menuNeedsUpdate(menu)
+
+        let nonSeparatorTitles = menu.items.filter { !$0.isSeparatorItem }.map(\.title)
+        #expect(nonSeparatorTitles.first == "Copy Domain Name")
+        #expect(!nonSeparatorTitles.contains("Copy App Name"))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Add Copy App Name / Copy Domain Name for app and domain nodes in the left sidebar context menu.
- Add right-panel packet details actions for Expand All, Collapse All, and a Wireshark-style Copy submenu.
- Add PacketInspectorByteCopyService with unit coverage for common and edge cases, including single and multiple node selections.

## Validation
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' -only-testing:TCPViewerTests/PacketInspectorByteCopyServiceTests`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' -only-testing:TCPViewerTests/PacketInspectorTreeViewModelTests`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' -only-testing:TCPViewerTests/SidebarOutlineReloadPolicyTests/deferredReloadPreservesSidebarScrollPositionAndSelection`

Full suite note: `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'` failed only at `SidebarOutlineReloadPolicyTests.deferredReloadPreservesSidebarScrollPositionAndSelection()`, which passed when rerun in isolation.

AI assistance disclosure: this PR was implemented with Codex assistance and should be reviewed by a maintainer before merge.
