### PR TITLE
[codex] Handle Wireshark critical exceptions

### DIFF
--- a/PcapPlusPlusCore/Dissection/WiresharkCriticalExceptionLogger.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkCriticalExceptionLogger.swift
@@ -1,0 +1,202 @@
+//
+//  WiresharkCriticalExceptionLogger.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/7/26.
+//
+
+import Foundation
+@_implementationOnly import TCPViewerWiresharkEpanShim
+
+struct WiresharkCriticalExceptionReport: Equatable {
+    let operation: String
+    let exceptionName: String
+    let exceptionGroup: UInt
+    let exceptionCode: UInt
+    let packetIdentifier: UInt64?
+    let reason: String
+
+    init(
+        operation: String,
+        exceptionName: String,
+        exceptionGroup: UInt,
+        exceptionCode: UInt,
+        packetIdentifier: UInt64?,
+        reason: String
+    ) {
+        self.operation = operation
+        self.exceptionName = exceptionName
+        self.exceptionGroup = exceptionGroup
+        self.exceptionCode = exceptionCode
+        self.packetIdentifier = packetIdentifier
+        self.reason = reason
+    }
+
+    init(_ report: TCPViewerWiresharkExceptionReport) {
+        self.init(
+            operation: Self.string(report.operation) ?? "Wireshark operation",
+            exceptionName: Self.string(report.exceptionName) ?? "Unknown",
+            exceptionGroup: UInt(report.exceptionGroup),
+            exceptionCode: UInt(report.exceptionCode),
+            packetIdentifier: report.hasPacketIdentifier ? report.packetIdentifier : nil,
+            reason: Self.string(report.reason) ?? "Wireshark raised a critical exception."
+        )
+    }
+
+    private static func string(_ pointer: UnsafePointer<CChar>?) -> String? {
+        guard let pointer else {
+            return nil
+        }
+        let value = String(cString: pointer).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}
+
+final class WiresharkCriticalExceptionLogger {
+    static let shared = WiresharkCriticalExceptionLogger()
+
+    static let appFolderName = "TCPViewer"
+    static let logsFolderName = "Logs"
+    static let logFileName = "wireshark-critical-exceptions.log"
+
+    private let fileManager: FileManager
+    private let applicationSupportBaseURL: URL
+    private let bundleInfo: [String: Any]
+    private let operatingSystemVersion: String
+    private let architecture: String
+    private let dateProvider: () -> Date
+    private let queue = DispatchQueue(label: "com.proxyman.tcpviewer.PcapPlusPlusCore.WiresharkCriticalExceptionLogger")
+
+    init(
+        fileManager: FileManager = .default,
+        applicationSupportBaseURL: URL? = nil,
+        bundleInfo: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        operatingSystemVersion: String = ProcessInfo.processInfo.operatingSystemVersionString,
+        architecture: String = WiresharkCriticalExceptionLogger.currentArchitecture(),
+        dateProvider: @escaping () -> Date = Date.init
+    ) {
+        self.fileManager = fileManager
+        self.applicationSupportBaseURL = applicationSupportBaseURL ?? Self.defaultApplicationSupportBaseURL(fileManager: fileManager)
+        self.bundleInfo = bundleInfo
+        self.operatingSystemVersion = operatingSystemVersion
+        self.architecture = architecture
+        self.dateProvider = dateProvider
+    }
+
+    var logsDirectoryURL: URL {
+        applicationSupportBaseURL
+            .appendingPathComponent(Self.appFolderName, isDirectory: true)
+            .appendingPathComponent(Self.logsFolderName, isDirectory: true)
+    }
+
+    var logFileURL: URL {
+        logsDirectoryURL.appendingPathComponent(Self.logFileName)
+    }
+
+    @discardableResult
+    func createLogsDirectoryIfNeeded() throws -> URL {
+        try fileManager.createDirectory(at: logsDirectoryURL, withIntermediateDirectories: true)
+        return logsDirectoryURL
+    }
+
+    @discardableResult
+    func log(_ report: WiresharkCriticalExceptionReport) throws -> URL {
+        try queue.sync {
+            try createLogsDirectoryIfNeeded()
+            let entry = logEntry(for: report)
+            let data = Data(entry.utf8)
+            if fileManager.fileExists(atPath: logFileURL.path) {
+                let handle = try FileHandle(forWritingTo: logFileURL)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: data)
+            } else {
+                try data.write(to: logFileURL, options: .atomic)
+            }
+            return logFileURL
+        }
+    }
+
+    private func logEntry(for report: WiresharkCriticalExceptionReport) -> String {
+        // Keep this support log narrow and free of packet content or user-identifying paths.
+        let timestamp = ISO8601DateFormatter().string(from: dateProvider())
+        let packetLine = report.packetIdentifier.map { "Packet Identifier: \($0)" } ?? "Packet Identifier: unavailable"
+        return """
+        ---
+        Timestamp: \(timestamp)
+        App Name: \(appName)
+        App Version: \(appVersion)
+        Build Version: \(buildVersion)
+        Bundle Identifier: \(bundleIdentifier)
+        macOS: \(operatingSystemVersion)
+        Architecture: \(architecture)
+        Operation: \(report.operation)
+        Exception: \(report.exceptionName)
+        Exception Group: \(report.exceptionGroup)
+        Exception Code: \(report.exceptionCode)
+        \(packetLine)
+        Reason: \(report.reason)
+
+        """
+    }
+
+    private var appName: String {
+        firstNonEmptyString(in: bundleInfo, keys: ["CFBundleDisplayName", "CFBundleName", "CFBundleExecutable"]) ?? "TCP Viewer"
+    }
+
+    private var appVersion: String {
+        nonEmpty(bundleInfo["CFBundleShortVersionString"] as? String) ?? "Unknown"
+    }
+
+    private var buildVersion: String {
+        nonEmpty(bundleInfo["CFBundleVersion"] as? String) ?? "Unknown"
+    }
+
+    private var bundleIdentifier: String {
+        nonEmpty(bundleInfo["CFBundleIdentifier"] as? String) ?? "Unknown"
+    }
+
+    private func firstNonEmptyString(in bundleInfo: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = nonEmpty(bundleInfo[key] as? String) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let trimmedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmedValue.isEmpty else {
+            return nil
+        }
+        return trimmedValue
+    }
+
+    private static func defaultApplicationSupportBaseURL(fileManager: FileManager) -> URL {
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+    }
+
+    private static func currentArchitecture() -> String {
+        #if arch(arm64)
+        return "arm64"
+        #elseif arch(x86_64)
+        return "x86_64"
+        #else
+        return "Unknown"
+        #endif
+    }
+}
+
+#if DEBUG
+enum WiresharkExceptionHandlingTestProbe {
+    static func caughtExceptionReport() -> WiresharkCriticalExceptionReport? {
+        guard let reportPointer = TCPViewerWiresharkTestCopyCaughtExceptionReport() else {
+            return nil
+        }
+        defer { TCPViewerWiresharkExceptionReportDestroy(reportPointer) }
+        return WiresharkCriticalExceptionReport(reportPointer.pointee)
+    }
+}
+#endif

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
@@ -22,29 +22,39 @@ struct WiresharkPacketInspectionFields {
 
 final class WiresharkEpanSession {
     private let handle: OpaquePointer
+    private let criticalExceptionLogger: WiresharkCriticalExceptionLogger
 
-    init(disabled: Bool = false) throws {
+    init(disabled: Bool = false, criticalExceptionLogger: WiresharkCriticalExceptionLogger = .shared) throws {
+        self.criticalExceptionLogger = criticalExceptionLogger
         guard let createdHandle = TCPViewerWiresharkSessionCreate(disabled) else {
             throw NativeNSError(.unavailableFeature, "Wireshark libwireshark backend could not be created.")
         }
 
         guard TCPViewerWiresharkSessionIsAvailable(createdHandle) else {
+            if let criticalError = Self.criticalExceptionErrorIfNeeded(for: createdHandle, logger: criticalExceptionLogger) {
+                TCPViewerWiresharkSessionDestroy(createdHandle)
+                throw criticalError
+            }
             let reason = Self.string(TCPViewerWiresharkSessionUnavailableReason(createdHandle))
                 ?? "Wireshark libwireshark backend is unavailable."
             TCPViewerWiresharkSessionDestroy(createdHandle)
             throw NativeNSError(.unavailableFeature, reason)
         }
-
         self.handle = createdHandle
     }
 
     deinit {
+        TCPViewerWiresharkSessionReleaseResources(handle)
+        logPendingCriticalExceptions()
         TCPViewerWiresharkSessionDestroy(handle)
     }
 
     func observe(_ record: NativePacketRecord) throws {
         try withContext(for: record) { context in
             guard TCPViewerWiresharkSessionObservePacket(handle, context) else {
+                if let criticalError = criticalExceptionErrorIfNeeded() {
+                    throw criticalError
+                }
                 throw unavailableError()
             }
         }
@@ -52,6 +62,9 @@ final class WiresharkEpanSession {
 
     func finishFirstPass() throws {
         guard TCPViewerWiresharkSessionFinishFirstPass(handle) else {
+            if let criticalError = criticalExceptionErrorIfNeeded() {
+                throw criticalError
+            }
             throw unavailableError()
         }
     }
@@ -65,6 +78,9 @@ final class WiresharkEpanSession {
 
             let result = resultPointer.pointee
             guard result.succeeded else {
+                if let criticalError = criticalExceptionErrorIfNeeded() {
+                    throw criticalError
+                }
                 throw unavailableError(Self.string(result.errorMessage))
             }
 
@@ -85,6 +101,9 @@ final class WiresharkEpanSession {
 
             let result = resultPointer.pointee
             guard result.succeeded else {
+                if let criticalError = criticalExceptionErrorIfNeeded() {
+                    throw criticalError
+                }
                 throw unavailableError(Self.string(result.errorMessage))
             }
 
@@ -135,6 +154,38 @@ final class WiresharkEpanSession {
             ?? Self.string(TCPViewerWiresharkSessionUnavailableReason(handle))
             ?? "Wireshark libwireshark backend is unavailable."
         return NativeNSError(.unavailableFeature, reason)
+    }
+
+    private func criticalExceptionErrorIfNeeded() -> NSError? {
+        Self.criticalExceptionErrorIfNeeded(for: handle, logger: criticalExceptionLogger)
+    }
+
+    private static func criticalExceptionErrorIfNeeded(for handle: OpaquePointer, logger: WiresharkCriticalExceptionLogger) -> NSError? {
+        let reports = copyPendingCriticalExceptions(for: handle)
+        guard let report = reports.first else {
+            return nil
+        }
+        log(reports, with: logger)
+        return NativeNSError(.criticalWiresharkException, report.reason)
+    }
+
+    private func logPendingCriticalExceptions() {
+        Self.log(Self.copyPendingCriticalExceptions(for: handle), with: criticalExceptionLogger)
+    }
+
+    private static func log(_ reports: [WiresharkCriticalExceptionReport], with logger: WiresharkCriticalExceptionLogger) {
+        for report in reports {
+            _ = try? logger.log(report)
+        }
+    }
+
+    private static func copyPendingCriticalExceptions(for handle: OpaquePointer) -> [WiresharkCriticalExceptionReport] {
+        var reports: [WiresharkCriticalExceptionReport] = []
+        while let reportPointer = TCPViewerWiresharkSessionCopyNextCriticalException(handle) {
+            reports.append(WiresharkCriticalExceptionReport(reportPointer.pointee))
+            TCPViewerWiresharkExceptionReportDestroy(reportPointer)
+        }
+        return reports
     }
 
     private func byteViews(from result: TCPViewerWiresharkInspectionResult) -> [PCPPNativePacketByteViewDescriptor] {
@@ -209,3 +260,16 @@ final class WiresharkEpanSession {
         return value.isEmpty ? nil : value
     }
 }
+
+#if DEBUG
+extension WiresharkEpanSession {
+    func testInjectCriticalException() throws {
+        guard TCPViewerWiresharkSessionTestInjectCriticalException(handle) else {
+            if let criticalError = criticalExceptionErrorIfNeeded() {
+                throw criticalError
+            }
+            throw unavailableError()
+        }
+    }
+}
+#endif

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
@@ -24,6 +24,7 @@
 #include <epan/column-utils.h>
 #include <epan/epan.h>
 #include <epan/epan_dissect.h>
+#include <epan/exceptions.h>
 #include <epan/frame_data_sequence.h>
 #include <epan/packet.h>
 #include <epan/prefs.h>
@@ -134,6 +135,17 @@ struct PacketContextView {
     uint32_t sectionNumber = 0;
 };
 
+struct WiresharkCriticalException {
+    bool isCriticalException = true;
+    unsigned long exceptionGroup = 0;
+    unsigned long exceptionCode = 0;
+    uint64_t packetIdentifier = 0;
+    bool hasPacketIdentifier = false;
+    std::string operation;
+    std::string exceptionName;
+    std::string reason;
+};
+
 std::mutex &WiresharkAPIMutex()
 {
     // libwireshark has process-wide registries, so all epan entry points share one lock.
@@ -176,6 +188,97 @@ char *CopyCString(const std::string &value, bool allowNull = true)
         return nullptr;
     }
     return strdup(value.c_str());
+}
+
+const char *WiresharkExceptionName(unsigned long code)
+{
+    switch (code) {
+        case BoundsError:
+            return "BoundsError";
+        case ContainedBoundsError:
+            return "ContainedBoundsError";
+        case ReportedBoundsError:
+            return "ReportedBoundsError";
+        case FragmentBoundsError:
+            return "FragmentBoundsError";
+        case TypeError:
+            return "TypeError";
+        case DissectorError:
+            return "DissectorError";
+        case ScsiBoundsError:
+            return "ScsiBoundsError";
+        case OutOfMemoryError:
+            return "OutOfMemoryError";
+        case ReassemblyError:
+            return "ReassemblyError";
+        default:
+            return "Unknown";
+    }
+}
+
+std::string CriticalExceptionReason(const std::string &operation)
+{
+    return "Wireshark raised a critical exception while " + operation + ". TCP Viewer stopped this operation to keep the app running.";
+}
+
+WiresharkCriticalException MakeCriticalException(const char *operation, except_t *exception, std::optional<uint64_t> packetIdentifier)
+{
+    WiresharkCriticalException report;
+    report.exceptionGroup = exception == nullptr ? 0 : except_group(exception);
+    report.exceptionCode = exception == nullptr ? 0 : except_code(exception);
+    report.operation = operation == nullptr || operation[0] == '\0' ? "running Wireshark" : operation;
+    report.exceptionName = WiresharkExceptionName(report.exceptionCode);
+    report.reason = CriticalExceptionReason(report.operation);
+    if (packetIdentifier.has_value()) {
+        report.packetIdentifier = *packetIdentifier;
+        report.hasPacketIdentifier = true;
+    }
+    return report;
+}
+
+template <typename Body>
+std::optional<WiresharkCriticalException> CatchWiresharkException(const char *operation, std::optional<uint64_t> packetIdentifier, Body body)
+{
+    static const except_id_t catchSpec[] = {{XCEPT_GROUP_WIRESHARK, XCEPT_CODE_ANY}};
+    struct except_stacknode stackNode;
+    struct except_catch catcher;
+    std::optional<WiresharkCriticalException> report;
+
+    except_setup_try(&stackNode, &catcher, catchSpec, 1);
+    if (setjmp(catcher.except_jmp) == 0) {
+        body();
+    } else {
+        report = MakeCriticalException(operation, &catcher.except_obj, packetIdentifier);
+    }
+    except_free(catcher.except_obj.except_dyndata);
+    except_pop();
+    return report;
+}
+
+using WiresharkCriticalExceptionReports = std::vector<WiresharkCriticalException>;
+
+void AppendCriticalExceptionIfNeeded(WiresharkCriticalExceptionReports &reports, std::optional<WiresharkCriticalException> report)
+{
+    if (report.has_value()) {
+        reports.push_back(std::move(*report));
+    }
+}
+
+TCPViewerWiresharkExceptionReport *CopyExceptionReport(const WiresharkCriticalException &report)
+{
+    auto *copy = static_cast<TCPViewerWiresharkExceptionReport *>(std::calloc(1, sizeof(TCPViewerWiresharkExceptionReport)));
+    if (copy == nullptr) {
+        return nullptr;
+    }
+    copy->isCriticalException = report.isCriticalException;
+    copy->exceptionGroup = report.exceptionGroup;
+    copy->exceptionCode = report.exceptionCode;
+    copy->packetIdentifier = report.packetIdentifier;
+    copy->hasPacketIdentifier = report.hasPacketIdentifier;
+    copy->operation = CopyCString(report.operation);
+    copy->exceptionName = CopyCString(report.exceptionName);
+    copy->reason = CopyCString(report.reason, false);
+    return copy;
 }
 
 std::string HexBytes(const uint8_t *bytes, size_t length)
@@ -283,24 +386,56 @@ struct WiresharkSessionResources {
     std::unique_ptr<packet_provider_data> provider;
 };
 
-void FreeWiresharkSessionResources(WiresharkSessionResources &resources)
+std::optional<WiresharkCriticalException> FreeEpanDissect(epan_dissect_t *&dissect, const char *operation, std::optional<uint64_t> packetIdentifier)
 {
+    if (dissect == nullptr) {
+        return std::nullopt;
+    }
+    auto *dissectToFree = dissect;
+    dissect = nullptr;
+    return CatchWiresharkException(operation, packetIdentifier, [dissectToFree] {
+        epan_dissect_free(dissectToFree);
+    });
+}
+
+WiresharkCriticalExceptionReports FreeWiresharkSessionResources(WiresharkSessionResources &resources)
+{
+    WiresharkCriticalExceptionReports reports;
     if (resources.epan != nullptr) {
-        epan_free(resources.epan);
+        auto *epan = resources.epan;
+        AppendCriticalExceptionIfNeeded(
+            reports,
+            CatchWiresharkException("freeing Wireshark session", std::nullopt, [epan] {
+                epan_free(epan);
+            })
+        );
         resources.epan = nullptr;
     }
     if (resources.provider == nullptr) {
-        return;
+        return reports;
     }
     if (resources.provider->frames != nullptr) {
-        free_frame_data_sequence(resources.provider->frames);
+        auto *frames = resources.provider->frames;
+        AppendCriticalExceptionIfNeeded(
+            reports,
+            CatchWiresharkException("freeing Wireshark frame storage", std::nullopt, [frames] {
+                free_frame_data_sequence(frames);
+            })
+        );
         resources.provider->frames = nullptr;
     }
     if (resources.provider->frames_modified_blocks != nullptr) {
-        g_tree_destroy(resources.provider->frames_modified_blocks);
+        auto *blocks = resources.provider->frames_modified_blocks;
+        AppendCriticalExceptionIfNeeded(
+            reports,
+            CatchWiresharkException("freeing Wireshark frame metadata", std::nullopt, [blocks] {
+                g_tree_destroy(blocks);
+            })
+        );
         resources.provider->frames_modified_blocks = nullptr;
     }
     resources.provider.reset();
+    return reports;
 }
 
 class WiresharkRecord {
@@ -404,17 +539,6 @@ struct WiresharkSourceSet {
     std::unordered_map<const tvbuff_t *, std::string> idsByTVB;
     std::unordered_map<std::string, size_t> indexByID;
 };
-
-struct EpanDissectDeleter {
-    void operator()(epan_dissect_t *dissect) const
-    {
-        if (dissect != nullptr) {
-            epan_dissect_free(dissect);
-        }
-    }
-};
-
-using EpanDissectPtr = std::unique_ptr<epan_dissect_t, EpanDissectDeleter>;
 
 uint32_t FrameNumberForContext(const PacketContextView &context, uint64_t fallbackFrameNumber)
 {
@@ -882,23 +1006,88 @@ public:
 
     bool isAvailable() const { return available_; }
     const std::string &unavailableReason() const { return unavailableReason_; }
+    const std::optional<WiresharkCriticalException> &criticalException() const { return criticalException_; }
+    const WiresharkCriticalExceptionReports &criticalExceptionReports() const { return criticalExceptionReports_; }
 
 private:
+    void recordCriticalException(WiresharkCriticalException report)
+    {
+        if (!criticalException_.has_value()) {
+            criticalException_ = report;
+        }
+        criticalExceptionReports_.push_back(std::move(report));
+    }
+
+    void cleanupEpanAfterSetupFailure()
+    {
+        if (auto report = CatchWiresharkException("cleaning up Wireshark protocol registry after setup failure", std::nullopt, [] {
+                epan_cleanup();
+            })) {
+            recordCriticalException(std::move(*report));
+        }
+    }
+
+    void cleanupWiretapAfterSetupFailure()
+    {
+        if (auto report = CatchWiresharkException("cleaning up Wireshark Wiretap after setup failure", std::nullopt, [] {
+                wtap_cleanup();
+            })) {
+            recordCriticalException(std::move(*report));
+        }
+    }
+
     WiresharkRuntime()
     {
         std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
-        wtap_init(true);
+        if (except_init() == 0) {
+            available_ = false;
+            unavailableReason_ = "Wireshark exception handling failed to initialize.";
+            return;
+        }
+        initializedExceptions_ = true;
+        if (auto report = CatchWiresharkException("initializing Wireshark Wiretap", std::nullopt, [] {
+                wtap_init(true);
+            })) {
+            recordCriticalException(std::move(*report));
+            available_ = false;
+            unavailableReason_ = criticalException_->reason;
+            return;
+        }
         initializedWiretap_ = true;
-        if (!epan_init(nullptr, nullptr, true)) {
+        bool didInitializeEpan = false;
+        if (auto report = CatchWiresharkException("initializing Wireshark protocol registry", std::nullopt, [&didInitializeEpan] {
+                didInitializeEpan = epan_init(nullptr, nullptr, true);
+            })) {
+            recordCriticalException(std::move(*report));
+            available_ = false;
+            unavailableReason_ = criticalException_->reason;
+            cleanupEpanAfterSetupFailure();
+            cleanupWiretapAfterSetupFailure();
+            initializedWiretap_ = false;
+            return;
+        }
+        if (!didInitializeEpan) {
             available_ = false;
             unavailableReason_ = "Wireshark protocol registry failed to initialize.";
-            wtap_cleanup();
+            cleanupEpanAfterSetupFailure();
+            cleanupWiretapAfterSetupFailure();
             initializedWiretap_ = false;
             return;
         }
         initializedEpan_ = true;
-        epan_load_settings();
-        prefs_apply_all();
+        if (auto report = CatchWiresharkException("loading Wireshark settings", std::nullopt, [] {
+                epan_load_settings();
+                prefs_apply_all();
+            })) {
+            recordCriticalException(std::move(*report));
+            available_ = false;
+            unavailableReason_ = criticalException_->reason;
+            cleanupEpanAfterSetupFailure();
+            cleanupWiretapAfterSetupFailure();
+            initializedEpan_ = false;
+            initializedWiretap_ = false;
+            return;
+        }
         available_ = true;
         unavailableReason_.clear();
     }
@@ -907,17 +1096,31 @@ private:
     {
         std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
         if (initializedEpan_) {
-            epan_cleanup();
+            if (auto report = CatchWiresharkException("cleaning up Wireshark protocol registry", std::nullopt, [] {
+                    epan_cleanup();
+                })) {
+                recordCriticalException(std::move(*report));
+            }
         }
         if (initializedWiretap_) {
-            wtap_cleanup();
+            if (auto report = CatchWiresharkException("cleaning up Wireshark Wiretap", std::nullopt, [] {
+                    wtap_cleanup();
+                })) {
+                recordCriticalException(std::move(*report));
+            }
+        }
+        if (initializedExceptions_) {
+            except_deinit();
         }
     }
 
     bool available_ = false;
+    bool initializedExceptions_ = false;
     bool initializedWiretap_ = false;
     bool initializedEpan_ = false;
     std::string unavailableReason_ = kBackendUnavailableReason;
+    std::optional<WiresharkCriticalException> criticalException_;
+    WiresharkCriticalExceptionReports criticalExceptionReports_;
 };
 
 }  // namespace
@@ -927,13 +1130,14 @@ struct TCPViewerWiresharkSession {
     std::string unavailableReason = kBackendUnavailableReason;
     std::unique_ptr<packet_provider_data> provider;
     epan_t *epan = nullptr;
-    EpanDissectPtr firstPassDissect;
+    epan_dissect_t *firstPassDissect = nullptr;
     nstime_t elapsedTime = NSTIME_INIT_ZERO;
     frame_data referenceFrame{};
     uint32_t cumulativeBytes = 0;
     std::vector<PacketSnapshot> observedPackets;
     std::unordered_set<uint32_t> storedFrameNumbers;
     std::unordered_set<uint32_t> activeFrameNumbers;
+    std::deque<WiresharkCriticalException> pendingCriticalExceptions;
     bool disabled = false;
     bool firstPassFinished = false;
     bool backendAvailable = false;
@@ -955,6 +1159,9 @@ struct TCPViewerWiresharkSession {
         auto &runtime = WiresharkRuntime::shared();
         backendAvailable = runtime.isAvailable();
         unavailableReason = runtime.unavailableReason();
+        for (const auto &report : runtime.criticalExceptionReports()) {
+            pendingCriticalExceptions.push_back(report);
+        }
         if (!backendAvailable) {
             return;
         }
@@ -978,6 +1185,39 @@ struct TCPViewerWiresharkSession {
         return epan != nullptr && provider != nullptr && provider->frames != nullptr;
     }
 
+    void clearCriticalExceptionsLocked()
+    {
+        pendingCriticalExceptions.clear();
+    }
+
+    bool hasCriticalExceptionLocked() const
+    {
+        return !pendingCriticalExceptions.empty();
+    }
+
+    void recordCriticalExceptionLocked(WiresharkCriticalException report, bool updateUnavailableReason)
+    {
+        if (updateUnavailableReason || unavailableReason.empty()) {
+            unavailableReason = report.reason;
+        }
+        pendingCriticalExceptions.push_back(std::move(report));
+    }
+
+    void recordCriticalExceptionsLocked(WiresharkCriticalExceptionReports reports, bool updateUnavailableReason)
+    {
+        for (auto &report : reports) {
+            recordCriticalExceptionLocked(std::move(report), updateUnavailableReason);
+            updateUnavailableReason = false;
+        }
+    }
+
+    bool failWithCriticalExceptionLocked(WiresharkCriticalException report)
+    {
+        recordCriticalExceptionLocked(std::move(report), true);
+        releaseWiresharkResourcesLocked(unavailableReason, true);
+        return false;
+    }
+
     void resetActiveFrameStateLocked()
     {
         activeFrameNumbers.clear();
@@ -996,13 +1236,15 @@ struct TCPViewerWiresharkSession {
         if (activeSession() == this) {
             activeSession() = nullptr;
         }
-        firstPassDissect.reset();
+        if (auto report = FreeEpanDissect(firstPassDissect, "freeing Wireshark first-pass dissector", std::nullopt)) {
+            recordCriticalExceptionLocked(std::move(*report), false);
+        }
         WiresharkSessionResources resources{epan, std::move(provider)};
         epan = nullptr;
         if (!reason.empty()) {
             unavailableReason = reason;
         }
-        FreeWiresharkSessionResources(resources);
+        recordCriticalExceptionsLocked(FreeWiresharkSessionResources(resources), false);
         resetActiveFrameStateLocked();
         if (finishSession) {
             firstPassFinished = true;
@@ -1017,23 +1259,48 @@ struct TCPViewerWiresharkSession {
         }
 
         provider = std::make_unique<packet_provider_data>();
-        provider->frames = new_frame_data_sequence();
+        frame_data_sequence *frames = nullptr;
+        if (auto report = CatchWiresharkException("creating Wireshark frame storage", std::nullopt, [&frames] {
+                frames = new_frame_data_sequence();
+            })) {
+            provider.reset();
+            return failWithCriticalExceptionLocked(std::move(*report));
+        }
+        provider->frames = frames;
         if (provider->frames == nullptr) {
             unavailableReason = "Wireshark frame storage could not be created.";
             provider.reset();
             return false;
         }
 
-        epan = epan_new(provider.get(), &kPacketProviderFuncs);
+        epan_t *newEpan = nullptr;
+        auto *providerPointer = provider.get();
+        if (auto report = CatchWiresharkException("creating Wireshark session", std::nullopt, [&newEpan, providerPointer] {
+                newEpan = epan_new(providerPointer, &kPacketProviderFuncs);
+            })) {
+            WiresharkSessionResources resources{nullptr, std::move(provider)};
+            recordCriticalExceptionLocked(std::move(*report), true);
+            recordCriticalExceptionsLocked(FreeWiresharkSessionResources(resources), false);
+            releaseWiresharkResourcesLocked(unavailableReason, true);
+            return false;
+        }
+        epan = newEpan;
         if (epan == nullptr) {
             WiresharkSessionResources resources{nullptr, std::move(provider)};
-            FreeWiresharkSessionResources(resources);
+            recordCriticalExceptionsLocked(FreeWiresharkSessionResources(resources), false);
             unavailableReason = "Wireshark session could not be created.";
             return false;
         }
 
-        firstPassDissect.reset(epan_dissect_new(epan, false, false));
-        if (!firstPassDissect) {
+        epan_dissect_t *firstPass = nullptr;
+        auto *currentEpan = epan;
+        if (auto report = CatchWiresharkException("creating Wireshark first-pass dissector", std::nullopt, [&firstPass, currentEpan] {
+                firstPass = epan_dissect_new(currentEpan, false, false);
+            })) {
+            return failWithCriticalExceptionLocked(std::move(*report));
+        }
+        firstPassDissect = firstPass;
+        if (firstPassDissect == nullptr) {
             releaseWiresharkResourcesLocked("Wireshark could not allocate a first-pass dissector.", true);
             return false;
         }
@@ -1069,17 +1336,23 @@ struct TCPViewerWiresharkSession {
         }
 
         frame_data frame{};
-        frame_data_init(&frame, frameNumber, record.get(), cumulativeBytes, cumulativeBytes);
-        frame_data_set_before_dissect(&frame, &elapsedTime, &provider->ref, provider->prev_dis);
-        if (provider->ref == &frame) {
-            referenceFrame = frame;
-            provider->ref = &referenceFrame;
+        frame_data *storedFrame = nullptr;
+        if (auto report = CatchWiresharkException("running Wireshark first-pass dissection", context.packetIdentifier, [&] {
+                frame_data_init(&frame, frameNumber, record.get(), cumulativeBytes, cumulativeBytes);
+                frame_data_set_before_dissect(&frame, &elapsedTime, &provider->ref, provider->prev_dis);
+                if (provider->ref == &frame) {
+                    referenceFrame = frame;
+                    provider->ref = &referenceFrame;
+                }
+                epan_dissect_run(firstPassDissect, WTAP_FILE_TYPE_SUBTYPE_UNKNOWN, record.get(), &frame, nullptr);
+                frame_data_set_after_dissect(&frame, &cumulativeBytes);
+                storedFrame = frame_data_sequence_add(provider->frames, &frame);
+                epan_dissect_reset(firstPassDissect);
+            })) {
+            return failWithCriticalExceptionLocked(std::move(*report));
         }
-        epan_dissect_run(firstPassDissect.get(), WTAP_FILE_TYPE_SUBTYPE_UNKNOWN, record.get(), &frame, nullptr);
-        frame_data_set_after_dissect(&frame, &cumulativeBytes);
 
-        provider->prev_cap = provider->prev_dis = frame_data_sequence_add(provider->frames, &frame);
-        epan_dissect_reset(firstPassDissect.get());
+        provider->prev_cap = provider->prev_dis = storedFrame;
         activeFrameNumbers.insert(frameNumber);
         return true;
     }
@@ -1098,7 +1371,10 @@ struct TCPViewerWiresharkSession {
         }
 
         if (shouldFinishFirstPass) {
-            finishActiveFirstPassLocked();
+            if (!finishActiveFirstPassLocked()) {
+                firstPassFinished = shouldFinishFirstPass;
+                return false;
+            }
         }
         firstPassFinished = shouldFinishFirstPass;
         return true;
@@ -1158,13 +1434,16 @@ struct TCPViewerWiresharkSession {
         return true;
     }
 
-    void finishActiveFirstPassLocked()
+    bool finishActiveFirstPassLocked()
     {
-        firstPassDissect.reset();
+        if (auto report = FreeEpanDissect(firstPassDissect, "freeing Wireshark first-pass dissector", std::nullopt)) {
+            return failWithCriticalExceptionLocked(std::move(*report));
+        }
         if (provider != nullptr) {
             provider->prev_dis = nullptr;
             provider->prev_cap = nullptr;
         }
+        return true;
     }
 
     bool finishFirstPassLocked()
@@ -1175,7 +1454,9 @@ struct TCPViewerWiresharkSession {
         if (!ensureActiveSessionLocked()) {
             return false;
         }
-        finishActiveFirstPassLocked();
+        if (!finishActiveFirstPassLocked()) {
+            return false;
+        }
         firstPassFinished = true;
         return true;
     }
@@ -1210,44 +1491,91 @@ struct TCPViewerWiresharkSession {
         }
 
         WiresharkColumnInfo columnInfo;
-        EpanDissectPtr dissect(epan_dissect_new(epan, buildTree, buildTree));
-        if (!dissect) {
+        epan_dissect_t *rawDissect = nullptr;
+        auto *currentEpan = epan;
+        if (auto report = CatchWiresharkException("creating Wireshark second-pass dissector", context.packetIdentifier, [&rawDissect, currentEpan, buildTree] {
+                rawDissect = epan_dissect_new(currentEpan, buildTree, buildTree);
+            })) {
+            failWithCriticalExceptionLocked(std::move(*report));
+            result.fallbackReason = unavailableReason;
+            return result;
+        }
+        if (rawDissect == nullptr) {
             result.fallbackReason = "Wireshark could not allocate a second-pass dissector.";
             return result;
         }
 
+        auto failWithLocalCriticalException = [&](WiresharkCriticalException report) {
+            recordCriticalExceptionLocked(std::move(report), true);
+            if (auto cleanupReport = FreeEpanDissect(rawDissect, "freeing Wireshark second-pass dissector", context.packetIdentifier)) {
+                recordCriticalExceptionLocked(std::move(*cleanupReport), false);
+            }
+            releaseWiresharkResourcesLocked(unavailableReason, true);
+            result = WiresharkDissectionResult{};
+            result.fallbackReason = unavailableReason;
+        };
+        auto freeSecondPassDissector = [&]() -> bool {
+            if (auto cleanupReport = FreeEpanDissect(rawDissect, "freeing Wireshark second-pass dissector", context.packetIdentifier)) {
+                failWithCriticalExceptionLocked(std::move(*cleanupReport));
+                result = WiresharkDissectionResult{};
+                result.fallbackReason = unavailableReason;
+                return false;
+            }
+            return true;
+        };
+
         if (columnInfo.get() != nullptr) {
-            col_custom_prime_edt(dissect.get(), columnInfo.get());
+            if (auto report = CatchWiresharkException("priming Wireshark custom columns", context.packetIdentifier, [&] {
+                    col_custom_prime_edt(rawDissect, columnInfo.get());
+                })) {
+                failWithLocalCriticalException(std::move(*report));
+                return result;
+            }
         }
 
-        frame_data_set_before_dissect(frame, &elapsedTime, &provider->ref, provider->prev_dis);
-        if (provider->ref == frame) {
-            referenceFrame = *frame;
-            provider->ref = &referenceFrame;
-        }
         wtap_block_t block = record.get()->block != nullptr ? wtap_block_ref(record.get()->block) : nullptr;
-        if (buildTree) {
-            epan_dissect_run_with_taps(dissect.get(), WTAP_FILE_TYPE_SUBTYPE_UNKNOWN, record.get(), frame, columnInfo.get());
-        } else {
-            epan_dissect_run(dissect.get(), WTAP_FILE_TYPE_SUBTYPE_UNKNOWN, record.get(), frame, columnInfo.get());
+        if (auto report = CatchWiresharkException("running Wireshark second-pass dissection", context.packetIdentifier, [&] {
+                frame_data_set_before_dissect(frame, &elapsedTime, &provider->ref, provider->prev_dis);
+                if (provider->ref == frame) {
+                    referenceFrame = *frame;
+                    provider->ref = &referenceFrame;
+                }
+                if (buildTree) {
+                    epan_dissect_run_with_taps(rawDissect, WTAP_FILE_TYPE_SUBTYPE_UNKNOWN, record.get(), frame, columnInfo.get());
+                } else {
+                    epan_dissect_run(rawDissect, WTAP_FILE_TYPE_SUBTYPE_UNKNOWN, record.get(), frame, columnInfo.get());
+                }
+                uint32_t secondPassCumulativeBytes = frame->cum_bytes >= frame->pkt_len ? frame->cum_bytes - frame->pkt_len : 0;
+                frame_data_set_after_dissect(frame, &secondPassCumulativeBytes);
+            })) {
+            record.get()->block = block;
+            failWithLocalCriticalException(std::move(*report));
+            return result;
         }
-        uint32_t secondPassCumulativeBytes = frame->cum_bytes >= frame->pkt_len ? frame->cum_bytes - frame->pkt_len : 0;
-        frame_data_set_after_dissect(frame, &secondPassCumulativeBytes);
 
         result.columns = ColumnsFromInfo(columnInfo.get());
         if (buildTree) {
-            auto sourceSet = ExtractByteSources(dissect->pi.data_src);
-            result.nodes = MapProtoTree(dissect->tree, sourceSet);
+            auto sourceSet = ExtractByteSources(rawDissect->pi.data_src);
+            result.nodes = MapProtoTree(rawDissect->tree, sourceSet);
             if (auto sni = FindSNIInNodes(result.nodes)) {
                 result.sniDomainName = *sni;
             }
             result.byteSources = std::move(sourceSet.sources);
         }
-        epan_dissect_reset(dissect.get());
+        if (auto report = CatchWiresharkException("resetting Wireshark second-pass dissector", context.packetIdentifier, [&] {
+                epan_dissect_reset(rawDissect);
+            })) {
+            record.get()->block = block;
+            failWithLocalCriticalException(std::move(*report));
+            return result;
+        }
         record.get()->block = block;
         result.usedWireshark = buildTree ? !result.nodes.empty() : (!result.columns.protocol.empty() || !result.columns.info.empty());
         if (!result.usedWireshark && buildTree) {
             result.fallbackReason = "Wireshark protocol-tree dissection returned no nodes for this packet.";
+        }
+        if (!freeSecondPassDissector()) {
+            return result;
         }
         return result;
     }
@@ -1257,6 +1585,9 @@ struct TCPViewerWiresharkSession {
         auto result = runSecondPassLocked(context, false);
         if (result.usedWireshark && ShouldExtractSNIFromTree(result.columns)) {
             auto treeResult = runSecondPassLocked(context, true);
+            if (!treeResult.usedWireshark && hasCriticalExceptionLocked()) {
+                return treeResult;
+            }
             if (!treeResult.sniDomainName.empty()) {
                 result.sniDomainName = treeResult.sniDomainName;
             }
@@ -1278,6 +1609,16 @@ TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled)
 void TCPViewerWiresharkSessionDestroy(TCPViewerWiresharkSession *session)
 {
     delete session;
+}
+
+void TCPViewerWiresharkSessionReleaseResources(TCPViewerWiresharkSession *session)
+{
+    if (session == nullptr || (session->epan == nullptr && session->provider == nullptr && session->firstPassDissect == nullptr)) {
+        return;
+    }
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->releaseWiresharkResourcesLocked("", false);
 }
 
 bool TCPViewerWiresharkSessionIsAvailable(TCPViewerWiresharkSession *session)
@@ -1305,6 +1646,7 @@ bool TCPViewerWiresharkSessionObservePacket(TCPViewerWiresharkSession *session, 
     }
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
     return session->observePacketLocked(ContextViewFromC(context));
 }
 
@@ -1315,6 +1657,7 @@ bool TCPViewerWiresharkSessionFinishFirstPass(TCPViewerWiresharkSession *session
     }
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
     return session->finishFirstPassLocked();
 }
 
@@ -1328,6 +1671,7 @@ TCPViewerWiresharkSummaryResult *TCPViewerWiresharkSessionSummarizePacket(TCPVie
 
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
     const auto dissection = session->summarizePacketLocked(ContextViewFromC(context));
     result->succeeded = dissection.usedWireshark;
     if (!dissection.usedWireshark) {
@@ -1350,6 +1694,7 @@ TCPViewerWiresharkInspectionResult *TCPViewerWiresharkSessionInspectPacket(TCPVi
 
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
     const auto dissection = session->inspectPacketLocked(ContextViewFromC(context));
     result->succeeded = dissection.usedWireshark;
     if (!dissection.usedWireshark) {
@@ -1372,6 +1717,32 @@ TCPViewerWiresharkInspectionResult *TCPViewerWiresharkSessionInspectPacket(TCPVi
         }
     }
     return result;
+}
+
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyLastCriticalException(TCPViewerWiresharkSession *session)
+{
+    if (session == nullptr) {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    if (session->pendingCriticalExceptions.empty()) {
+        return nullptr;
+    }
+    return CopyExceptionReport(session->pendingCriticalExceptions.back());
+}
+
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyNextCriticalException(TCPViewerWiresharkSession *session)
+{
+    if (session == nullptr) {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    if (session->pendingCriticalExceptions.empty()) {
+        return nullptr;
+    }
+    auto report = CopyExceptionReport(session->pendingCriticalExceptions.front());
+    session->pendingCriticalExceptions.pop_front();
+    return report;
 }
 
 void TCPViewerWiresharkSummaryResultDestroy(TCPViewerWiresharkSummaryResult *result)
@@ -1403,3 +1774,49 @@ void TCPViewerWiresharkInspectionResultDestroy(TCPViewerWiresharkInspectionResul
     std::free(result->nodes);
     std::free(result);
 }
+
+void TCPViewerWiresharkExceptionReportDestroy(TCPViewerWiresharkExceptionReport *report)
+{
+    if (report == nullptr) {
+        return;
+    }
+    std::free(const_cast<char *>(report->operation));
+    std::free(const_cast<char *>(report->exceptionName));
+    std::free(const_cast<char *>(report->reason));
+    std::free(report);
+}
+
+#if DEBUG
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(void)
+{
+    auto &runtime = WiresharkRuntime::shared();
+    if (!runtime.isAvailable()) {
+        return runtime.criticalException().has_value() ? CopyExceptionReport(*runtime.criticalException()) : nullptr;
+    }
+
+    std::optional<WiresharkCriticalException> report;
+    {
+        std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+        report = CatchWiresharkException("testing Wireshark exception handling", uint64_t{42}, [] {
+            except_throw(XCEPT_GROUP_WIRESHARK, DissectorError, "test-only private message");
+        });
+    }
+    return report.has_value() ? CopyExceptionReport(*report) : nullptr;
+}
+
+bool TCPViewerWiresharkSessionTestInjectCriticalException(TCPViewerWiresharkSession *session)
+{
+    if (session == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
+    if (auto report = CatchWiresharkException("testing Wireshark session exception handling", uint64_t{42}, [] {
+            except_throw(XCEPT_GROUP_WIRESHARK, DissectorError, "test-only private message");
+        })) {
+        return session->failWithCriticalExceptionLocked(std::move(*report));
+    }
+    return true;
+}
+#endif

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
@@ -73,16 +73,36 @@ typedef struct TCPViewerWiresharkInspectionResult {
     size_t nodeCount;
 } TCPViewerWiresharkInspectionResult;
 
+typedef struct TCPViewerWiresharkExceptionReport {
+    bool isCriticalException;
+    unsigned long exceptionGroup;
+    unsigned long exceptionCode;
+    uint64_t packetIdentifier;
+    bool hasPacketIdentifier;
+    const char *operation;
+    const char *exceptionName;
+    const char *reason;
+} TCPViewerWiresharkExceptionReport;
+
 TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled);
 void TCPViewerWiresharkSessionDestroy(TCPViewerWiresharkSession *session);
+void TCPViewerWiresharkSessionReleaseResources(TCPViewerWiresharkSession *session);
 bool TCPViewerWiresharkSessionIsAvailable(TCPViewerWiresharkSession *session);
 const char *TCPViewerWiresharkSessionUnavailableReason(TCPViewerWiresharkSession *session);
 bool TCPViewerWiresharkSessionObservePacket(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *context);
 bool TCPViewerWiresharkSessionFinishFirstPass(TCPViewerWiresharkSession *session);
 TCPViewerWiresharkSummaryResult *TCPViewerWiresharkSessionSummarizePacket(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *context);
 TCPViewerWiresharkInspectionResult *TCPViewerWiresharkSessionInspectPacket(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *context);
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyLastCriticalException(TCPViewerWiresharkSession *session);
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyNextCriticalException(TCPViewerWiresharkSession *session);
 void TCPViewerWiresharkSummaryResultDestroy(TCPViewerWiresharkSummaryResult *result);
 void TCPViewerWiresharkInspectionResultDestroy(TCPViewerWiresharkInspectionResult *result);
+void TCPViewerWiresharkExceptionReportDestroy(TCPViewerWiresharkExceptionReport *report);
+
+#if DEBUG
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(void);
+bool TCPViewerWiresharkSessionTestInjectCriticalException(TCPViewerWiresharkSession *session);
+#endif
 
 #ifdef __cplusplus
 }

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
@@ -539,6 +539,8 @@ enum NativeBridgeMapper {
             code = .operationCancelled
         case 1012:
             code = .unavailableFeature
+        case 1013:
+            code = .unavailableFeature
         default:
             code = defaultCode
         }

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeTypes.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeTypes.swift
@@ -491,8 +491,15 @@ enum TCPViewerNativeErrorCode: Int {
     case invalidFilter = 1010
     case operationCancelled = 1011
     case unavailableFeature = 1012
+    case criticalWiresharkException = 1013
 }
 
 func NativeNSError(_ code: TCPViewerNativeErrorCode, _ message: String) -> NSError {
     NSError(domain: TCPViewerNativeErrorDomain, code: code.rawValue, userInfo: [NSLocalizedDescriptionKey: message])
+}
+
+func NativeErrorIsCriticalWiresharkException(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == TCPViewerNativeErrorDomain
+        && nsError.code == TCPViewerNativeErrorCode.criticalWiresharkException.rawValue
 }

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -244,8 +244,8 @@ final class PCPPNativeOfflineDocument {
             guard let record = state.file.records.first(where: { $0.identifier == identifier }) else {
                 throw NativeNSError(.fileReadFailed, "Packet \(identifier) is not available in the backing store.")
             }
-            return autoreleasepool {
-                self.makePacketInspectionDescriptorSafely(record: record, state: &state)
+            return try autoreleasepool {
+                try self.makePacketInspectionDescriptorSafely(record: record, state: &state)
             }
         }
     }
@@ -329,9 +329,9 @@ final class PCPPNativeOfflineDocument {
                     throw NativeNSError(.operationCancelled, progress.message)
                 }
 
-                let summary = autoreleasepool {
-                    state.write {
-                        self.makePacketSummaryDescriptorSafely(record: record, state: &$0)
+                let summary = try autoreleasepool {
+                    try state.write {
+                        try self.makePacketSummaryDescriptorSafely(record: record, state: &$0)
                     }
                 }
                 summaries.append(summary)
@@ -400,7 +400,7 @@ final class PCPPNativeOfflineDocument {
     private func makePacketSummaryDescriptorSafely(
         record: NativePacketRecord,
         state: inout PCPPNativeOfflineDocumentState
-    ) -> PCPPNativePacketSummaryDescriptor {
+    ) throws -> PCPPNativePacketSummaryDescriptor {
         do {
             let session = try requireDissectionSession(in: state)
             try session.observe(record)
@@ -408,6 +408,9 @@ final class PCPPNativeOfflineDocument {
             let analyzer = PacketAnalyzer(record: record).analyze()
             return makePacketSummaryDescriptor(record: record, analyzed: analyzer, wireshark: wiresharkSummary)
         } catch {
+            if NativeErrorIsCriticalWiresharkException(error) {
+                throw error
+            }
             // A single packet can be malformed enough for epan to reject it; keep the file open.
             state.partiallyLoaded = true
             return SwiftPacketDissector.dissect(record: record, disablesWireshark: true).summary
@@ -417,12 +420,15 @@ final class PCPPNativeOfflineDocument {
     private func makePacketInspectionDescriptorSafely(
         record: NativePacketRecord,
         state: inout PCPPNativeOfflineDocumentState
-    ) -> PCPPNativePacketInspectionDescriptor {
+    ) throws -> PCPPNativePacketInspectionDescriptor {
         do {
             let analyzer = PacketAnalyzer(record: record).analyze()
             let inspection = try requireDissectionSession(in: state).inspect(record)
             return makePacketInspectionDescriptor(record: record, analyzed: analyzer, wireshark: inspection)
         } catch {
+            if NativeErrorIsCriticalWiresharkException(error) {
+                throw error
+            }
             return SwiftPacketDissector.dissect(record: record, disablesWireshark: true).inspection
         }
     }

--- a/PcapPlusPlusCoreTests/Dissection/WiresharkCriticalExceptionLoggerTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/WiresharkCriticalExceptionLoggerTests.swift
@@ -1,0 +1,107 @@
+//
+//  WiresharkCriticalExceptionLoggerTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/7/26.
+//
+
+import Foundation
+import Testing
+@testable import PcapPlusPlusCore
+
+@Suite(.serialized)
+struct WiresharkCriticalExceptionLoggerTests {
+
+    @Test func writesPrivacySafeCriticalExceptionLog() throws {
+        let baseURL = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: baseURL) }
+        let logger = WiresharkCriticalExceptionLogger(
+            applicationSupportBaseURL: baseURL,
+            bundleInfo: [
+                "CFBundleDisplayName": "TCP Viewer",
+                "CFBundleShortVersionString": "1.2.3",
+                "CFBundleVersion": "45",
+                "CFBundleIdentifier": "com.proxyman.tcpviewer",
+            ],
+            operatingSystemVersion: "macOS Test 1.0",
+            architecture: "arm64",
+            dateProvider: { Date(timeIntervalSince1970: 0) }
+        )
+        let report = WiresharkCriticalExceptionReport(
+            operation: "running Wireshark second-pass dissection",
+            exceptionName: "DissectorError",
+            exceptionGroup: 1,
+            exceptionCode: 6,
+            packetIdentifier: 42,
+            reason: "Wireshark raised a critical exception while running Wireshark second-pass dissection. TCP Viewer stopped this operation to keep the app running."
+        )
+
+        let logURL = try logger.log(report)
+        let content = try String(contentsOf: logURL, encoding: .utf8)
+
+        var isDirectory = ObjCBool(false)
+        #expect(FileManager.default.fileExists(atPath: logger.logsDirectoryURL.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+        #expect(logURL.lastPathComponent == WiresharkCriticalExceptionLogger.logFileName)
+        #expect(content.contains("App Version: 1.2.3"))
+        #expect(content.contains("Build Version: 45"))
+        #expect(content.contains("macOS: macOS Test 1.0"))
+        #expect(content.contains("Operation: running Wireshark second-pass dissection"))
+        #expect(content.contains("Exception: DissectorError"))
+        #expect(content.contains("Packet Identifier: 42"))
+        #expect(!content.contains("Packet Bytes"))
+        #expect(!content.contains("File Path"))
+        #expect(!content.contains("Interface Name"))
+        #expect(!content.contains("api.example.com"))
+    }
+
+    @Test func testHookCatchesWiresharkExceptionWithoutAbort() throws {
+        let report = try #require(WiresharkExceptionHandlingTestProbe.caughtExceptionReport())
+
+        #expect(report.operation == "testing Wireshark exception handling")
+        #expect(report.exceptionName == "DissectorError")
+        #expect(report.exceptionGroup == 1)
+        #expect(report.exceptionCode == 6)
+        #expect(report.packetIdentifier == 42)
+        #expect(!report.reason.contains("test-only private message"))
+    }
+
+    @Test func sessionCriticalExceptionPathLogsAndThrowsNativeError() throws {
+        let baseURL = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: baseURL) }
+        let logger = WiresharkCriticalExceptionLogger(
+            applicationSupportBaseURL: baseURL,
+            bundleInfo: [
+                "CFBundleDisplayName": "TCP Viewer",
+                "CFBundleShortVersionString": "1.2.3",
+                "CFBundleVersion": "45",
+                "CFBundleIdentifier": "com.proxyman.tcpviewer",
+            ],
+            operatingSystemVersion: "macOS Test 1.0",
+            architecture: "arm64",
+            dateProvider: { Date(timeIntervalSince1970: 1) }
+        )
+        let session = try WiresharkEpanSession(criticalExceptionLogger: logger)
+
+        do {
+            try session.testInjectCriticalException()
+            Issue.record("Expected injected Wireshark exception to throw.")
+        } catch {
+            #expect(NativeErrorIsCriticalWiresharkException(error))
+        }
+
+        let content = try String(contentsOf: logger.logFileURL, encoding: .utf8)
+        #expect(content.contains("Operation: testing Wireshark session exception handling"))
+        #expect(content.contains("Exception: DissectorError"))
+        #expect(content.contains("Packet Identifier: 42"))
+        #expect(!content.contains("test-only private message"))
+        #expect(!content.contains("Packet Bytes"))
+        #expect(!content.contains("Interface Name"))
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/TCPViewer/App/AppDelegate.swift
+++ b/TCPViewer/App/AppDelegate.swift
@@ -326,6 +326,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         presentFactoryResetConfirmation()
     }
 
+    @IBAction func openLogFolder(_ sender: Any?) {
+        do {
+            let logsURL = try TCPViewerUserDataDirectory.shared.createLogsDirectoryIfNeeded()
+            guard NSWorkspace.shared.open(logsURL) else {
+                throw TCPViewerCoreError(code: .offlineFileOpenFailed, message: "TCP Viewer could not open the log folder.")
+            }
+        } catch {
+            presentOpenLogFolderAlert(error)
+        }
+    }
+
     private func presentLicenseSheet(presentationMode: TCPViewerLicensePresentationMode, sender: Any?) {
         // Reuse one sheet owner while allowing Trial and menu actions to open different license modes.
         guard let parentWindow = licenseSheetParentWindow() ?? createLicenseSheetParentWindow() else {
@@ -593,6 +604,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        let logFolderItem = findOrCreateLogFolderMenuItem(in: helpMenu)
+        configureLogFolderMenuItem(logFolderItem)
+
         let advancedItem = findOrCreateAdvancedMenuItem(in: helpMenu)
         let advancedMenu = advancedItem.submenu ?? NSMenu(title: "Advanced")
         advancedItem.submenu = advancedMenu
@@ -605,6 +619,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let item = NSMenuItem(title: "Factory Reset…", action: #selector(factoryReset(_:)), keyEquivalent: "")
         configureFactoryResetMenuItem(item)
         advancedMenu.addItem(item)
+    }
+
+    private func findOrCreateLogFolderMenuItem(in helpMenu: NSMenu) -> NSMenuItem {
+        if let existingItem = helpMenu.items.first(where: { $0.action == #selector(openLogFolder(_:)) || $0.title == "Open Log Folder" }) {
+            return existingItem
+        }
+
+        let item = NSMenuItem(title: "Open Log Folder", action: #selector(openLogFolder(_:)), keyEquivalent: "")
+        if !helpMenu.items.isEmpty, helpMenu.items.last?.isSeparatorItem == false {
+            helpMenu.addItem(NSMenuItem.separator())
+        }
+        helpMenu.addItem(item)
+        return item
     }
 
     private func findOrCreateAdvancedMenuItem(in helpMenu: NSMenu) -> NSMenuItem {
@@ -628,6 +655,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         item.action = #selector(factoryReset(_:))
         item.keyEquivalent = ""
         item.keyEquivalentModifierMask = []
+    }
+
+    private func configureLogFolderMenuItem(_ item: NSMenuItem) {
+        item.title = "Open Log Folder"
+        item.target = self
+        item.action = #selector(openLogFolder(_:))
+        item.keyEquivalent = ""
+        item.keyEquivalentModifierMask = []
+    }
+
+    private func presentOpenLogFolderAlert(_ error: Error) {
+        let alert = NSAlert(error: error)
+        alert.messageText = "Could Not Open Log Folder"
+        alert.informativeText = error.localizedDescription
+        alert.runModal()
     }
 
     private func presentFactoryResetConfirmation() {

--- a/TCPViewer/Core/TCPViewerUserDataDirectory.swift
+++ b/TCPViewer/Core/TCPViewerUserDataDirectory.swift
@@ -12,6 +12,7 @@ final class TCPViewerUserDataDirectory {
 
     private static let appFolderName = "TCPViewer"
     private static let settingsFolderName = "settings"
+    private static let logsFolderName = "Logs"
 
     private let fileManager: FileManager
     private let applicationSupportBaseURL: URL
@@ -29,6 +30,10 @@ final class TCPViewerUserDataDirectory {
         appDirectoryURL.appendingPathComponent(Self.settingsFolderName, isDirectory: true)
     }
 
+    var logsDirectoryURL: URL {
+        appDirectoryURL.appendingPathComponent(Self.logsFolderName, isDirectory: true)
+    }
+
     func settingsFileURL(named fileName: String) -> URL {
         settingsDirectoryURL.appendingPathComponent(fileName)
     }
@@ -37,6 +42,12 @@ final class TCPViewerUserDataDirectory {
     func createSettingsDirectoryIfNeeded() throws -> URL {
         try fileManager.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)
         return settingsDirectoryURL
+    }
+
+    @discardableResult
+    func createLogsDirectoryIfNeeded() throws -> URL {
+        try fileManager.createDirectory(at: logsDirectoryURL, withIntermediateDirectories: true)
+        return logsDirectoryURL
     }
 
     private static func defaultApplicationSupportBaseURL(fileManager: FileManager) -> URL {

--- a/TCPViewerTests/App/TCPViewerUserDataDirectoryTests.swift
+++ b/TCPViewerTests/App/TCPViewerUserDataDirectoryTests.swift
@@ -19,12 +19,16 @@ struct TCPViewerUserDataDirectoryTests {
 
         #expect(directory.appDirectoryURL == baseURL.appendingPathComponent("TCPViewer", isDirectory: true))
         #expect(directory.settingsDirectoryURL == directory.appDirectoryURL.appendingPathComponent("settings", isDirectory: true))
+        #expect(directory.logsDirectoryURL == directory.appDirectoryURL.appendingPathComponent("Logs", isDirectory: true))
         #expect(directory.settingsFileURL(named: "PinnedPackets.json") == directory.settingsDirectoryURL.appendingPathComponent("PinnedPackets.json"))
 
         try directory.createSettingsDirectoryIfNeeded()
+        try directory.createLogsDirectoryIfNeeded()
 
         var isDirectory = ObjCBool(false)
         #expect(FileManager.default.fileExists(atPath: directory.settingsDirectoryURL.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+        #expect(FileManager.default.fileExists(atPath: directory.logsDirectoryURL.path, isDirectory: &isDirectory))
         #expect(isDirectory.boolValue)
     }
 


### PR DESCRIPTION
## Summary

- Catch Wireshark `except` exceptions at the C++ shim boundary and convert them into normal `PcapPlusPlusCore` critical errors.
- Write privacy-safe critical exception entries to `~/Library/Application Support/TCPViewer/Logs/wireshark-critical-exceptions.log`.
- Add `Help > Open Log Folder` so users can reveal the support log folder in Finder.
- Stop the affected capture/open/inspection path gracefully after a caught Wireshark exception.

## Root Cause

Wireshark can throw catchable `except` exceptions from libwireshark entry points. When those exceptions reached the unhandled catcher, the process aborted immediately instead of letting TCP Viewer fail only the current operation.

## Validation

- `xcodebuild test -project TCPViewer.xcodeproj -scheme PcapPlusPlusCore -destination 'platform=macOS' -only-testing:PcapPlusPlusCoreTests`
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`
- `git diff --check`

## AI Assistance

This PR was substantially assisted by Codex and should be reviewed carefully before merge.