### PR TITLE
Fix top unresolved Sentry crashes

### DIFF
--- a/PcapPlusPlusCore/Dissection/WiresharkCriticalExceptionLogger.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkCriticalExceptionLogger.swift
@@ -192,7 +192,13 @@ final class WiresharkCriticalExceptionLogger {
 #if DEBUG
 enum WiresharkExceptionHandlingTestProbe {
     static func caughtExceptionReport() -> WiresharkCriticalExceptionReport? {
-        guard let reportPointer = TCPViewerWiresharkTestCopyCaughtExceptionReport() else {
+        guard let configurationDirectory = try? WiresharkRuntimeConfiguration().createPersonalConfigurationDirectoryIfNeeded() else {
+            return nil
+        }
+        let reportPointer = configurationDirectory.path.withCString { path in
+            TCPViewerWiresharkTestCopyCaughtExceptionReport(path)
+        }
+        guard let reportPointer else {
             return nil
         }
         defer { TCPViewerWiresharkExceptionReportDestroy(reportPointer) }

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
@@ -20,13 +20,59 @@ struct WiresharkPacketInspectionFields {
     let sniDomainName: String?
 }
 
+struct WiresharkRuntimeConfiguration {
+    private static let appFolderName = "TCPViewer"
+    private static let settingsFolderName = "settings"
+    private static let wiresharkFolderName = "Wireshark"
+
+    private let fileManager: FileManager
+    private let applicationSupportBaseURL: URL
+
+    init(fileManager: FileManager = .default, applicationSupportBaseURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.applicationSupportBaseURL = applicationSupportBaseURL ?? Self.defaultApplicationSupportBaseURL(fileManager: fileManager)
+    }
+
+    var personalConfigurationDirectoryURL: URL {
+        applicationSupportBaseURL
+            .appendingPathComponent(Self.appFolderName, isDirectory: true)
+            .appendingPathComponent(Self.settingsFolderName, isDirectory: true)
+            .appendingPathComponent(Self.wiresharkFolderName, isDirectory: true)
+    }
+
+    @discardableResult
+    func createPersonalConfigurationDirectoryIfNeeded() throws -> URL {
+        try fileManager.createDirectory(at: personalConfigurationDirectoryURL, withIntermediateDirectories: true)
+        return personalConfigurationDirectoryURL
+    }
+
+    private static func defaultApplicationSupportBaseURL(fileManager: FileManager) -> URL {
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+    }
+}
+
 final class WiresharkEpanSession {
     private let handle: OpaquePointer
     private let criticalExceptionLogger: WiresharkCriticalExceptionLogger
 
-    init(disabled: Bool = false, criticalExceptionLogger: WiresharkCriticalExceptionLogger = .shared) throws {
+    init(
+        disabled: Bool = false,
+        criticalExceptionLogger: WiresharkCriticalExceptionLogger = .shared,
+        runtimeConfiguration: WiresharkRuntimeConfiguration = WiresharkRuntimeConfiguration()
+    ) throws {
         self.criticalExceptionLogger = criticalExceptionLogger
-        guard let createdHandle = TCPViewerWiresharkSessionCreate(disabled) else {
+        let createdHandle: OpaquePointer?
+        if disabled {
+            createdHandle = TCPViewerWiresharkSessionCreate(true, nil)
+        } else {
+            let configurationDirectory = try runtimeConfiguration.createPersonalConfigurationDirectoryIfNeeded()
+            createdHandle = configurationDirectory.path.withCString { path in
+                TCPViewerWiresharkSessionCreate(false, path)
+            }
+        }
+
+        guard let createdHandle else {
             throw NativeNSError(.unavailableFeature, "Wireshark libwireshark backend could not be created.")
         }
 

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
@@ -34,6 +34,11 @@
 #include <wiretap/wtap.h>
 #include <wiretap/wtap_opttypes.h>
 #include <wsutil/buffer.h>
+#include <wsutil/filesystem.h>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
 
 struct packet_provider_data {
     wtap *wth = nullptr;
@@ -152,6 +157,21 @@ std::mutex &WiresharkAPIMutex()
     // Keep the lock alive until process exit; test runners can tear down Swift objects late.
     static auto *mutex = new std::mutex();
     return *mutex;
+}
+
+std::string CurrentExecutablePath()
+{
+#if defined(__APPLE__)
+    uint32_t size = 0;
+    _NSGetExecutablePath(nullptr, &size);
+    if (size > 0) {
+        std::vector<char> buffer(size);
+        if (_NSGetExecutablePath(buffer.data(), &size) == 0) {
+            return std::string(buffer.data());
+        }
+    }
+#endif
+    return "TCPViewer";
 }
 
 const char *KindString(NodeKind kind)
@@ -998,9 +1018,9 @@ void DestroyByteSource(TCPViewerWiresharkByteSource &source)
 
 class WiresharkRuntime {
 public:
-    static WiresharkRuntime &shared()
+    static WiresharkRuntime &shared(const char *personalConfigurationDirectory)
     {
-        static WiresharkRuntime runtime;
+        static WiresharkRuntime runtime(personalConfigurationDirectory);
         return runtime;
     }
 
@@ -1036,9 +1056,23 @@ private:
         }
     }
 
-    WiresharkRuntime()
+    explicit WiresharkRuntime(const char *personalConfigurationDirectory)
     {
         std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+        if (personalConfigurationDirectory == nullptr || personalConfigurationDirectory[0] == '\0') {
+            available_ = false;
+            unavailableReason_ = "Wireshark personal configuration directory is unavailable.";
+            return;
+        }
+        // Wireshark resolves bundled data relative to the host executable path.
+        const auto executablePath = CurrentExecutablePath();
+        if (char *configurationError = configuration_init(executablePath.c_str())) {
+            available_ = false;
+            unavailableReason_ = std::string("Wireshark configuration initialization failed: ") + configurationError;
+            g_free(configurationError);
+            return;
+        }
+        set_persconffile_dir(personalConfigurationDirectory);
         if (except_init() == 0) {
             available_ = false;
             unavailableReason_ = "Wireshark exception handling failed to initialize.";
@@ -1046,7 +1080,7 @@ private:
         }
         initializedExceptions_ = true;
         if (auto report = CatchWiresharkException("initializing Wireshark Wiretap", std::nullopt, [] {
-                wtap_init(true);
+                wtap_init(false);
             })) {
             recordCriticalException(std::move(*report));
             available_ = false;
@@ -1056,7 +1090,7 @@ private:
         initializedWiretap_ = true;
         bool didInitializeEpan = false;
         if (auto report = CatchWiresharkException("initializing Wireshark protocol registry", std::nullopt, [&didInitializeEpan] {
-                didInitializeEpan = epan_init(nullptr, nullptr, true);
+                didInitializeEpan = epan_init(nullptr, nullptr, false);
             })) {
             recordCriticalException(std::move(*report));
             available_ = false;
@@ -1138,6 +1172,7 @@ struct TCPViewerWiresharkSession {
     std::unordered_set<uint32_t> storedFrameNumbers;
     std::unordered_set<uint32_t> activeFrameNumbers;
     std::deque<WiresharkCriticalException> pendingCriticalExceptions;
+    std::string personalConfigurationDirectory;
     bool disabled = false;
     bool firstPassFinished = false;
     bool backendAvailable = false;
@@ -1148,15 +1183,16 @@ struct TCPViewerWiresharkSession {
         return session;
     }
 
-    explicit TCPViewerWiresharkSession(bool disablesWireshark)
+    TCPViewerWiresharkSession(bool disablesWireshark, const char *personalConfigurationDirectory)
     {
+        this->personalConfigurationDirectory = personalConfigurationDirectory == nullptr ? "" : personalConfigurationDirectory;
         if (disablesWireshark) {
             disabled = true;
             unavailableReason = kBackendDisabledReason;
             firstPassFinished = true;
             return;
         }
-        auto &runtime = WiresharkRuntime::shared();
+        auto &runtime = WiresharkRuntime::shared(this->personalConfigurationDirectory.c_str());
         backendAvailable = runtime.isAvailable();
         unavailableReason = runtime.unavailableReason();
         for (const auto &report : runtime.criticalExceptionReports()) {
@@ -1385,7 +1421,7 @@ struct TCPViewerWiresharkSession {
         if (disabled) {
             return false;
         }
-        auto &runtime = WiresharkRuntime::shared();
+        auto &runtime = WiresharkRuntime::shared(personalConfigurationDirectory.c_str());
         backendAvailable = runtime.isAvailable();
         if (!backendAvailable) {
             unavailableReason = runtime.unavailableReason();
@@ -1601,9 +1637,9 @@ struct TCPViewerWiresharkSession {
     }
 };
 
-TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled)
+TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled, const char *personalConfigurationDirectory)
 {
-    return new TCPViewerWiresharkSession(disabled);
+    return new TCPViewerWiresharkSession(disabled, personalConfigurationDirectory);
 }
 
 void TCPViewerWiresharkSessionDestroy(TCPViewerWiresharkSession *session)
@@ -1787,9 +1823,9 @@ void TCPViewerWiresharkExceptionReportDestroy(TCPViewerWiresharkExceptionReport 
 }
 
 #if DEBUG
-TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(void)
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(const char *personalConfigurationDirectory)
 {
-    auto &runtime = WiresharkRuntime::shared();
+    auto &runtime = WiresharkRuntime::shared(personalConfigurationDirectory);
     if (!runtime.isAvailable()) {
         return runtime.criticalException().has_value() ? CopyExceptionReport(*runtime.criticalException()) : nullptr;
     }

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
@@ -84,7 +84,7 @@ typedef struct TCPViewerWiresharkExceptionReport {
     const char *reason;
 } TCPViewerWiresharkExceptionReport;
 
-TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled);
+TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled, const char *personalConfigurationDirectory);
 void TCPViewerWiresharkSessionDestroy(TCPViewerWiresharkSession *session);
 void TCPViewerWiresharkSessionReleaseResources(TCPViewerWiresharkSession *session);
 bool TCPViewerWiresharkSessionIsAvailable(TCPViewerWiresharkSession *session);
@@ -100,7 +100,7 @@ void TCPViewerWiresharkInspectionResultDestroy(TCPViewerWiresharkInspectionResul
 void TCPViewerWiresharkExceptionReportDestroy(TCPViewerWiresharkExceptionReport *report);
 
 #if DEBUG
-TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(void);
+TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(const char *personalConfigurationDirectory);
 bool TCPViewerWiresharkSessionTestInjectCriticalException(TCPViewerWiresharkSession *session);
 #endif
 

--- a/PcapPlusPlusCoreTests/Dissection/WiresharkCriticalExceptionLoggerTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/WiresharkCriticalExceptionLoggerTests.swift
@@ -12,6 +12,22 @@ import Testing
 @Suite(.serialized)
 struct WiresharkCriticalExceptionLoggerTests {
 
+    @Test func runtimeConfigurationUsesTCPViewerOwnedSettingsDirectory() throws {
+        let baseURL = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: baseURL) }
+        let configuration = WiresharkRuntimeConfiguration(applicationSupportBaseURL: baseURL)
+
+        let directory = try configuration.createPersonalConfigurationDirectoryIfNeeded()
+
+        #expect(directory == baseURL
+            .appendingPathComponent("TCPViewer", isDirectory: true)
+            .appendingPathComponent("settings", isDirectory: true)
+            .appendingPathComponent("Wireshark", isDirectory: true))
+        var isDirectory = ObjCBool(false)
+        #expect(FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+    }
+
     @Test func writesPrivacySafeCriticalExceptionLog() throws {
         let baseURL = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: baseURL) }

--- a/TCPViewer/App/TCPViewerSentryService.swift
+++ b/TCPViewer/App/TCPViewerSentryService.swift
@@ -10,6 +10,7 @@ import Sentry
 
 enum TCPViewerSentryConfiguration {
     static let dsnInfoKey = "TCPViewerSentryDSN"
+    static let environment = "production"
 
     // Return a configured DSN only when local build settings resolved it.
     static func dsn(from bundle: Bundle = .main) -> String? {
@@ -106,7 +107,7 @@ final class TCPViewerSentryService {
             return
         }
 
-        controller.start(dsn: dsn) { [weak configuration] in
+        controller.start(dsn: dsn, environment: TCPViewerSentryConfiguration.environment) { [weak configuration] in
             configuration?.sharesCrashReports == true
         }
     }
@@ -115,7 +116,7 @@ final class TCPViewerSentryService {
 protocol TCPViewerSentryControlling: AnyObject {
     var isStarted: Bool { get }
 
-    func start(dsn: String, isCrashReportingAllowed: @escaping () -> Bool)
+    func start(dsn: String, environment: String, isCrashReportingAllowed: @escaping () -> Bool)
     func close()
 }
 
@@ -125,13 +126,14 @@ final class TCPViewerSentrySDKController: TCPViewerSentryControlling {
     }
 
     // Configure Sentry as crash-report-only telemetry for the Privacy crash report toggle.
-    func start(dsn: String, isCrashReportingAllowed: @escaping () -> Bool) {
+    func start(dsn: String, environment: String, isCrashReportingAllowed: @escaping () -> Bool) {
         guard !isStarted else {
             return
         }
 
         SentrySDK.start { options in
             options.dsn = dsn
+            options.environment = environment
             options.debug = false
             options.enabled = true
             options.enableSwizzling = false

--- a/TCPViewer/Features/License/Services/TCPViewerLicenseService.swift
+++ b/TCPViewer/Features/License/Services/TCPViewerLicenseService.swift
@@ -63,11 +63,11 @@ final class TCPViewerLicenseService {
     func activate(licenseKey: String, completion: @escaping (TCPViewerLicenseStatus) -> Void) {
         let normalizedKey = licenseKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard normalizedKey.hasPrefix("TCPV-") else {
-            completion(.unauthorized(.invalidLicense))
+            completeOnMain(.unauthorized(.invalidLicense), completion)
             return
         }
         guard let deviceUUID = deviceProvider.currentDeviceUUID() else {
-            completion(.unauthorized(.couldNotGetDeviceUUID))
+            completeOnMain(.unauthorized(.couldNotGetDeviceUUID), completion)
             return
         }
 
@@ -78,22 +78,22 @@ final class TCPViewerLicenseService {
             buildNumber: buildNumberProvider(),
             appVersion: appVersionProvider(),
             osVersion: osVersionProvider()
-        ) { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case .success(let license):
-                do {
-                    try storage.writeLicense(license)
-                    updateLastVerifyLicenseTime()
-                    let status = TCPViewerLicenseStatus.authorized(license)
-                    setStatus(status)
-                    completion(status)
-                } catch {
-                    completion(.unauthorized(.error(error.localizedDescription)))
+        ) { result in
+            self.workerQueue.async {
+                switch result {
+                case .success(let license):
+                    do {
+                        try self.storage.writeLicense(license)
+                        self.updateLastVerifyLicenseTime()
+                        let status = TCPViewerLicenseStatus.authorized(license)
+                        self.setStatus(status)
+                        self.completeOnMain(status, completion)
+                    } catch {
+                        self.completeOnMain(.unauthorized(.error(error.localizedDescription)), completion)
+                    }
+                case .failure(let error):
+                    self.completeOnMain(.unauthorized(error), completion)
                 }
-            case .failure(let error):
-                completion(.unauthorized(error))
             }
         }
     }
@@ -116,27 +116,29 @@ final class TCPViewerLicenseService {
         if Date() > nextVerifyDate {
             verifyStoredLicense(completion: completion)
         } else {
-            completion?(status)
+            completeOnMain(status, completion)
         }
     }
 
     func revokeCurrentDevice(completion: @escaping (Result<Void, TCPViewerLicenseError>) -> Void) {
-        guard let license = storage.readLicense() else {
-            clearLicense()
-            completion(.success(()))
-            return
-        }
+        workerQueue.async {
+            guard let license = self.storage.readLicense() else {
+                self.clearLicense()
+                self.completeOnMain(.success(()), completion)
+                return
+            }
 
-        networkClient.revokeLicense(license: license) { [weak self] result in
-            guard let self else { return }
-
-            // Clear locally only after License Manager accepted or already lost this device.
-            switch result {
-            case .success, .failure(.invalidLicense):
-                clearLicense()
-                completion(.success(()))
-            case .failure(let error):
-                completion(.failure(error))
+            self.networkClient.revokeLicense(license: license) { result in
+                self.workerQueue.async {
+                    // Clear locally only after License Manager accepted or already lost this device.
+                    switch result {
+                    case .success, .failure(.invalidLicense):
+                        self.clearLicense()
+                        self.completeOnMain(.success(()), completion)
+                    case .failure(let error):
+                        self.completeOnMain(.failure(error), completion)
+                    }
+                }
             }
         }
     }
@@ -178,25 +180,25 @@ final class TCPViewerLicenseService {
                 buildNumber: buildNumberProvider(),
                 appVersion: appVersionProvider(),
                 osVersion: osVersionProvider()
-            ) { [weak self] result in
-                guard let self else { return }
-
-                switch result {
-                case .success(let updatedLicense):
-                    do {
-                        try storage.writeLicense(updatedLicense)
-                        updateLastVerifyLicenseTime()
-                        let status = TCPViewerLicenseStatus.authorized(updatedLicense)
-                        setStatus(status)
-                        completion?(status)
-                    } catch {
-                        completion?(.unauthorized(.error(error.localizedDescription)))
+            ) { result in
+                self.workerQueue.async {
+                    switch result {
+                    case .success(let updatedLicense):
+                        do {
+                            try self.storage.writeLicense(updatedLicense)
+                            self.updateLastVerifyLicenseTime()
+                            let status = TCPViewerLicenseStatus.authorized(updatedLicense)
+                            self.setStatus(status)
+                            self.completeOnMain(status, completion)
+                        } catch {
+                            self.completeOnMain(.unauthorized(.error(error.localizedDescription)), completion)
+                        }
+                    case .failure(.noInternetConnection):
+                        // Offline Macs keep their current receipt until the server can be reached.
+                        self.completeOnMain(self.status, completion)
+                    case .failure(let error):
+                        self.removeStoredLicenseAndComplete(completion, error: error)
                     }
-                case .failure(.noInternetConnection):
-                    // Offline Macs keep their current receipt until the server can be reached.
-                    completion?(status)
-                case .failure(let error):
-                    removeStoredLicenseAndComplete(completion, error: error)
                 }
             }
         }
@@ -239,7 +241,7 @@ final class TCPViewerLicenseService {
         defaults.removeObject(forKey: Constants.lastVerifyDefaultsKey)
         let status = TCPViewerLicenseStatus.unauthorized(error)
         setStatus(status)
-        completion?(status)
+        completeOnMain(status, completion)
     }
 
     private func setStatus(_ status: TCPViewerLicenseStatus) {
@@ -260,14 +262,26 @@ final class TCPViewerLicenseService {
         defaults.set(Date().timeIntervalSince1970, forKey: Constants.lastVerifyDefaultsKey)
     }
 
+    private func completeOnMain<T>(_ value: T, _ completion: ((T) -> Void)?) {
+        guard let completion else {
+            return
+        }
+
+        Self.performOnMain {
+            completion(value)
+        }
+    }
+
     private static func postStatusDidChange(_ status: TCPViewerLicenseStatus) {
-        let block = {
+        performOnMain {
             NotificationCenter.default.post(
                 name: TCPViewerLicenseService.statusDidChangeNotification,
                 object: status
             )
         }
+    }
 
+    private static func performOnMain(_ block: @escaping () -> Void) {
         if Thread.isMainThread {
             block()
         } else {

--- a/TCPViewerTests/App/TCPViewerSentryConfigurationTests.swift
+++ b/TCPViewerTests/App/TCPViewerSentryConfigurationTests.swift
@@ -48,7 +48,22 @@ struct TCPViewerSentryConfigurationTests {
 
         configuration.sharesCrashReports = true
         #expect(controller.startCalls == ["https://public@example.ingest.sentry.io/1"])
+        #expect(controller.environmentCalls == ["production"])
         #expect(controller.isCrashReportingAllowed?() == true)
+    }
+
+    @Test func serviceUsesProductionSentryEnvironment() {
+        let configuration = AppConfiguration(defaults: Self.makeUserDefaults())
+        let controller = StubSentryController()
+        let service = TCPViewerSentryService(
+            configuration: configuration,
+            controller: controller,
+            dsnProvider: { "https://public@example.ingest.sentry.io/1" }
+        )
+
+        service.start()
+
+        #expect(controller.environmentCalls == [TCPViewerSentryConfiguration.environment])
     }
 
     @Test func serviceClosesWhenCrashReportsAreDisabled() {
@@ -92,6 +107,7 @@ struct TCPViewerSentryConfigurationTests {
 
 private final class StubSentryController: TCPViewerSentryControlling {
     private(set) var startCalls: [String] = []
+    private(set) var environmentCalls: [String] = []
     private(set) var closeCallCount = 0
     private(set) var isCrashReportingAllowed: (() -> Bool)?
 
@@ -99,8 +115,9 @@ private final class StubSentryController: TCPViewerSentryControlling {
         !startCalls.isEmpty && closeCallCount == 0
     }
 
-    func start(dsn: String, isCrashReportingAllowed: @escaping () -> Bool) {
+    func start(dsn: String, environment: String, isCrashReportingAllowed: @escaping () -> Bool) {
         startCalls.append(dsn)
+        environmentCalls.append(environment)
         self.isCrashReportingAllowed = isCrashReportingAllowed
     }
 

--- a/TCPViewerTests/Features/License/TCPViewerLicenseServiceTests.swift
+++ b/TCPViewerTests/Features/License/TCPViewerLicenseServiceTests.swift
@@ -31,6 +31,26 @@ struct TCPViewerLicenseServiceTests {
         #expect(network.registeredOSVersion == "macOS 15.6")
     }
 
+    @Test func activationCompletionRunsOnMainQueueAfterAsyncNetworkCallback() throws {
+        let storage = try makeStorage()
+        let network = StubLicenseNetworkClient()
+        let license = makeLicense()
+        network.registerResult = .success(license)
+        network.callbackQueue = DispatchQueue(label: "TCPViewerLicenseServiceTests.activationCallback")
+        let service = makeService(storage: storage, network: network)
+        var completedOnMain = false
+
+        let status = waitForStatus { finish in
+            service.activate(licenseKey: "TCPV-KEY") { status in
+                completedOnMain = Thread.isMainThread
+                finish(status)
+            }
+        }
+
+        #expect(status == .authorized(license))
+        #expect(completedOnMain)
+    }
+
     @Test func activationRejectsInvalidPrefixBeforeNetworkCall() throws {
         let storage = try makeStorage()
         let network = StubLicenseNetworkClient()
@@ -80,6 +100,27 @@ struct TCPViewerLicenseServiceTests {
         #expect(storage.readLicense() == updatedLicense)
         #expect(network.verifiedSignature == oldLicense.signature)
         #expect(network.verifiedDeviceUUID == "device-1")
+    }
+
+    @Test func verificationCompletionRunsOnMainQueueAfterAsyncNetworkCallback() throws {
+        let storage = try makeStorage()
+        let license = makeLicense()
+        try storage.writeLicense(license)
+        let network = StubLicenseNetworkClient()
+        network.verifyResult = .success(license)
+        network.callbackQueue = DispatchQueue(label: "TCPViewerLicenseServiceTests.verifyCallback")
+        let service = makeService(storage: storage, network: network)
+        var completedOnMain = false
+
+        let status = waitForStatus { finish in
+            service.verifyAtLaunch { status in
+                completedOnMain = Thread.isMainThread
+                finish(status)
+            }
+        }
+
+        #expect(status == .authorized(license))
+        #expect(completedOnMain)
     }
 
     @Test func launchVerificationUsesStoredFallbackDeviceUUID() throws {
@@ -292,6 +333,27 @@ struct TCPViewerLicenseServiceTests {
         #expect(network.revokedSignature == license.signature)
     }
 
+    @Test func revokeCompletionRunsOnMainQueueAfterAsyncNetworkCallback() throws {
+        let storage = try makeStorage()
+        let license = makeLicense()
+        try storage.writeLicense(license)
+        let network = StubLicenseNetworkClient()
+        network.revokeResult = .success(())
+        network.callbackQueue = DispatchQueue(label: "TCPViewerLicenseServiceTests.revokeCallback")
+        let service = makeService(storage: storage, network: network)
+        var completedOnMain = false
+
+        let result = waitForVoid { finish in
+            service.revokeCurrentDevice { result in
+                completedOnMain = Thread.isMainThread
+                finish(result)
+            }
+        }
+
+        try result.get()
+        #expect(completedOnMain)
+    }
+
     private func makeService(
         storage: TCPViewerLicenseStorage,
         network: StubLicenseNetworkClient,
@@ -352,7 +414,7 @@ struct TCPViewerLicenseServiceTests {
             status = $0
             semaphore.signal()
         }
-        #expect(semaphore.wait(timeout: .now() + 2) == .success)
+        #expect(waitUntilSignaled(semaphore))
         return status ?? .unauthorized(.error("Missing callback"))
     }
 
@@ -365,8 +427,23 @@ struct TCPViewerLicenseServiceTests {
             result = $0
             semaphore.signal()
         }
-        #expect(semaphore.wait(timeout: .now() + 2) == .success)
+        #expect(waitUntilSignaled(semaphore))
         return result ?? .failure(.error("Missing callback"))
+    }
+
+    private func waitUntilSignaled(_ semaphore: DispatchSemaphore) -> Bool {
+        let deadline = Date().addingTimeInterval(2)
+        if Thread.isMainThread {
+            while Date() < deadline {
+                if semaphore.wait(timeout: .now()) == .success {
+                    return true
+                }
+                _ = RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            }
+            return semaphore.wait(timeout: .now()) == .success
+        }
+
+        return semaphore.wait(timeout: .now() + 2) == .success
     }
 }
 
@@ -390,6 +467,7 @@ private final class StubLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
     var registerResult: Result<TCPViewerLicense, TCPViewerLicenseError> = .failure(.invalidLicense)
     var verifyResult: Result<TCPViewerLicense, TCPViewerLicenseError> = .failure(.invalidLicense)
     var revokeResult: Result<Void, TCPViewerLicenseError> = .success(())
+    var callbackQueue: DispatchQueue?
 
     var registeredLicenseKey: String?
     var registeredDeviceUUID: String?
@@ -416,7 +494,7 @@ private final class StubLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
         registeredBuildNumber = buildNumber
         registeredAppVersion = appVersion
         registeredOSVersion = osVersion
-        completion(registerResult)
+        complete(registerResult, completion: completion)
     }
 
     func verifyLicense(
@@ -431,7 +509,7 @@ private final class StubLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
         verifiedDeviceUUID = deviceUUID
         verifiedAppVersion = appVersion
         verifiedOSVersion = osVersion
-        completion(verifyResult)
+        complete(verifyResult, completion: completion)
     }
 
     func revokeLicense(
@@ -439,6 +517,17 @@ private final class StubLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
         completion: @escaping (Result<Void, TCPViewerLicenseError>) -> Void
     ) {
         revokedSignature = license.signature
-        completion(revokeResult)
+        complete(revokeResult, completion: completion)
+    }
+
+    private func complete<T>(_ value: T, completion: @escaping (T) -> Void) {
+        guard let callbackQueue else {
+            completion(value)
+            return
+        }
+
+        callbackQueue.async {
+            completion(value)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Harden license activation, verification, and revoke callback delivery so completions run on the main queue while storage/status changes stay on the license worker queue.
- Isolate embedded Wireshark personal configuration under `Application Support/TCPViewer/settings/Wireshark` and disable external Wireshark plugin loading.
- Set Sentry environment explicitly to `production`.
- Add focused tests for license callback delivery, Wireshark settings isolation, and Sentry environment configuration.

## Review
- Reviewed the full branch diff against `origin/main` after the checkpoint commit.
- No additional actionable issues were found, so no follow-up fix commit was needed.

## Tests
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build -quiet`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' -quiet`

## AI Disclosure
This PR was written and reviewed with AI assistance. The changes were verified locally with the build and test commands above.
