### PR TITLE
[codex] Add custom packet detail columns

### DIFF
--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -2720,6 +2720,18 @@ final class TCPViewerWorkspaceController {
         scheduleInspection(for: identifier)
     }
 
+    func inspectPacket(id identifier: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>) {
+        guard let packet = snapshot.packetIngestState.packet(withID: identifier) else {
+            completion(.failure(TCPViewerCoreError(
+                code: .offlineFileOpenFailed,
+                message: "Packet \(identifier) is no longer available for inspection."
+            )))
+            return
+        }
+
+        inspectPacket(packet, identifier: identifier, completion: completion)
+    }
+
     func cancelBackgroundWork() {
         cancelControllerTasks()
 
@@ -3629,8 +3641,6 @@ final class TCPViewerWorkspaceController {
             return
         }
 
-        let liveSession = self.liveSession
-        let document = self.document
         let completion: TCPViewerCompletion<PacketInspection> = { [weak self] result in
             DispatchQueue.main.async {
                 guard let self,
@@ -3658,9 +3668,26 @@ final class TCPViewerWorkspaceController {
             }
         }
 
+        inspectPacket(packet, identifier: identifier, completion: completion)
+    }
+
+    // Inspect a packet without mutating selection so table custom-column lookups can reuse decode data.
+    private func inspectPacket(
+        _ packet: PacketSummary,
+        identifier: PacketSummary.ID,
+        completion: @escaping TCPViewerCompletion<PacketInspection>
+    ) {
         switch packet.source {
         case .live:
-            liveSession?.inspectPacket(id: identifier, completion: completion)
+            guard let liveSession else {
+                completion(.failure(TCPViewerCoreError(
+                    code: .offlineFileOpenFailed,
+                    message: "Live packet \(identifier) is no longer available for inspection."
+                )))
+                return
+            }
+
+            liveSession.inspectPacket(id: identifier, completion: completion)
         case .offline:
             if let reference = snapshot.packetIngestState.importedPacketReference(for: identifier),
                let importedDocument = importedDocumentsByFileID[reference.fileID] {
@@ -3668,10 +3695,21 @@ final class TCPViewerWorkspaceController {
                     completion(result.map { $0.tcpviewerRemapping(packetID: identifier) })
                 }
             } else {
-                document?.inspectPacket(id: identifier, completion: completion)
+                guard let document else {
+                    completion(.failure(TCPViewerCoreError(
+                        code: .offlineFileOpenFailed,
+                        message: "Packet \(identifier) is no longer available for inspection."
+                    )))
+                    return
+                }
+
+                document.inspectPacket(id: identifier, completion: completion)
             }
         @unknown default:
-            break
+            completion(.failure(TCPViewerCoreError(
+                code: .offlineFileOpenFailed,
+                message: "Packet \(identifier) cannot be inspected."
+            )))
         }
     }
 

--- a/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
@@ -49,6 +49,7 @@ enum PacketTableColumnRole: String, Equatable, Sendable {
 struct PacketTableMenuState: Equatable {
     let targetRows: [Int]
     let clickedColumn: PacketTableColumnRole
+    let clickedColumnIdentifier: String?
     let copyRowEnabled: Bool
     let copyCellEnabled: Bool
     let pinEnabled: Bool
@@ -59,6 +60,7 @@ struct PacketTableMenuState: Equatable {
     static let empty = PacketTableMenuState(
         targetRows: [],
         clickedColumn: .unknown,
+        clickedColumnIdentifier: nil,
         copyRowEnabled: false,
         copyCellEnabled: false,
         pinEnabled: false,
@@ -94,8 +96,9 @@ enum PacketTableMenuLogic {
         return PacketTableMenuState(
             targetRows: targetIndexes,
             clickedColumn: clickedColumn,
+            clickedColumnIdentifier: clickedColumnIdentifier,
             copyRowEnabled: !targetRows.isEmpty,
-            copyCellEnabled: !targetRows.isEmpty && clickedColumn != .unknown,
+            copyCellEnabled: !targetRows.isEmpty && clickedColumnIdentifier != nil,
             pinEnabled: targetRows.contains { $0.canPinClient },
             saveEnabled: !targetRows.isEmpty,
             exportEnabled: !targetRows.isEmpty,
@@ -236,9 +239,12 @@ enum PacketTableCopyFormatter {
 
     // Build newline-separated values from the clicked table column.
     static func csvCells(_ rows: [PacketTableRow], column: PacketTableColumnRole) -> String {
-        rows
-            .map { csvEscaped($0.text(for: column)) }
-            .joined(separator: "\n")
+        csvValues(rows.map { $0.text(for: column) })
+    }
+
+    // Build newline-separated CSV values that may come from built-in or custom table columns.
+    static func csvValues(_ values: [String]) -> String {
+        values.map(csvEscaped).joined(separator: "\n")
     }
 
     private static func plainTextEscaped(_ value: String) -> String {

--- a/TCPViewer/Features/NetworkInspector/Services/PacketCustomColumnService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketCustomColumnService.swift
@@ -118,6 +118,18 @@ final class PacketCustomColumnService {
         valuesByColumnID = [:]
     }
 
+    // Return unresolved packet IDs from an already-bounded packet list.
+    func unresolvedPacketIDs(
+        for column: PacketCustomColumn,
+        packetIDs: [PacketSummary.ID]
+    ) -> [PacketSummary.ID] {
+        var seenIDs = Set<PacketSummary.ID>()
+        return packetIDs.filter { packetID in
+            seenIDs.insert(packetID).inserted &&
+                !hasResolvedValue(columnIdentifier: column.identifier, packetID: packetID)
+        }
+    }
+
     // Return unresolved packet IDs with visible/current rows first, then the remaining rows.
     func unresolvedPacketIDs(
         for column: PacketCustomColumn,

--- a/TCPViewer/Features/NetworkInspector/Services/PacketCustomColumnService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketCustomColumnService.swift
@@ -1,0 +1,224 @@
+//
+//  PacketCustomColumnService.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/7/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+
+struct PacketCustomColumn: Codable, Equatable, Sendable {
+    let identifier: String
+    let fieldName: String
+    let title: String
+    let defaultWidth: Double
+    let minimumWidth: Double
+
+    init(
+        identifier: String,
+        fieldName: String,
+        title: String,
+        defaultWidth: Double = 140,
+        minimumWidth: Double = 90
+    ) {
+        self.identifier = identifier
+        self.fieldName = fieldName
+        self.title = title
+        self.defaultWidth = defaultWidth
+        self.minimumWidth = minimumWidth
+    }
+}
+
+struct PacketCustomColumnRequest: Equatable, Sendable {
+    let fieldName: String
+    let title: String
+    let packetID: PacketSummary.ID?
+    let sampleValue: String?
+}
+
+enum PacketCustomColumnCreationResult: Equatable {
+    case created(PacketCustomColumn)
+    case existing(PacketCustomColumn)
+    case invalid
+
+    var column: PacketCustomColumn? {
+        switch self {
+        case .created(let column), .existing(let column):
+            return column
+        case .invalid:
+            return nil
+        }
+    }
+
+    var didCreate: Bool {
+        if case .created = self {
+            return true
+        }
+
+        return false
+    }
+}
+
+final class PacketCustomColumnService {
+    private(set) var columns: [PacketCustomColumn]
+    private var valuesByColumnID: [String: [PacketSummary.ID: String]] = [:]
+
+    init(columns: [PacketCustomColumn] = []) {
+        self.columns = Self.uniqueColumns(columns)
+    }
+
+    // Create or reveal an existing column for the normalized protocol field name.
+    @discardableResult
+    func createColumn(from request: PacketCustomColumnRequest) -> PacketCustomColumnCreationResult {
+        guard let normalizedFieldName = Self.normalizedFieldName(request.fieldName) else {
+            return .invalid
+        }
+
+        if let existingColumn = columns.first(where: { Self.normalizedFieldName($0.fieldName) == normalizedFieldName }) {
+            storeSampleValue(from: request, column: existingColumn)
+            return .existing(existingColumn)
+        }
+
+        let column = PacketCustomColumn(
+            identifier: Self.identifier(forNormalizedFieldName: normalizedFieldName),
+            fieldName: normalizedFieldName,
+            title: Self.title(from: request.title, fieldName: normalizedFieldName)
+        )
+        columns.append(column)
+        storeSampleValue(from: request, column: column)
+        return .created(column)
+    }
+
+    func restoreColumns(_ columns: [PacketCustomColumn]) {
+        self.columns = Self.uniqueColumns(columns)
+        valuesByColumnID = valuesByColumnID.filter { columnID, _ in
+            self.columns.contains { $0.identifier == columnID }
+        }
+    }
+
+    func reset() {
+        columns = []
+        valuesByColumnID = [:]
+    }
+
+    func value(columnIdentifier: String, packetID: PacketSummary.ID) -> String? {
+        valuesByColumnID[columnIdentifier]?[packetID]
+    }
+
+    func hasResolvedValue(columnIdentifier: String, packetID: PacketSummary.ID) -> Bool {
+        valuesByColumnID[columnIdentifier]?[packetID] != nil
+    }
+
+    func storeValue(_ value: String, columnIdentifier: String, packetID: PacketSummary.ID) {
+        valuesByColumnID[columnIdentifier, default: [:]][packetID] = value
+    }
+
+    func clearValues() {
+        valuesByColumnID = [:]
+    }
+
+    // Return unresolved packet IDs with visible/current rows first, then the remaining rows.
+    func unresolvedPacketIDs(
+        for column: PacketCustomColumn,
+        rows: [PacketTableRow],
+        preferredPacketIDs: [PacketSummary.ID]
+    ) -> [PacketSummary.ID] {
+        let rowIDs = rows.map(\.id)
+        let rowIDSet = Set(rowIDs)
+        var seenIDs = Set<PacketSummary.ID>()
+        var orderedIDs: [PacketSummary.ID] = []
+
+        for packetID in preferredPacketIDs where rowIDSet.contains(packetID) && seenIDs.insert(packetID).inserted {
+            orderedIDs.append(packetID)
+        }
+
+        for packetID in rowIDs where seenIDs.insert(packetID).inserted {
+            orderedIDs.append(packetID)
+        }
+
+        return orderedIDs.filter {
+            !hasResolvedValue(columnIdentifier: column.identifier, packetID: $0)
+        }
+    }
+
+    static func resolvedValue(fieldName: String, in inspection: PacketInspection) -> String {
+        guard let normalizedFieldName = normalizedFieldName(fieldName),
+              let node = firstNode(matching: normalizedFieldName, in: inspection.detailNodes) else {
+            return ""
+        }
+
+        return node.value ?? node.rawValue ?? ""
+    }
+
+    static func normalizedFieldName(_ fieldName: String) -> String? {
+        let normalized = fieldName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func identifier(forNormalizedFieldName fieldName: String) -> String {
+        let sanitized = fieldName
+            .map { character -> Character in
+                if character.isLetter || character.isNumber || character == "." || character == "_" || character == "-" {
+                    return character
+                }
+
+                return "-"
+            }
+            .reduce(into: "") { result, character in
+                if character == "-", result.last == "-" {
+                    return
+                }
+
+                result.append(character)
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+        return "custom.field.\(sanitized.isEmpty ? "field" : sanitized)"
+    }
+
+    private static func title(from value: String, fieldName: String) -> String {
+        let trimmedTitle = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTitle.isEmpty {
+            return trimmedTitle
+        }
+
+        return fieldName
+    }
+
+    private static func firstNode(matching normalizedFieldName: String, in nodes: [PacketDetailNode]) -> PacketDetailNode? {
+        for node in nodes {
+            if self.normalizedFieldName(node.fieldName) == normalizedFieldName {
+                return node
+            }
+
+            if let match = firstNode(matching: normalizedFieldName, in: node.children) {
+                return match
+            }
+        }
+
+        return nil
+    }
+
+    private static func uniqueColumns(_ columns: [PacketCustomColumn]) -> [PacketCustomColumn] {
+        var seenFieldNames = Set<String>()
+        return columns.filter { column in
+            guard let normalizedFieldName = normalizedFieldName(column.fieldName) else {
+                return false
+            }
+
+            return seenFieldNames.insert(normalizedFieldName).inserted
+        }
+    }
+
+    private func storeSampleValue(from request: PacketCustomColumnRequest, column: PacketCustomColumn) {
+        guard let packetID = request.packetID,
+              let sampleValue = request.sampleValue else {
+            return
+        }
+
+        storeValue(sampleValue, columnIdentifier: column.identifier, packetID: packetID)
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketTableColumnService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketTableColumnService.swift
@@ -112,14 +112,40 @@ struct PacketTableColumnLayout: Codable, Equatable {
         let width: Double
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case columns
+        case customColumns
+    }
+
     static let currentVersion = 1
 
     let version: Int
     let columns: [Column]
+    let customColumns: [PacketCustomColumn]
 
-    init(version: Int = PacketTableColumnLayout.currentVersion, columns: [Column]) {
+    init(
+        version: Int = PacketTableColumnLayout.currentVersion,
+        columns: [Column],
+        customColumns: [PacketCustomColumn] = []
+    ) {
         self.version = version
         self.columns = columns
+        self.customColumns = customColumns
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? Self.currentVersion
+        columns = try container.decode([Column].self, forKey: .columns)
+        customColumns = try container.decodeIfPresent([PacketCustomColumn].self, forKey: .customColumns) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(columns, forKey: .columns)
+        try container.encode(customColumns, forKey: .customColumns)
     }
 }
 
@@ -183,12 +209,14 @@ final class PacketTableColumnService {
         .builtIn(.tags, title: "Tags", defaultWidth: 140, minimumWidth: 90),
     ]
 
-    let definitions: [PacketTableColumnDefinition]
+    private(set) var definitions: [PacketTableColumnDefinition]
+    private let baseDefinitions: [PacketTableColumnDefinition]
     private var visibilityByIdentifier: [String: Bool]
 
     // Start each known column from its declared default visibility.
     init(definitions: [PacketTableColumnDefinition] = PacketTableColumnService.defaultDefinitions) {
-        self.definitions = Self.uniqueDefinitions(definitions)
+        self.baseDefinitions = Self.uniqueDefinitions(definitions)
+        self.definitions = baseDefinitions
         self.visibilityByIdentifier = Dictionary(
             uniqueKeysWithValues: self.definitions.map { ($0.identifier, $0.isDefaultVisible) }
         )
@@ -211,6 +239,36 @@ final class PacketTableColumnService {
 
     func definition(identifier: String) -> PacketTableColumnDefinition? {
         definitions.first { $0.identifier == identifier }
+    }
+
+    // Append custom definitions after built-ins while preserving known visibility state.
+    func setCustomColumns(_ customColumns: [PacketCustomColumn]) {
+        let customDefinitions = customColumns.map { column in
+            PacketTableColumnDefinition.custom(
+                identifier: column.identifier,
+                title: column.title,
+                defaultWidth: column.defaultWidth,
+                minimumWidth: column.minimumWidth
+            )
+        }
+        let nextDefinitions = Self.uniqueDefinitions(baseDefinitions + customDefinitions)
+        var nextVisibility = Dictionary(
+            uniqueKeysWithValues: nextDefinitions.map { definition in
+                (
+                    definition.identifier,
+                    visibilityByIdentifier[definition.identifier] ?? definition.isDefaultVisible
+                )
+            }
+        )
+
+        nextDefinitions.forEach { definition in
+            if !definition.canUserHide {
+                nextVisibility[definition.identifier] = true
+            }
+        }
+
+        definitions = nextDefinitions
+        visibilityByIdentifier = nextVisibility
     }
 
     func isColumnVisible(identifier: String) -> Bool {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -2055,6 +2055,10 @@ final class NetworkInspectorViewModel {
         rebuildSnapshot()
     }
 
+    func inspectPacket(_ identifier: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>) {
+        controller.inspectPacket(id: identifier, completion: completion)
+    }
+
     func selectInspectorTab(_ tab: PacketInspectorTab) {
         inspectorTab = tab
         rebuildSnapshot()

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -1497,6 +1497,7 @@ extension PacketInspectorViewController: NSMenuDelegate {
         let hasExpandableRows = hasExpandableInspectorRows()
         let canCreateColumn = selectedCustomColumnRequest() != nil
         menu.addItem(copySubmenuItem(hasSelectedRows: hasSelectedRows, hasSelectedByteRanges: hasSelectedByteRanges))
+        menu.addItem(.separator())
         menu.addItem(createColumnItem(isEnabled: canCreateColumn))
         menu.addItem(.separator())
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketInspectorViewController.swift
@@ -10,6 +10,7 @@ import PcapPlusPlusCore
 
 protocol PacketInspectorViewControllerDelegate: AnyObject {
     func packetInspectorViewController(_ controller: PacketInspectorViewController, didSelectDetailNode identifier: String?)
+    func packetInspectorViewController(_ controller: PacketInspectorViewController, didRequestCreateCustomColumn request: PacketCustomColumnRequest)
 }
 
 enum PacketInspectorTreeItemKind: Equatable {
@@ -87,6 +88,7 @@ final class PacketInspectorTreeItem: NSObject {
     let name: String
     let fieldName: String?
     let value: String?
+    let rawValue: String?
     let kind: PacketInspectorTreeItemKind
     let severity: PacketDetailNodeSeverity
     let byteRange: PacketByteRange?
@@ -99,6 +101,7 @@ final class PacketInspectorTreeItem: NSObject {
         name: String,
         fieldName: String? = nil,
         value: String? = nil,
+        rawValue: String? = nil,
         kind: PacketInspectorTreeItemKind,
         severity: PacketDetailNodeSeverity = .normal,
         byteRange: PacketByteRange? = nil,
@@ -110,6 +113,7 @@ final class PacketInspectorTreeItem: NSObject {
         self.name = name
         self.fieldName = fieldName
         self.value = value
+        self.rawValue = rawValue
         self.kind = kind
         self.severity = severity
         self.byteRange = byteRange
@@ -286,6 +290,7 @@ final class PacketInspectorTreeViewModel {
             name: item.name,
             fieldName: item.fieldName,
             value: item.value,
+            rawValue: item.rawValue,
             kind: item.kind,
             severity: item.severity,
             byteRange: item.byteRange,
@@ -446,6 +451,7 @@ final class PacketInspectorTreeViewModel {
             name: displayParts.name,
             fieldName: node.fieldName,
             value: displayParts.value,
+            rawValue: node.rawValue,
             kind: itemKind(from: node.kind),
             severity: node.severity,
             byteRange: node.byteRange,
@@ -1153,6 +1159,24 @@ final class PacketInspectorViewController: NSViewController {
         viewModel.copyItems(forSelectionIDs: selectedCopySelectionIDs())
     }
 
+    private func selectedCustomColumnRequest() -> PacketCustomColumnRequest? {
+        guard outlineView.selectedRowIndexes.count == 1,
+              let row = outlineView.selectedRowIndexes.first,
+              let item = outlineView.item(atRow: row) as? PacketInspectorTreeItem,
+              item.kind != .message,
+              let fieldName = item.fieldName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !fieldName.isEmpty else {
+            return nil
+        }
+
+        return PacketCustomColumnRequest(
+            fieldName: fieldName,
+            title: item.name,
+            packetID: latestInspectionState?.selectedPacketID,
+            sampleValue: item.value ?? item.rawValue
+        )
+    }
+
     // Write inspector copy rows to the system pasteboard as plain text.
     private func copyRowsToPasteboard(_ rows: [PacketInspectorCopyRow]) {
         let text = PacketInspectorCopyFormatter.text(for: rows)
@@ -1263,6 +1287,14 @@ final class PacketInspectorViewController: NSViewController {
         }
 
         copySelectedBytesToPasteboard(format: format)
+    }
+
+    @objc private func createColumnFromMenu(_ sender: Any?) {
+        guard let request = selectedCustomColumnRequest() else {
+            return
+        }
+
+        delegate?.packetInspectorViewController(self, didRequestCreateCustomColumn: request)
     }
 
     @objc private func expandAllRowsFromMenu(_ sender: Any?) {
@@ -1463,7 +1495,9 @@ extension PacketInspectorViewController: NSMenuDelegate {
         let hasSelectedRows = !selectedCopySelectionIDs().isEmpty
         let hasSelectedByteRanges = hasSelectedBytes()
         let hasExpandableRows = hasExpandableInspectorRows()
+        let canCreateColumn = selectedCustomColumnRequest() != nil
         menu.addItem(copySubmenuItem(hasSelectedRows: hasSelectedRows, hasSelectedByteRanges: hasSelectedByteRanges))
+        menu.addItem(createColumnItem(isEnabled: canCreateColumn))
         menu.addItem(.separator())
 
         let expandAllItem = NSMenuItem(
@@ -1546,6 +1580,19 @@ extension PacketInspectorViewController: NSMenuDelegate {
         menuItem.isEnabled = hasSelectedRows || viewModel.hasCopyableDetails()
         menuItem.toolTip = "Choose how to copy packet detail rows or bytes."
         menuItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy")
+        return menuItem
+    }
+
+    private func createColumnItem(isEnabled: Bool) -> NSMenuItem {
+        let menuItem = NSMenuItem(
+            title: "Create Column",
+            action: #selector(createColumnFromMenu(_:)),
+            keyEquivalent: ""
+        )
+        menuItem.target = self
+        menuItem.isEnabled = isEnabled
+        menuItem.toolTip = "Create a packet table column from the selected packet detail field."
+        menuItem.image = NSImage(systemSymbolName: "tablecells", accessibilityDescription: "Create Column")
         return menuItem
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import PcapPlusPlusCore
+import QuartzCore
 
 protocol PacketTableViewControllerDelegate: AnyObject {
     func packetTableViewController(_ controller: PacketTableViewController, didSelectPacket identifier: PacketSummary.ID?)
@@ -17,6 +18,11 @@ protocol PacketTableViewControllerDelegate: AnyObject {
     func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
     func packetTableViewController(_ controller: PacketTableViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
     func packetTableViewController(_ controller: PacketTableViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        inspectPacket identifier: PacketSummary.ID,
+        completion: @escaping TCPViewerCompletion<PacketInspection>
+    )
 }
 
 enum PacketTableSelectionSyncAction: Equatable {
@@ -104,6 +110,10 @@ final class PacketTableViewModel {
         return rowStore.rowIDs[index]
     }
 
+    func rowIndex(for identifier: PacketSummary.ID) -> Int? {
+        rowStore.visiblePacketRowIndexByID[identifier]
+    }
+
     // Store the latest render state so the controller can apply incremental table updates.
     func render(snapshot: NetworkInspectorSnapshot) -> PacketTableUpdatePlan {
         let previousRowStore = rowStore
@@ -126,6 +136,12 @@ final class PacketTableViewModel {
 final class PacketTableViewController: NSViewController {
     static let columnAutosaveName: NSTableView.AutosaveName = "TCPViewer.PacketTable.Columns"
 
+    private struct CustomColumnWorkItem {
+        let generation: Int
+        let column: PacketCustomColumn
+        let packetID: PacketSummary.ID
+    }
+
     weak var delegate: PacketTableViewControllerDelegate?
 
     private let configuration: AppConfiguration
@@ -133,6 +149,7 @@ final class PacketTableViewController: NSViewController {
     private let scrollView = NSScrollView()
     private let viewModel = PacketTableViewModel()
     private let contextMenuController = PacketTableContextMenuController()
+    private let customColumnService = PacketCustomColumnService()
     private let columnService: PacketTableColumnService
     private let columnLayoutStore: PacketTableColumnLayoutStore
     private let columnVisibilityMenuController: PacketTableColumnVisibilityMenuController
@@ -142,6 +159,16 @@ final class PacketTableViewController: NSViewController {
     private var pendingUserSelection: PendingUserSelection?
     private var clickedRowIndex: Int?
     private var clickedColumnIdentifier: String?
+    private var customColumnWorkQueue: [CustomColumnWorkItem] = []
+    private var customColumnWorkQueueHeadIndex = 0
+    private var queuedCustomColumnWorkKeys = Set<String>()
+    private var activeCustomColumnInspectionCount = 0
+    private var customColumnResolutionGeneration = 0
+    private var pendingCustomColumnReloadIndexes = IndexSet()
+    private var pendingCustomColumnReloadWorkItem: DispatchWorkItem?
+    private var renderedPacketLineageRevision: UInt64?
+
+    private let maximumConcurrentCustomColumnInspections = 8
 
     // Wraps Optional<ID> so we can distinguish "no pending intent" from a
     // pending user-driven deselect. A pending intent means the user has just
@@ -190,6 +217,12 @@ final class PacketTableViewController: NSViewController {
 
     // Apply packet rows, using append plans when the model says only new visible rows arrived.
     func render(snapshot: NetworkInspectorSnapshot) {
+        if renderedPacketLineageRevision != snapshot.base.packetIngestState.packetLineageRevision {
+            customColumnService.clearValues()
+            resetCustomColumnResolutionQueue()
+            renderedPacketLineageRevision = snapshot.base.packetIngestState.packetLineageRevision
+        }
+
         let previousRowCount = rows.count
         let updatePlan = viewModel.render(snapshot: snapshot)
         applyAppearanceConfiguration(reload: false)
@@ -213,6 +246,8 @@ final class PacketTableViewController: NSViewController {
 
             syncSelection()
         }
+
+        enqueueCustomColumnResolution(after: updatePlan, previousRowCount: previousRowCount)
     }
 
     private func applyAppendPlan(range: Range<Int>, previousRowCount: Int) {
@@ -265,6 +300,8 @@ final class PacketTableViewController: NSViewController {
         tableView.headerView?.menu = columnVisibilityMenuController.makeMenu()
 
         let restoredLayout = columnLayoutStore.load()
+        customColumnService.restoreColumns(restoredLayout?.customColumns ?? [])
+        columnService.setCustomColumns(customColumnService.columns)
         if let restoredLayout {
             columnService.applyVisibility(from: restoredLayout)
         }
@@ -298,6 +335,15 @@ final class PacketTableViewController: NSViewController {
         column.dataCell = cell(for: definition.cellKind)
         column.isHidden = !columnService.isColumnVisible(identifier: definition.identifier)
         tableView.addTableColumn(column)
+    }
+
+    private func addCustomColumnIfNeeded(_ column: PacketCustomColumn) {
+        guard tableView.tableColumn(withIdentifier: NSUserInterfaceItemIdentifier(column.identifier)) == nil,
+              let definition = columnService.definition(identifier: column.identifier) else {
+            return
+        }
+
+        addColumn(definition)
     }
 
     private func cell(for kind: PacketTableColumnCellKind) -> NSCell {
@@ -362,6 +408,8 @@ final class PacketTableViewController: NSViewController {
         isRestoringColumnLayout = true
         defer { isRestoringColumnLayout = false }
 
+        removeCustomTableColumns()
+        columnService.setCustomColumns(customColumnService.columns)
         columnService.definitions.enumerated().forEach { targetIndex, definition in
             guard let currentIndex = tableView.tableColumns.firstIndex(where: {
                 $0.identifier.rawValue == definition.identifier
@@ -380,6 +428,13 @@ final class PacketTableViewController: NSViewController {
         }
     }
 
+    private func removeCustomTableColumns() {
+        let customColumnIDs = Set(customColumnService.columns.map(\.identifier))
+        for column in tableView.tableColumns where customColumnIDs.contains(column.identifier.rawValue) || column.identifier.rawValue.hasPrefix("custom.field.") {
+            tableView.removeTableColumn(column)
+        }
+    }
+
     private func currentColumnLayout() -> PacketTableColumnLayout {
         PacketTableColumnLayout(columns: tableView.tableColumns.map { column in
             PacketTableColumnLayout.Column(
@@ -387,7 +442,7 @@ final class PacketTableViewController: NSViewController {
                 isVisible: !column.isHidden,
                 width: Double(column.width)
             )
-        })
+        }, customColumns: customColumnService.columns)
     }
 
     private func saveColumnLayout() {
@@ -397,6 +452,22 @@ final class PacketTableViewController: NSViewController {
 
         syncColumnVisibilityFromTable()
         columnLayoutStore.save(currentColumnLayout())
+    }
+
+    func createCustomColumn(from request: PacketCustomColumnRequest) {
+        let result = customColumnService.createColumn(from: request)
+        guard let customColumn = result.column else {
+            return
+        }
+
+        columnService.setCustomColumns(customColumnService.columns)
+        addCustomColumnIfNeeded(customColumn)
+        _ = columnService.setColumnVisibility(identifier: customColumn.identifier, isVisible: true)
+        applyColumnVisibility(identifier: customColumn.identifier)
+        saveColumnLayout()
+        reloadColumn(identifier: customColumn.identifier)
+        enqueueCustomColumnResolution(for: customColumn, visibleFirst: true)
+        animateScrollToColumn(identifier: customColumn.identifier)
     }
 
     private func columnIdentifier(from sender: Any?) -> String? {
@@ -417,6 +488,33 @@ final class PacketTableViewController: NSViewController {
         updates()
         clipView.scroll(to: visibleOrigin)
         scrollView.reflectScrolledClipView(clipView)
+    }
+
+    private func animateScrollToColumn(identifier: String) {
+        guard let columnIndex = tableView.tableColumns.firstIndex(where: { $0.identifier.rawValue == identifier }) else {
+            return
+        }
+
+        tableView.layoutSubtreeIfNeeded()
+        let columnRect = tableView.rect(ofColumn: columnIndex)
+        let clipView = scrollView.contentView
+        let documentWidth = max(tableView.bounds.width, columnRect.maxX)
+        let targetX = min(
+            max(0, columnRect.minX - 16),
+            max(0, documentWidth - clipView.bounds.width)
+        )
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.24
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            clipView.animator().setBoundsOrigin(NSPoint(x: targetX, y: clipView.bounds.origin.y))
+        } completionHandler: { [weak self] in
+            guard let self else {
+                return
+            }
+
+            self.scrollView.reflectScrolledClipView(clipView)
+        }
     }
 
     private func suppressSelectionCallbacks(_ updates: () -> Void) {
@@ -479,7 +577,11 @@ final class PacketTableViewController: NSViewController {
     }
 
     private func text(for column: String, in row: PacketTableRow) -> String {
-        row.text(for: PacketTableColumnRole(columnIdentifier: column))
+        if customColumnService.columns.contains(where: { $0.identifier == column }) {
+            return customColumnService.value(columnIdentifier: column, packetID: row.id) ?? ""
+        }
+
+        return row.text(for: PacketTableColumnRole(columnIdentifier: column))
     }
 
     private func textStyle(for column: String, in row: PacketTableRow) -> PacketTextCell.Style {
@@ -523,6 +625,215 @@ final class PacketTableViewController: NSViewController {
         clickedColumnIdentifier = tableView.tableColumns.indices.contains(column)
             ? tableView.tableColumns[column].identifier.rawValue
             : nil
+    }
+
+    private func enqueueCustomColumnResolution(after updatePlan: PacketTableUpdatePlan, previousRowCount: Int) {
+        guard !customColumnService.columns.isEmpty else {
+            return
+        }
+
+        switch updatePlan {
+        case .none:
+            return
+        case .append(let range), .appendAndReloadRows(let range, _):
+            let lowerBound = max(range.lowerBound, previousRowCount)
+            let upperBound = min(range.upperBound, rows.count)
+            guard lowerBound < upperBound else {
+                return
+            }
+            let safeRange = lowerBound..<upperBound
+            guard !safeRange.isEmpty else {
+                return
+            }
+            let appendedPacketIDs = rows[safeRange].map(\.id)
+            visibleCustomColumns().forEach { column in
+                enqueueCustomColumnResolution(for: column, preferredPacketIDs: appendedPacketIDs)
+            }
+        case .reload:
+            visibleCustomColumns().forEach { column in
+                enqueueCustomColumnResolution(for: column, visibleFirst: true)
+            }
+        case .reloadRows:
+            return
+        }
+    }
+
+    private func enqueueCustomColumnResolution(for column: PacketCustomColumn, visibleFirst: Bool) {
+        let preferredPacketIDs = visibleFirst ? visiblePacketIDs() : []
+        enqueueCustomColumnResolution(for: column, preferredPacketIDs: preferredPacketIDs)
+    }
+
+    private func enqueueCustomColumnResolution(
+        for column: PacketCustomColumn,
+        preferredPacketIDs: [PacketSummary.ID]
+    ) {
+        let packetIDs = customColumnService.unresolvedPacketIDs(
+            for: column,
+            rows: rows,
+            preferredPacketIDs: preferredPacketIDs
+        )
+        guard !packetIDs.isEmpty else {
+            return
+        }
+
+        for packetID in packetIDs {
+            let key = customColumnWorkKey(columnIdentifier: column.identifier, packetID: packetID)
+            guard queuedCustomColumnWorkKeys.insert(key).inserted else {
+                continue
+            }
+
+            customColumnWorkQueue.append(CustomColumnWorkItem(
+                generation: customColumnResolutionGeneration,
+                column: column,
+                packetID: packetID
+            ))
+        }
+
+        processCustomColumnWorkIfNeeded()
+    }
+
+    private func processCustomColumnWorkIfNeeded() {
+        guard let delegate else {
+            customColumnWorkQueue.removeAll()
+            customColumnWorkQueueHeadIndex = 0
+            queuedCustomColumnWorkKeys.removeAll()
+            activeCustomColumnInspectionCount = 0
+            return
+        }
+
+        while activeCustomColumnInspectionCount < maximumConcurrentCustomColumnInspections,
+              customColumnWorkQueueHeadIndex < customColumnWorkQueue.count {
+            let workItem = customColumnWorkQueue[customColumnWorkQueueHeadIndex]
+            customColumnWorkQueueHeadIndex += 1
+            activeCustomColumnInspectionCount += 1
+            delegate.packetTableViewController(self, inspectPacket: workItem.packetID) { [weak self] result in
+                DispatchQueue.main.async {
+                    self?.completeCustomColumnWork(workItem, result: result)
+                }
+            }
+        }
+
+        compactCustomColumnWorkQueueIfNeeded()
+    }
+
+    private func completeCustomColumnWork(
+        _ workItem: CustomColumnWorkItem,
+        result: Result<PacketInspection, Error>
+    ) {
+        guard workItem.generation == customColumnResolutionGeneration else {
+            return
+        }
+
+        activeCustomColumnInspectionCount = max(0, activeCustomColumnInspectionCount - 1)
+        queuedCustomColumnWorkKeys.remove(customColumnWorkKey(
+            columnIdentifier: workItem.column.identifier,
+            packetID: workItem.packetID
+        ))
+
+        let value: String
+        switch result {
+        case .success(let inspection):
+            value = PacketCustomColumnService.resolvedValue(fieldName: workItem.column.fieldName, in: inspection)
+        case .failure:
+            value = ""
+        }
+
+        customColumnService.storeValue(value, columnIdentifier: workItem.column.identifier, packetID: workItem.packetID)
+        queueCustomColumnReload(packetID: workItem.packetID)
+        processCustomColumnWorkIfNeeded()
+    }
+
+    // Compact consumed queue entries in batches so large captures avoid repeated removeFirst work.
+    private func compactCustomColumnWorkQueueIfNeeded() {
+        guard customColumnWorkQueueHeadIndex > 0 else {
+            return
+        }
+
+        if customColumnWorkQueueHeadIndex >= customColumnWorkQueue.count {
+            customColumnWorkQueue.removeAll(keepingCapacity: true)
+            customColumnWorkQueueHeadIndex = 0
+            return
+        }
+
+        if customColumnWorkQueueHeadIndex > 512,
+           customColumnWorkQueueHeadIndex * 2 >= customColumnWorkQueue.count {
+            customColumnWorkQueue.removeFirst(customColumnWorkQueueHeadIndex)
+            customColumnWorkQueueHeadIndex = 0
+        }
+    }
+
+    private func queueCustomColumnReload(packetID: PacketSummary.ID) {
+        guard let rowIndex = viewModel.rowIndex(for: packetID),
+              rowIndex >= 0,
+              rowIndex < tableView.numberOfRows else {
+            return
+        }
+
+        pendingCustomColumnReloadIndexes.insert(rowIndex)
+        guard pendingCustomColumnReloadWorkItem == nil else {
+            return
+        }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.flushPendingCustomColumnReloads()
+        }
+        pendingCustomColumnReloadWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: workItem)
+    }
+
+    private func flushPendingCustomColumnReloads() {
+        pendingCustomColumnReloadWorkItem = nil
+        let validRange = 0..<tableView.numberOfRows
+        let rowIndexes = IndexSet(pendingCustomColumnReloadIndexes.filter { validRange.contains($0) })
+        pendingCustomColumnReloadIndexes = []
+        guard !rowIndexes.isEmpty else {
+            return
+        }
+
+        tableView.reloadData(forRowIndexes: rowIndexes, columnIndexes: IndexSet(0..<tableView.numberOfColumns))
+    }
+
+    private func visiblePacketIDs() -> [PacketSummary.ID] {
+        let visibleRows = tableView.rows(in: scrollView.contentView.bounds)
+        guard visibleRows.location != NSNotFound else {
+            return []
+        }
+
+        let rowRange = visibleRows.location..<(visibleRows.location + visibleRows.length)
+        return rowRange.compactMap { rowIndex in
+            rows.indices.contains(rowIndex) ? rows[rowIndex].id : nil
+        }
+    }
+
+    private func resetCustomColumnResolutionQueue() {
+        customColumnResolutionGeneration += 1
+        customColumnWorkQueue.removeAll()
+        customColumnWorkQueueHeadIndex = 0
+        queuedCustomColumnWorkKeys.removeAll()
+        activeCustomColumnInspectionCount = 0
+        pendingCustomColumnReloadIndexes = []
+        pendingCustomColumnReloadWorkItem?.cancel()
+        pendingCustomColumnReloadWorkItem = nil
+    }
+
+    private func customColumnWorkKey(columnIdentifier: String, packetID: PacketSummary.ID) -> String {
+        "\(columnIdentifier)|\(packetID)"
+    }
+
+    private func visibleCustomColumns() -> [PacketCustomColumn] {
+        customColumnService.columns.filter { columnService.isColumnVisible(identifier: $0.identifier) }
+    }
+
+    private func reloadColumn(identifier: String) {
+        guard let columnIndex = tableView.tableColumns.firstIndex(where: { $0.identifier.rawValue == identifier }),
+              tableView.numberOfRows > 0 else {
+            return
+        }
+
+        tableView.reloadData(
+            forRowIndexes: IndexSet(0..<tableView.numberOfRows),
+            columnIndexes: IndexSet(integer: columnIndex)
+        )
     }
 
     private func menuState() -> PacketTableMenuState {
@@ -735,11 +1046,17 @@ extension PacketTableViewController: PacketTableColumnVisibilityMenuActionHandli
         }
 
         applyColumnVisibility(identifier: identifier)
+        if columnService.isColumnVisible(identifier: identifier),
+           let customColumn = customColumnService.columns.first(where: { $0.identifier == identifier }) {
+            enqueueCustomColumnResolution(for: customColumn, visibleFirst: true)
+        }
         saveColumnLayout()
         tableView.headerView?.menu?.cancelTracking()
     }
 
     func resetPacketTableColumnsFromMenu(_ sender: Any?) {
+        resetCustomColumnResolutionQueue()
+        customColumnService.reset()
         columnService.resetToDefaults()
         restoreDefaultColumnLayout()
         columnLayoutStore.clear()

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -647,7 +647,7 @@ final class PacketTableViewController: NSViewController {
             }
             let appendedPacketIDs = rows[safeRange].map(\.id)
             visibleCustomColumns().forEach { column in
-                enqueueCustomColumnResolution(for: column, preferredPacketIDs: appendedPacketIDs)
+                enqueueCustomColumnResolution(for: column, packetIDs: appendedPacketIDs)
             }
         case .reload:
             visibleCustomColumns().forEach { column in
@@ -665,6 +665,14 @@ final class PacketTableViewController: NSViewController {
 
     private func enqueueCustomColumnResolution(
         for column: PacketCustomColumn,
+        packetIDs: [PacketSummary.ID]
+    ) {
+        let unresolvedPacketIDs = customColumnService.unresolvedPacketIDs(for: column, packetIDs: packetIDs)
+        enqueueCustomColumnResolutionWork(for: column, packetIDs: unresolvedPacketIDs)
+    }
+
+    private func enqueueCustomColumnResolution(
+        for column: PacketCustomColumn,
         preferredPacketIDs: [PacketSummary.ID]
     ) {
         let packetIDs = customColumnService.unresolvedPacketIDs(
@@ -672,6 +680,13 @@ final class PacketTableViewController: NSViewController {
             rows: rows,
             preferredPacketIDs: preferredPacketIDs
         )
+        enqueueCustomColumnResolutionWork(for: column, packetIDs: packetIDs)
+    }
+
+    private func enqueueCustomColumnResolutionWork(
+        for column: PacketCustomColumn,
+        packetIDs: [PacketSummary.ID]
+    ) {
         guard !packetIDs.isEmpty else {
             return
         }
@@ -888,8 +903,12 @@ final class PacketTableViewController: NSViewController {
 
     @objc func copyCellFromMenu(_ sender: Any?) {
         let state = menuState()
+        guard let columnIdentifier = state.clickedColumnIdentifier else {
+            return
+        }
+
         let rows = state.targetRows.compactMap { self.rows.indices.contains($0) ? self.rows[$0] : nil }
-        writeToPasteboard(PacketTableCopyFormatter.csvCells(rows, column: state.clickedColumn))
+        writeToPasteboard(PacketTableCopyFormatter.csvValues(rows.map { text(for: columnIdentifier, in: $0) }))
     }
 
     @objc func pinRowsFromMenu(_ sender: Any?) {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -17,6 +17,11 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        inspectPacket identifier: PacketSummary.ID,
+        completion: @escaping TCPViewerCompletion<PacketInspection>
+    )
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didUpdateStructuredFilterGroup group: PacketStructuredFilterGroup)
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSaveCustomFilterNamed name: String, group: PacketStructuredFilterGroup)
     func packetWorkspaceViewController(
@@ -157,6 +162,10 @@ final class PacketWorkspaceViewController: NSViewController {
     func focusStructuredFilter() {
         applyStructuredFilterVisibility(true)
         structuredFilterController.focusLastFilterTextField()
+    }
+
+    func createCustomColumn(from request: PacketCustomColumnRequest) {
+        tableController.createCustomColumn(from: request)
     }
 
     private func setupContent() {
@@ -379,6 +388,14 @@ extension PacketWorkspaceViewController: PacketTableViewControllerDelegate {
 
     func packetTableViewController(_ controller: PacketTableViewController, didRequestDeletePackets identifiers: [PacketSummary.ID]) {
         delegate?.packetWorkspaceViewController(self, didRequestDeletePackets: identifiers)
+    }
+
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        inspectPacket identifier: PacketSummary.ID,
+        completion: @escaping TCPViewerCompletion<PacketInspection>
+    ) {
+        delegate?.packetWorkspaceViewController(self, inspectPacket: identifier, completion: completion)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -1301,6 +1301,14 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         viewModel.deletePackets(identifiers)
     }
 
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        inspectPacket identifier: PacketSummary.ID,
+        completion: @escaping TCPViewerCompletion<PacketInspection>
+    ) {
+        viewModel.inspectPacket(identifier, completion: completion)
+    }
+
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didUpdateStructuredFilterGroup group: PacketStructuredFilterGroup) {
         viewModel.updateStructuredFilterGroup(group)
     }
@@ -1389,6 +1397,13 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 extension TCPViewerRootViewController: PacketInspectorViewControllerDelegate {
     func packetInspectorViewController(_ controller: PacketInspectorViewController, didSelectDetailNode identifier: String?) {
         viewModel.selectDetailNode(identifier)
+    }
+
+    func packetInspectorViewController(
+        _ controller: PacketInspectorViewController,
+        didRequestCreateCustomColumn request: PacketCustomColumnRequest
+    ) {
+        workspaceViewController.createCustomColumn(from: request)
     }
 }
 

--- a/TCPViewerTests/Features/NetworkInspector/PacketCustomColumnServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCustomColumnServiceTests.swift
@@ -1,0 +1,156 @@
+//
+//  PacketCustomColumnServiceTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/7/26.
+//
+
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct PacketCustomColumnServiceTests {
+    @Test func createsColumnFromProtocolFieldAndRejectsInvalidField() {
+        let service = PacketCustomColumnService()
+
+        let result = service.createColumn(from: PacketCustomColumnRequest(
+            fieldName: " TCP.SrcPort ",
+            title: "Source Port",
+            packetID: 1,
+            sampleValue: "443"
+        ))
+        let column = result.column
+
+        #expect(result.didCreate)
+        #expect(column?.identifier == "custom.field.tcp.srcport")
+        #expect(column?.fieldName == "tcp.srcport")
+        #expect(column?.title == "Source Port")
+        #expect(service.value(columnIdentifier: "custom.field.tcp.srcport", packetID: 1) == "443")
+        #expect(service.createColumn(from: PacketCustomColumnRequest(
+            fieldName: "   ",
+            title: "Blank",
+            packetID: nil,
+            sampleValue: nil
+        )) == .invalid)
+    }
+
+    @Test func duplicateProtocolFieldRevealsExistingColumn() throws {
+        let service = PacketCustomColumnService()
+        let first = try #require(service.createColumn(from: PacketCustomColumnRequest(
+            fieldName: "ip.src",
+            title: "Source Address",
+            packetID: nil,
+            sampleValue: nil
+        )).column)
+
+        let duplicate = service.createColumn(from: PacketCustomColumnRequest(
+            fieldName: "IP.SRC",
+            title: "Different Title",
+            packetID: nil,
+            sampleValue: nil
+        ))
+
+        #expect(duplicate == .existing(first))
+        #expect(service.columns == [first])
+    }
+
+    @Test func resolvedValueWalksChildrenAndUsesDisplayValueBeforeRawValue() {
+        let inspection = Self.inspection(detailNodes: [
+            PacketDetailNode(id: "frame", name: "Frame", fieldName: "frame", children: [
+                PacketDetailNode(id: "ip", name: "IP", fieldName: "ip", children: [
+                    PacketDetailNode(
+                        id: "ip.src",
+                        name: "Source Address",
+                        fieldName: "ip.src",
+                        value: "10.0.0.1",
+                        rawValue: "0a000001"
+                    ),
+                ]),
+            ]),
+        ])
+
+        #expect(PacketCustomColumnService.resolvedValue(fieldName: "IP.SRC", in: inspection) == "10.0.0.1")
+    }
+
+    @Test func resolvedValueFallsBackToRawValueAndMissingFieldIsEmpty() {
+        let inspection = Self.inspection(detailNodes: [
+            PacketDetailNode(
+                id: "tcp.flags.syn",
+                name: "Syn",
+                fieldName: "tcp.flags.syn",
+                value: nil,
+                rawValue: "02"
+            ),
+        ])
+
+        #expect(PacketCustomColumnService.resolvedValue(fieldName: "tcp.flags.syn", in: inspection) == "02")
+        #expect(PacketCustomColumnService.resolvedValue(fieldName: "tls.handshake.type", in: inspection) == "")
+    }
+
+    @Test func cacheStoresEmptyValuesAndCanReset() throws {
+        let service = PacketCustomColumnService()
+        let column = try #require(service.createColumn(from: PacketCustomColumnRequest(
+            fieldName: "dns.qry.name",
+            title: "Name",
+            packetID: nil,
+            sampleValue: nil
+        )).column)
+
+        #expect(!service.hasResolvedValue(columnIdentifier: column.identifier, packetID: 7))
+
+        service.storeValue("", columnIdentifier: column.identifier, packetID: 7)
+        #expect(service.hasResolvedValue(columnIdentifier: column.identifier, packetID: 7))
+        #expect(service.value(columnIdentifier: column.identifier, packetID: 7) == "")
+
+        service.reset()
+        #expect(service.columns.isEmpty)
+        #expect(!service.hasResolvedValue(columnIdentifier: column.identifier, packetID: 7))
+    }
+
+    @Test func unresolvedPacketIDsUsePreferredVisibleRowsFirst() {
+        let column = PacketCustomColumn(identifier: "custom.field.ip.src", fieldName: "ip.src", title: "Source")
+        let service = PacketCustomColumnService(columns: [column])
+        let rows = [1, 2, 3, 4].map { PacketTableRow(packet: Self.packet(packetNumber: UInt64($0))) }
+
+        service.storeValue("cached", columnIdentifier: column.identifier, packetID: 3)
+
+        let unresolvedIDs = service.unresolvedPacketIDs(
+            for: column,
+            rows: rows,
+            preferredPacketIDs: [4, 2, 99, 4]
+        )
+
+        #expect(unresolvedIDs == [4, 2, 1])
+    }
+
+    private static func packet(packetNumber: UInt64) -> PacketSummary {
+        PacketSummary(
+            packetNumber: packetNumber,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(packetNumber)),
+            source: .offline,
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+            ),
+            originalLength: 64,
+            capturedLength: 64,
+            infoSummary: "Packet \(packetNumber)",
+            layers: [PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false)
+        )
+    }
+
+    private static func inspection(detailNodes: [PacketDetailNode]) -> PacketInspection {
+        PacketInspection(
+            packetID: 1,
+            packetNumber: 1,
+            rawBytes: Data(),
+            detailNodes: detailNodes,
+            decodeStatus: PacketDecodeStatus(kind: .complete)
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketCustomColumnServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCustomColumnServiceTests.swift
@@ -125,6 +125,20 @@ struct PacketCustomColumnServiceTests {
         #expect(unresolvedIDs == [4, 2, 1])
     }
 
+    @Test func unresolvedPacketIDsForBoundedListDoNotExpandBeyondInput() {
+        let column = PacketCustomColumn(identifier: "custom.field.ip.src", fieldName: "ip.src", title: "Source")
+        let service = PacketCustomColumnService(columns: [column])
+
+        service.storeValue("cached", columnIdentifier: column.identifier, packetID: 2)
+
+        let unresolvedIDs = service.unresolvedPacketIDs(
+            for: column,
+            packetIDs: [2, 4, 4, 1]
+        )
+
+        #expect(unresolvedIDs == [4, 1])
+    }
+
     private static func packet(packetNumber: UInt64) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
@@ -184,13 +184,14 @@ struct PacketInspectorTreeViewModelTests {
 
         controller.menuNeedsUpdate(menu)
 
-        #expect(menu.items.count == 6)
+        #expect(menu.items.count == 7)
         let copyItem = menu.items[0]
-        let separatorItem = menu.items[1]
-        let expandAllItem = menu.items[2]
-        let collapseAllItem = menu.items[3]
-        let secondSeparatorItem = menu.items[4]
-        let filterItem = menu.items[5]
+        let createColumnItem = menu.items[1]
+        let separatorItem = menu.items[2]
+        let expandAllItem = menu.items[3]
+        let collapseAllItem = menu.items[4]
+        let secondSeparatorItem = menu.items[5]
+        let filterItem = menu.items[6]
         let copySubmenu = try #require(copyItem.submenu)
         let copySubmenuTitles = copySubmenu.items.map(\.title)
 
@@ -216,6 +217,9 @@ struct PacketInspectorTreeViewModelTests {
         #expect(copySubmenu.items[2].isSeparatorItem)
         let byteCopyItemsEnabled = copySubmenu.items.dropFirst(3).allSatisfy { $0.isEnabled }
         #expect(byteCopyItemsEnabled)
+        #expect(createColumnItem.title == "Create Column")
+        #expect(createColumnItem.isEnabled)
+        #expect(createColumnItem.toolTip == "Create a packet table column from the selected packet detail field.")
         #expect(separatorItem.isSeparatorItem)
         #expect(expandAllItem.title == "Expand All")
         #expect(expandAllItem.isEnabled)
@@ -1137,8 +1141,16 @@ struct PacketInspectorTreeViewModelTests {
 
 private final class PacketInspectorDelegateSpy: PacketInspectorViewControllerDelegate {
     var selectedDetailNodeID: String?
+    var customColumnRequest: PacketCustomColumnRequest?
 
     func packetInspectorViewController(_ controller: PacketInspectorViewController, didSelectDetailNode identifier: String?) {
         selectedDetailNodeID = identifier
+    }
+
+    func packetInspectorViewController(
+        _ controller: PacketInspectorViewController,
+        didRequestCreateCustomColumn request: PacketCustomColumnRequest
+    ) {
+        customColumnRequest = request
     }
 }

--- a/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketInspectorTreeViewModelTests.swift
@@ -184,14 +184,15 @@ struct PacketInspectorTreeViewModelTests {
 
         controller.menuNeedsUpdate(menu)
 
-        #expect(menu.items.count == 7)
+        #expect(menu.items.count == 8)
         let copyItem = menu.items[0]
-        let createColumnItem = menu.items[1]
-        let separatorItem = menu.items[2]
-        let expandAllItem = menu.items[3]
-        let collapseAllItem = menu.items[4]
-        let secondSeparatorItem = menu.items[5]
-        let filterItem = menu.items[6]
+        let createColumnSeparatorItem = menu.items[1]
+        let createColumnItem = menu.items[2]
+        let separatorItem = menu.items[3]
+        let expandAllItem = menu.items[4]
+        let collapseAllItem = menu.items[5]
+        let secondSeparatorItem = menu.items[6]
+        let filterItem = menu.items[7]
         let copySubmenu = try #require(copyItem.submenu)
         let copySubmenuTitles = copySubmenu.items.map(\.title)
 
@@ -217,6 +218,7 @@ struct PacketInspectorTreeViewModelTests {
         #expect(copySubmenu.items[2].isSeparatorItem)
         let byteCopyItemsEnabled = copySubmenu.items.dropFirst(3).allSatisfy { $0.isEnabled }
         #expect(byteCopyItemsEnabled)
+        #expect(createColumnSeparatorItem.isSeparatorItem)
         #expect(createColumnItem.title == "Create Column")
         #expect(createColumnItem.isEnabled)
         #expect(createColumnItem.toolTip == "Create a packet table column from the selected packet detail field.")

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableColumnServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableColumnServiceTests.swift
@@ -78,6 +78,29 @@ struct PacketTableColumnServiceTests {
         #expect(!service.isColumnVisible(identifier: "custom.tcpFlags"))
     }
 
+    @Test func appendsCustomColumnsAfterBuiltInsAndIgnoresDuplicateFields() {
+        let service = PacketTableColumnService()
+        let customColumns = [
+            PacketCustomColumn(identifier: "custom.field.ip.src", fieldName: "ip.src", title: "Source Address"),
+            PacketCustomColumn(identifier: "custom.field.tcp.srcport", fieldName: "tcp.srcport", title: "TCP Source Port"),
+        ]
+
+        service.setCustomColumns(customColumns)
+
+        #expect(service.definitions.suffix(2).map(\.identifier) == [
+            "custom.field.ip.src",
+            "custom.field.tcp.srcport",
+        ])
+        #expect(!service.isColumnVisible(identifier: "custom.field.ip.src"))
+        #expect(service.setColumnVisibility(identifier: "custom.field.ip.src", isVisible: true))
+        #expect(service.isColumnVisible(identifier: "custom.field.ip.src"))
+
+        service.setCustomColumns([customColumns[0]])
+
+        #expect(service.definition(identifier: "custom.field.tcp.srcport") == nil)
+        #expect(service.isColumnVisible(identifier: "custom.field.ip.src"))
+    }
+
     @Test func preventsHidingTheLastVisibleColumn() {
         let service = PacketTableColumnService(definitions: [
             .builtIn(.number, title: "#", defaultWidth: 68, minimumWidth: 52),
@@ -121,10 +144,11 @@ struct PacketTableColumnServiceTests {
     @Test func layoutStoreRoundTripsAndClearsColumnLayout() throws {
         let defaults = Self.makeUserDefaults()
         let store = PacketTableColumnLayoutStore(defaults: defaults)
+        let customColumn = PacketCustomColumn(identifier: "custom.field.ip.src", fieldName: "ip.src", title: "Source Address")
         let layout = PacketTableColumnLayout(columns: [
             .init(identifier: "number", isVisible: true, width: 70),
             .init(identifier: "sourcePort", isVisible: false, width: 92),
-        ])
+        ], customColumns: [customColumn])
 
         #expect(store.load() == nil)
 
@@ -135,11 +159,32 @@ struct PacketTableColumnServiceTests {
         #expect(store.load() == nil)
     }
 
+    @Test func layoutDecodesOlderPayloadWithoutCustomColumns() throws {
+        let data = try #require("""
+        {
+          "version": 1,
+          "columns": [
+            { "identifier": "number", "isVisible": true, "width": 70 }
+          ]
+        }
+        """.data(using: .utf8))
+
+        let layout = try JSONDecoder().decode(PacketTableColumnLayout.self, from: data)
+
+        #expect(layout.columns == [
+            PacketTableColumnLayout.Column(identifier: "number", isVisible: true, width: 70),
+        ])
+        #expect(layout.customColumns.isEmpty)
+    }
+
     @MainActor
     @Test func columnVisibilityMenuUsesNativeCheckedItemsAndResetAtBottom() throws {
         let service = PacketTableColumnService(definitions: [
             .builtIn(.number, title: "#", defaultWidth: 68, minimumWidth: 52),
             .builtIn(.time, title: "Time", defaultWidth: 112, minimumWidth: 96, isDefaultVisible: false),
+        ])
+        service.setCustomColumns([
+            PacketCustomColumn(identifier: "custom.field.ip.src", fieldName: "ip.src", title: "Source Address"),
         ])
         let controller = PacketTableColumnVisibilityMenuController(columnService: service)
         let actionHandler = ColumnMenuActionHandler()
@@ -154,8 +199,8 @@ struct PacketTableColumnServiceTests {
         let resetItem = try #require(menu.items.last)
 
         #expect(menu.showsStateColumn)
-        #expect(visibleTitles == ["#", "Time", "Reset All Columns"])
-        #expect(menu.items[2].isSeparatorItem)
+        #expect(visibleTitles == ["#", "Time", "Source Address", "Reset All Columns"])
+        #expect(menu.items[3].isSeparatorItem)
         #expect(numberItem.view == nil)
         #expect(timeItem.view == nil)
         #expect(resetItem.view == nil)

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -192,6 +192,53 @@ struct PacketTableMenuLogicTests {
     }
 
     @MainActor
+    @Test func packetTableCreatesPersistsAndResetsCustomColumns() throws {
+        let defaults = Self.makeUserDefaults()
+        let controller = PacketTableViewController(configuration: AppConfiguration(defaults: defaults))
+        controller.loadViewIfNeeded()
+        let tableView = try Self.tableView(in: controller)
+
+        controller.createCustomColumn(from: PacketCustomColumnRequest(
+            fieldName: "ip.src",
+            title: "Source Address",
+            packetID: 1,
+            sampleValue: "10.0.0.1"
+        ))
+        controller.createCustomColumn(from: PacketCustomColumnRequest(
+            fieldName: "IP.SRC",
+            title: "Duplicate Source",
+            packetID: 1,
+            sampleValue: "10.0.0.1"
+        ))
+
+        let customColumns = tableView.tableColumns.filter { $0.identifier.rawValue == "custom.field.ip.src" }
+        let customColumn = try #require(customColumns.first)
+
+        #expect(customColumns.count == 1)
+        #expect(!customColumn.isHidden)
+        #expect(tableView.tableColumns.last?.identifier.rawValue == "custom.field.ip.src")
+
+        let restoredController = PacketTableViewController(configuration: AppConfiguration(defaults: defaults))
+        restoredController.loadViewIfNeeded()
+        let restoredTableView = try Self.tableView(in: restoredController)
+        let restoredCustomColumn = try #require(restoredTableView.tableColumn(
+            withIdentifier: NSUserInterfaceItemIdentifier("custom.field.ip.src")
+        ))
+
+        #expect(restoredTableView.tableColumns.last?.identifier.rawValue == "custom.field.ip.src")
+        #expect(!restoredCustomColumn.isHidden)
+
+        restoredController.resetPacketTableColumnsFromMenu(nil)
+
+        let resetController = PacketTableViewController(configuration: AppConfiguration(defaults: defaults))
+        resetController.loadViewIfNeeded()
+        let resetTableView = try Self.tableView(in: resetController)
+
+        #expect(resetTableView.tableColumn(withIdentifier: NSUserInterfaceItemIdentifier("custom.field.ip.src")) == nil)
+        #expect(Set(resetTableView.tableColumns.map { $0.identifier.rawValue }) == Set(PacketTableColumnService.defaultDefinitions.map(\.identifier)))
+    }
+
+    @MainActor
     @Test func contextMenuItemsIncludeCopyRowsAsSubmenuAndTooltips() throws {
         let controller = PacketTableContextMenuController()
         let stateProvider = MenuStateProvider(state: PacketTableMenuState(

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -56,6 +56,22 @@ struct PacketTableMenuLogicTests {
         #expect(state.exportEnabled)
     }
 
+    @Test func customClickedColumnEnablesCopyCellWithRawIdentifier() {
+        let rows = [PacketTableRow(packet: makePacket(packetNumber: 1))]
+
+        let state = PacketTableMenuLogic.state(
+            rows: rows,
+            selectedRowIndexes: IndexSet(),
+            clickedRowIndex: 0,
+            clickedColumnIdentifier: "custom.field.ip.src"
+        )
+
+        #expect(state.targetRows == [0])
+        #expect(state.clickedColumn == .unknown)
+        #expect(state.clickedColumnIdentifier == "custom.field.ip.src")
+        #expect(state.copyCellEnabled)
+    }
+
     @Test func copyFormatterUsesCSVRowsAndClickedColumnCells() {
         let rows = [
             PacketTableRow(packet: makePacket(packetNumber: 1, infoSummary: "Hello, world")),
@@ -64,12 +80,17 @@ struct PacketTableMenuLogicTests {
 
         let rowCopy = PacketTableCopyFormatter.rows(rows, format: .csv)
         let cellCopy = PacketTableCopyFormatter.csvCells(rows, column: .summary)
+        let customCellCopy = PacketTableCopyFormatter.csvValues(["10.0.0.1", "Hello, world"])
 
         #expect(rowCopy.contains("\"Hello, world\""))
         #expect(rowCopy.split(separator: "\n").count == 2)
         #expect(cellCopy == """
         "Hello, world"
         Plain
+        """)
+        #expect(customCellCopy == """
+        10.0.0.1
+        "Hello, world"
         """)
     }
 
@@ -244,6 +265,7 @@ struct PacketTableMenuLogicTests {
         let stateProvider = MenuStateProvider(state: PacketTableMenuState(
             targetRows: [0],
             clickedColumn: .source,
+            clickedColumnIdentifier: "source",
             copyRowEnabled: true,
             copyCellEnabled: true,
             pinEnabled: true,


### PR DESCRIPTION
## Summary

- Add a custom packet-detail column service with duplicate detection, stable custom column identifiers, value extraction, caching, and reset behavior.
- Wire the inspector context menu to create columns from selected packet detail fields and reveal them in the main packet table.
- Persist built-in and custom column layout state, include custom columns in the header visibility menu, and remove custom columns on reset.
- Resolve custom column values through callback-based packet inspection without changing the selected packet.

## Validation

- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`

## AI Assistance

This PR was substantially assisted by Codex and should be reviewed by the maintainer before merging.
