### PR TITLE
Show available update counts in the toolbar

### DIFF
--- a/TCPViewer/App/AppDelegate.swift
+++ b/TCPViewer/App/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var licenseWindowController: TCPViewerLicenseWindowController?
     private var updaterController: SPUStandardUpdaterController?
     private let sparkleUpdaterDelegate = TCPViewerSparkleUpdaterDelegate()
+    private let updateAvailabilityService = TCPViewerUpdateAvailabilityService()
     private weak var checkForUpdatesMenuItem: NSMenuItem?
     private weak var licenseMenuItem: NSMenuItem?
     private var licenseStatusObserver: NSObjectProtocol?
@@ -29,6 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var isShowingRenewalRequiredAlert = false
     private var isVerifyingLicenseAtLaunch = false
     private var didCheckForUpdatesAtLaunch = false
+    private var availableUpdateCount = 0
     private var isTerminatingAfterFactoryReset = false
     #if DEBUG
     private var shouldOpenUntitledDocumentAfterIgnoringDebugLaunchFiles = false
@@ -42,6 +44,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         wireAboutMenu()
         wirePreferencesMenu()
         wireUpdatesMenu()
+        checkForAvailableUpdatesAtLaunch()
         wireClearAllPacketsMenu()
         wireFilterMenu()
         wireHelpMenu()
@@ -502,6 +505,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         updater.checkForUpdatesInBackground()
+    }
+
+    // Check the release count separately so skipped Sparkle releases still appear in the toolbar badge.
+    private func checkForAvailableUpdatesAtLaunch() {
+        guard isSparkleConfigured() else {
+            return
+        }
+
+        updateAvailabilityService.checkForAvailableBuilds { [weak self] count in
+            DispatchQueue.main.async {
+                guard let self else {
+                    return
+                }
+
+                self.availableUpdateCount = count
+                self.updateToolbarUpdateBadges()
+            }
+        }
+    }
+
+    // Supply the last launch-time count to document windows created after the network request completes.
+    func currentAvailableUpdateCount() -> Int {
+        availableUpdateCount
+    }
+
+    // Trigger Sparkle's user-initiated flow so its normal update presentation remains the single install path.
+    func checkForUpdatesFromToolbar() {
+        guard let updaterController = makeUpdaterControllerIfConfigured() else {
+            return
+        }
+
+        updaterController.checkForUpdates(nil)
+    }
+
+    private func updateToolbarUpdateBadges() {
+        for windowController in NSApp.windows.compactMap({ $0.windowController as? TCPViewerWindowController }) {
+            windowController.updateAvailableBuildCount(availableUpdateCount)
+        }
     }
 
     private func isSparkleConfigured() -> Bool {

--- a/TCPViewer/App/TCPViewerUpdateAvailabilityService.swift
+++ b/TCPViewer/App/TCPViewerUpdateAvailabilityService.swift
@@ -1,0 +1,97 @@
+//
+//  TCPViewerUpdateAvailabilityService.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 12/7/26.
+//
+
+import Foundation
+
+final class TCPViewerUpdateAvailabilityService {
+    private struct Response: Decodable {
+        let newReleasesCount: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case newReleasesCount = "new_releases_count"
+        }
+    }
+
+    private let baseURLOverride: URL?
+    private let bundleInfo: [String: Any]
+    private let transport: any TCPViewerServerNetworkTransport
+    private let buildNumberProvider: () -> String
+    private let workerQueue: DispatchQueue
+    private let decoder = JSONDecoder()
+
+    init(
+        baseURL: URL? = nil,
+        bundleInfo: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        transport: any TCPViewerServerNetworkTransport = TCPViewerServerURLSessionTransport(),
+        buildNumberProvider: @escaping () -> String = { TCPViewerLicenseAppVersion.current.buildNumber },
+        workerQueue: DispatchQueue = DispatchQueue(label: "com.proxyman.tcpviewer.UpdateAvailability", qos: .utility)
+    ) {
+        self.baseURLOverride = baseURL
+        self.bundleInfo = bundleInfo
+        self.transport = transport
+        self.buildNumberProvider = buildNumberProvider
+        self.workerQueue = workerQueue
+    }
+
+    // Fetch the number of releases newer than this build without invoking Sparkle's skipped-version policy.
+    func checkForAvailableBuilds(completion: @escaping (Int) -> Void) {
+        workerQueue.async { [weak self] in
+            guard let self, let request = self.makeRequest() else {
+                completion(0)
+                return
+            }
+
+            self.transport.perform(request) { [weak self] data, response, error in
+                guard let self else {
+                    return
+                }
+
+                self.workerQueue.async {
+                    completion(self.availableBuildCount(data: data, response: response, error: error))
+                }
+            }
+        }
+    }
+
+    // Build the existing release-count request with the running app's numeric build identifier.
+    private func makeRequest() -> URLRequest? {
+        let baseURL = baseURLOverride ?? TCPViewerServerEndpoint.baseURL(bundleInfo: bundleInfo)
+        let endpointURL = baseURL.appendingPathComponent("api/releases/check-new-updates")
+        guard var components = URLComponents(url: endpointURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        components.queryItems = [
+            URLQueryItem(name: "platform", value: "macos"),
+            URLQueryItem(name: "build_number", value: buildNumberProvider()),
+        ]
+        guard let url = components.url else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 10
+        return request
+    }
+
+    // Treat all network and malformed responses as no badge so update checks never disrupt launch.
+    private func availableBuildCount(
+        data: Data?,
+        response: HTTPURLResponse?,
+        error: Error?
+    ) -> Int {
+        guard error == nil,
+              response?.statusCode == 200,
+              let data,
+              let result = try? decoder.decode(Response.self, from: data) else {
+            return 0
+        }
+
+        return max(0, result.newReleasesCount)
+    }
+}

--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -661,7 +661,7 @@ private final class TCPViewerToolbarStatusView: NSView {
     private let statusLabel = TCPViewerUI.label("", font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium), color: .secondaryLabelColor)
     private let emphasizedLabel = TCPViewerUI.label("", font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold))
     private let helperErrorButton = NSButton(title: "Error", target: nil, action: nil)
-    private let updateBadgeButton = NSButton(title: "", target: nil, action: nil)
+    private let updateBadgeButton = TCPViewerToolbarUpdateBadgeButton(title: "", target: nil, action: nil)
     private var helperError: TCPViewerToolbarHelperError?
 
     override init(frame frameRect: NSRect) {
@@ -697,7 +697,13 @@ private final class TCPViewerToolbarStatusView: NSView {
             return
         }
 
-        updateBadgeButton.title = count == 1 ? "New Update" : "\(count) New Updates"
+        updateBadgeButton.attributedTitle = NSAttributedString(
+            string: count == 1 ? "New Update" : "\(count) New Updates",
+            attributes: [
+                .font: updateBadgeButton.font as Any,
+                .foregroundColor: NSColor.black,
+            ]
+        )
         updateBadgeButton.isHidden = false
     }
 
@@ -709,14 +715,18 @@ private final class TCPViewerToolbarStatusView: NSView {
         emphasizedLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         configureHelperErrorButton()
         configureUpdateBadgeButton()
+        let flexibleSpacer = NSView()
+        flexibleSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        flexibleSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        let stack = NSStackView(views: [dot, statusLabel, emphasizedLabel, updateBadgeButton, helperErrorButton])
+        let stack = NSStackView(views: [dot, statusLabel, emphasizedLabel, helperErrorButton, flexibleSpacer, updateBadgeButton])
         stack.orientation = .horizontal
         stack.alignment = .centerY
         stack.spacing = 6
         stack.setCustomSpacing(10, after: dot)
         stack.setCustomSpacing(4, after: statusLabel)
         stack.setCustomSpacing(8, after: emphasizedLabel)
+        stack.setCustomSpacing(8, after: flexibleSpacer)
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
 
@@ -758,8 +768,12 @@ private final class TCPViewerToolbarStatusView: NSView {
     private func configureUpdateBadgeButton() {
         updateBadgeButton.target = self
         updateBadgeButton.action = #selector(updateBadgeButtonPressed(_:))
-        updateBadgeButton.bezelStyle = .rounded
-        updateBadgeButton.controlSize = .small
+        updateBadgeButton.bezelStyle = .regularSquare
+        updateBadgeButton.isBordered = false
+        updateBadgeButton.wantsLayer = true
+        updateBadgeButton.refreshBackgroundColor()
+        updateBadgeButton.layer?.cornerRadius = 11
+        updateBadgeButton.layer?.masksToBounds = true
         updateBadgeButton.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
         updateBadgeButton.toolTip = "Check for Updates"
         updateBadgeButton.isHidden = true
@@ -776,5 +790,58 @@ private final class TCPViewerToolbarStatusView: NSView {
 
     @objc private func updateBadgeButtonPressed(_ sender: NSButton) {
         onCheckForUpdates?()
+    }
+}
+
+private final class TCPViewerToolbarUpdateBadgeButton: NSButton {
+    private var trackingArea: NSTrackingArea?
+    private var isPointerInside = false {
+        didSet {
+            updateBackgroundColor()
+        }
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let size = super.intrinsicContentSize
+        return NSSize(width: size.width + 16, height: 22)
+    }
+
+    // Keep the release badge visibly interactive without changing its compact toolbar layout.
+    override func updateTrackingAreas() {
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        self.trackingArea = trackingArea
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+    }
+
+    func refreshBackgroundColor() {
+        updateBackgroundColor()
+    }
+
+    private func updateBackgroundColor() {
+        layer?.backgroundColor = NSColor(
+            white: isPointerInside ? 0.82 : 0.72,
+            alpha: 1
+        ).cgColor
     }
 }

--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -50,6 +50,7 @@ protocol TCPViewerToolbarDataSourceDelegate: AnyObject {
     func tcpviewerToolbarDataSourceDidToggleBottomInspector(_ dataSource: TCPViewerToolbarDataSource)
     func tcpviewerToolbarDataSourceDidRequestHelperToolScreen(_ dataSource: TCPViewerToolbarDataSource)
     func tcpviewerToolbarDataSourceDidRequestPaywall(_ dataSource: TCPViewerToolbarDataSource)
+    func tcpviewerToolbarDataSourceDidRequestCheckForUpdates(_ dataSource: TCPViewerToolbarDataSource)
 }
 
 final class TCPViewerToolbarDataSource: NSObject {
@@ -77,6 +78,7 @@ final class TCPViewerToolbarDataSource: NSObject {
     private let inspectorBottomButton = NSButton(frame: NSRect(x: 0, y: 0, width: 34, height: 30))
     private var interfacePopupWidthConstraint: NSLayoutConstraint?
     private var isTrialButtonRequired = !TCPViewerLicenseService.shared.isLicenseAuthorized
+    private var availableUpdateCount = 0
 
     private var allowedItemIdentifiers: [NSToolbarItem.Identifier] {
         var identifiers = TCPViewerToolbarItemMetadata.allCases
@@ -135,6 +137,12 @@ final class TCPViewerToolbarDataSource: NSObject {
         renderInspectorButton()
         statusView.render(viewModel: viewModel)
         syncTrialToolbarItem()
+    }
+
+    // Update only the status badge because release availability is independent of capture state.
+    func setAvailableUpdateCount(_ count: Int) {
+        availableUpdateCount = max(0, count)
+        statusView.renderUpdateBadge(availableUpdateCount)
     }
 
     private func configureToolbar() {
@@ -234,6 +242,14 @@ final class TCPViewerToolbarDataSource: NSObject {
             }
 
             delegate?.tcpviewerToolbarDataSourceDidRequestHelperToolScreen(self)
+        }
+
+        statusView.onCheckForUpdates = { [weak self] in
+            guard let self else {
+                return
+            }
+
+            delegate?.tcpviewerToolbarDataSourceDidRequestCheckForUpdates(self)
         }
     }
 
@@ -639,11 +655,13 @@ private struct TCPViewerToolbarHelperError {
 
 private final class TCPViewerToolbarStatusView: NSView {
     var onOpenHelperToolScreen: (() -> Void)?
+    var onCheckForUpdates: (() -> Void)?
 
     private let dot = NSView()
     private let statusLabel = TCPViewerUI.label("", font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium), color: .secondaryLabelColor)
     private let emphasizedLabel = TCPViewerUI.label("", font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold))
     private let helperErrorButton = NSButton(title: "Error", target: nil, action: nil)
+    private let updateBadgeButton = NSButton(title: "", target: nil, action: nil)
     private var helperError: TCPViewerToolbarHelperError?
 
     override init(frame frameRect: NSRect) {
@@ -672,6 +690,17 @@ private final class TCPViewerToolbarStatusView: NSView {
         toolTip = viewModel.helpText
     }
 
+    // Render the optional release badge independently from live-capture status updates.
+    func renderUpdateBadge(_ count: Int) {
+        guard count > 0 else {
+            updateBadgeButton.isHidden = true
+            return
+        }
+
+        updateBadgeButton.title = count == 1 ? "New Update" : "\(count) New Updates"
+        updateBadgeButton.isHidden = false
+    }
+
     private func setupLayout() {
         dot.wantsLayer = true
         dot.layer?.cornerRadius = 4
@@ -679,14 +708,15 @@ private final class TCPViewerToolbarStatusView: NSView {
         statusLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         emphasizedLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         configureHelperErrorButton()
+        configureUpdateBadgeButton()
 
-        let stack = NSStackView(views: [dot, statusLabel, emphasizedLabel, helperErrorButton])
+        let stack = NSStackView(views: [dot, statusLabel, emphasizedLabel, updateBadgeButton, helperErrorButton])
         stack.orientation = .horizontal
         stack.alignment = .centerY
         stack.spacing = 6
         stack.setCustomSpacing(10, after: dot)
         stack.setCustomSpacing(4, after: statusLabel)
-        stack.setCustomSpacing(12, after: emphasizedLabel)
+        stack.setCustomSpacing(8, after: emphasizedLabel)
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
 
@@ -725,11 +755,26 @@ private final class TCPViewerToolbarStatusView: NSView {
         helperErrorButton.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
+    private func configureUpdateBadgeButton() {
+        updateBadgeButton.target = self
+        updateBadgeButton.action = #selector(updateBadgeButtonPressed(_:))
+        updateBadgeButton.bezelStyle = .rounded
+        updateBadgeButton.controlSize = .small
+        updateBadgeButton.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
+        updateBadgeButton.toolTip = "Check for Updates"
+        updateBadgeButton.isHidden = true
+        updateBadgeButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
     @objc private func helperErrorButtonPressed(_ sender: NSButton) {
         guard helperError != nil else {
             return
         }
 
         onOpenHelperToolScreen?()
+    }
+
+    @objc private func updateBadgeButtonPressed(_ sender: NSButton) {
+        onCheckForUpdates?()
     }
 }

--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -105,6 +105,12 @@ final class TCPViewerWindowController: NSWindowController {
         toolbarDataSource.delegate = self
         window?.toolbar = toolbarDataSource.toolbar
         window?.toolbarStyle = .unified
+        toolbarDataSource.setAvailableUpdateCount((NSApp.delegate as? AppDelegate)?.currentAvailableUpdateCount() ?? 0)
+    }
+
+    // Update the independent release badge without rebuilding the capture toolbar state.
+    func updateAvailableBuildCount(_ count: Int) {
+        toolbarDataSource.setAvailableUpdateCount(count)
     }
 
     private func setupQuickFilters() {
@@ -261,6 +267,10 @@ extension TCPViewerWindowController: TCPViewerToolbarDataSourceDelegate {
 
     func tcpviewerToolbarDataSourceDidRequestPaywall(_ dataSource: TCPViewerToolbarDataSource) {
         (NSApp.delegate as? AppDelegate)?.showPaywall(self)
+    }
+
+    func tcpviewerToolbarDataSourceDidRequestCheckForUpdates(_ dataSource: TCPViewerToolbarDataSource) {
+        (NSApp.delegate as? AppDelegate)?.checkForUpdatesFromToolbar()
     }
 }
 

--- a/TCPViewer/Features/License/Services/TCPViewerLicenseNetworkClient.swift
+++ b/TCPViewer/Features/License/Services/TCPViewerLicenseNetworkClient.swift
@@ -33,14 +33,14 @@ protocol TCPViewerLicenseNetworkClienting: AnyObject {
     )
 }
 
-protocol TCPViewerLicenseNetworkTransport {
+protocol TCPViewerServerNetworkTransport {
     func perform(
         _ request: URLRequest,
         completion: @escaping (Data?, HTTPURLResponse?, Error?) -> Void
     )
 }
 
-final class TCPViewerLicenseURLSessionTransport: TCPViewerLicenseNetworkTransport {
+final class TCPViewerServerURLSessionTransport: TCPViewerServerNetworkTransport {
     private let session: URLSession
 
     init(session: URLSession = .shared) {
@@ -58,22 +58,49 @@ final class TCPViewerLicenseURLSessionTransport: TCPViewerLicenseNetworkTranspor
     }
 }
 
-final class TCPViewerLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
-    private enum ServerEndpoint {
-        static let localServerInfoKey = "TCPViewerUsesLocalLicenseServer"
-        static let productionBaseURL = URL(string: "https://api-tcpviewer.proxyman.com")!
-        static let localBaseURL = URL(string: "http://proxyman.debug:3000")!
+enum TCPViewerServerEndpoint {
+    static let localServerInfoKey = "TCPViewerUsesLocalLicenseServer"
+    static let productionBaseURL = URL(string: "https://api-tcpviewer.proxyman.com")!
+    static let localBaseURL = URL(string: "http://proxyman.debug:3000")!
+
+    // Resolve the shared server root so release and license requests use the same environment.
+    static func baseURL(bundleInfo: [String: Any]) -> URL {
+        guard isEnabled(bundleInfo[localServerInfoKey]) else {
+            return productionBaseURL
+        }
+
+        return localBaseURL
     }
 
+    // Accept plist/build-setting values regardless of whether Xcode emits string, number, or bool.
+    private static func isEnabled(_ value: Any?) -> Bool {
+        if let value = value as? Bool {
+            return value
+        }
+
+        if let value = value as? NSNumber {
+            return value.boolValue
+        }
+
+        guard let value = value as? String else {
+            return false
+        }
+
+        let normalizedValue = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["1", "true", "yes", "on"].contains(normalizedValue)
+    }
+}
+
+final class TCPViewerLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
     private let baseURLOverride: URL?
     private let bundleInfo: [String: Any]
-    private let transport: any TCPViewerLicenseNetworkTransport
+    private let transport: any TCPViewerServerNetworkTransport
     private let decoder = JSONDecoder()
 
     init(
         baseURL: URL? = nil,
         bundleInfo: [String: Any] = Bundle.main.infoDictionary ?? [:],
-        transport: any TCPViewerLicenseNetworkTransport = TCPViewerLicenseURLSessionTransport()
+        transport: any TCPViewerServerNetworkTransport = TCPViewerServerURLSessionTransport()
     ) {
         self.baseURLOverride = baseURL
         self.bundleInfo = bundleInfo
@@ -198,7 +225,7 @@ final class TCPViewerLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
 
     private func makeJSONRequest(path: String, method: String, body: [String: Any]) throws -> URLRequest {
         let relativePath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let baseURL = baseURLOverride ?? Self.baseURL(bundleInfo: bundleInfo)
+        let baseURL = baseURLOverride ?? TCPViewerServerEndpoint.baseURL(bundleInfo: bundleInfo)
         guard let url = URL(string: relativePath, relativeTo: baseURL)?.absoluteURL else {
             throw TCPViewerLicenseError.error("Invalid license server URL.")
         }
@@ -207,33 +234,6 @@ final class TCPViewerLicenseNetworkClient: TCPViewerLicenseNetworkClienting {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
         return request
-    }
-
-    // Resolve the shared server root so every license request honors the same build setting.
-    private static func baseURL(bundleInfo: [String: Any]) -> URL {
-        guard isEnabled(bundleInfo[ServerEndpoint.localServerInfoKey]) else {
-            return ServerEndpoint.productionBaseURL
-        }
-
-        return ServerEndpoint.localBaseURL
-    }
-
-    // Accept plist/build-setting values regardless of whether Xcode emits string, number, or bool.
-    private static func isEnabled(_ value: Any?) -> Bool {
-        if let value = value as? Bool {
-            return value
-        }
-
-        if let value = value as? NSNumber {
-            return value.boolValue
-        }
-
-        guard let value = value as? String else {
-            return false
-        }
-
-        let normalizedValue = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return ["1", "true", "yes", "on"].contains(normalizedValue)
     }
 
     private static func mapNetworkError(_ error: Error) -> TCPViewerLicenseError {

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -907,6 +907,7 @@ extension SidebarViewController: NSSearchFieldDelegate {
 
 extension SidebarViewController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
+        // Rebuild the available actions for the rows targeted by the current click.
         updateSelectionFromCurrentMenuEvent()
         let copyAction = selectedCopyAction()
         let pinTargets = selectedPinTargets()
@@ -919,25 +920,25 @@ extension SidebarViewController: NSMenuDelegate {
             return
         }
 
+        if !pinTargets.isEmpty {
+            let pinItem = NSMenuItem(title: "Pin", action: #selector(pinSelectedSourceListItems(_:)), keyEquivalent: "")
+            pinItem.target = self
+            pinItem.isEnabled = true
+            pinItem.image = NSImage(systemSymbolName: "pin", accessibilityDescription: "Pin")
+            menu.addItem(pinItem)
+        }
+
         if let copyAction {
+            if !pinTargets.isEmpty {
+                menu.addItem(.separator())
+            }
+
             let copyItem = NSMenuItem(title: copyAction.menuTitle, action: #selector(copySelectedSourceListItemName(_:)), keyEquivalent: "")
             copyItem.target = self
             copyItem.isEnabled = true
             copyItem.toolTip = "Copy the selected source-list name."
             copyItem.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: copyAction.menuTitle)
             menu.addItem(copyItem)
-        }
-
-        if !pinTargets.isEmpty {
-            if copyAction != nil {
-                menu.addItem(.separator())
-            }
-
-            let pinItem = NSMenuItem(title: "Pin", action: #selector(pinSelectedSourceListItems(_:)), keyEquivalent: "")
-            pinItem.target = self
-            pinItem.isEnabled = true
-            pinItem.image = NSImage(systemSymbolName: "pin", accessibilityDescription: "Pin")
-            menu.addItem(pinItem)
         }
 
         if exportSelection != nil {

--- a/TCPViewerTests/App/TCPViewerUpdateAvailabilityServiceTests.swift
+++ b/TCPViewerTests/App/TCPViewerUpdateAvailabilityServiceTests.swift
@@ -1,0 +1,121 @@
+//
+//  TCPViewerUpdateAvailabilityServiceTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 12/7/26.
+//
+
+import Foundation
+import Testing
+@testable import TCPViewer
+
+struct TCPViewerUpdateAvailabilityServiceTests {
+    @Test func fetchesNewerBuildCountFromReleaseEndpoint() throws {
+        let transport = StubUpdateAvailabilityTransport()
+        transport.nextResult = .success((
+            Data(#"{"new_releases_count":2}"#.utf8),
+            makeResponse(statusCode: 200)
+        ))
+        let service = TCPViewerUpdateAvailabilityService(
+            baseURL: URL(string: "https://example.com")!,
+            transport: transport,
+            buildNumberProvider: { "123" },
+            workerQueue: DispatchQueue(label: "TCPViewerTests.UpdateAvailability", qos: .userInitiated)
+        )
+
+        let count = waitForCount { service.checkForAvailableBuilds(completion: $0) }
+
+        #expect(count == 2)
+        let request = try #require(transport.requests.first)
+        let requestURL = try #require(request.url)
+        let components = try #require(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        #expect(request.httpMethod == "GET")
+        #expect(components.path == "/api/releases/check-new-updates")
+        #expect(components.queryItems?.contains(URLQueryItem(name: "platform", value: "macos")) == true)
+        #expect(components.queryItems?.contains(URLQueryItem(name: "build_number", value: "123")) == true)
+    }
+
+    @Test func hidesBadgeForReleaseEndpointFailures() {
+        let transport = StubUpdateAvailabilityTransport()
+        transport.nextResult = .success((Data(), makeResponse(statusCode: 404)))
+        let service = TCPViewerUpdateAvailabilityService(
+            baseURL: URL(string: "https://example.com")!,
+            transport: transport,
+            workerQueue: DispatchQueue(label: "TCPViewerTests.UpdateAvailability", qos: .userInitiated)
+        )
+
+        let count = waitForCount { service.checkForAvailableBuilds(completion: $0) }
+
+        #expect(count == 0)
+    }
+
+    @Test func usesLocalServerWhenConfigured() throws {
+        let transport = StubUpdateAvailabilityTransport()
+        transport.nextResult = .success((
+            Data(#"{"new_releases_count":1}"#.utf8),
+            makeResponse(statusCode: 200)
+        ))
+        let service = TCPViewerUpdateAvailabilityService(
+            bundleInfo: ["TCPViewerUsesLocalLicenseServer": true],
+            transport: transport,
+            buildNumberProvider: { "123" },
+            workerQueue: DispatchQueue(label: "TCPViewerTests.UpdateAvailability", qos: .userInitiated)
+        )
+
+        _ = waitForCount { service.checkForAvailableBuilds(completion: $0) }
+
+        let request = try #require(transport.requests.first)
+        #expect(request.url?.absoluteString == "http://proxyman.debug:3000/api/releases/check-new-updates?platform=macos&build_number=123")
+    }
+
+    private func makeResponse(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    private func waitForCount(_ start: (@escaping (Int) -> Void) -> Void) -> Int {
+        var count: Int?
+        let semaphore = DispatchSemaphore(value: 0)
+        start {
+            count = $0
+            semaphore.signal()
+        }
+        #expect(semaphore.wait(timeout: .now() + 2) == .success)
+        return count ?? 0
+    }
+}
+
+private final class StubUpdateAvailabilityTransport: TCPViewerServerNetworkTransport {
+    enum TransportResult {
+        case success((Data?, HTTPURLResponse))
+        case failure(Error)
+    }
+
+    var requests: [URLRequest] = []
+    var nextResult: TransportResult = .success((
+        Data(),
+        HTTPURLResponse(
+            url: URL(string: "https://example.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    ))
+
+    func perform(
+        _ request: URLRequest,
+        completion: @escaping (Data?, HTTPURLResponse?, Error?) -> Void
+    ) {
+        requests.append(request)
+        switch nextResult {
+        case .success(let response):
+            completion(response.0, response.1, nil)
+        case .failure(let error):
+            completion(nil, nil, error)
+        }
+    }
+}

--- a/TCPViewerTests/Features/License/TCPViewerLicenseNetworkClientTests.swift
+++ b/TCPViewerTests/Features/License/TCPViewerLicenseNetworkClientTests.swift
@@ -289,7 +289,7 @@ struct TCPViewerLicenseNetworkClientTests {
     }
 }
 
-private final class StubLicenseTransport: TCPViewerLicenseNetworkTransport {
+private final class StubLicenseTransport: TCPViewerServerNetworkTransport {
     enum TransportResult {
         case success((Data?, HTTPURLResponse))
         case failure(Error)

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -150,7 +150,7 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
-    @Test func sidebarContextMenuPlacesCopyAndShowInFinderAboveDelete() throws {
+    @Test func sidebarContextMenuPlacesPinFirstAndShowInFinderAboveDelete() throws {
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
         let controller = SidebarViewController()
         controller.loadViewIfNeeded()
@@ -167,7 +167,10 @@ struct SidebarOutlineReloadPolicyTests {
         controller.menuNeedsUpdate(menu)
 
         let nonSeparatorTitles = menu.items.filter { !$0.isSeparatorItem }.map(\.title)
-        #expect(nonSeparatorTitles == ["Copy App Name", "Pin", "Export", "Show in Finder…", "Delete"])
+        #expect(nonSeparatorTitles == ["Pin", "Copy App Name", "Export", "Show in Finder…", "Delete"])
+        let pinIndex = try #require(menu.items.firstIndex { $0.title == "Pin" })
+        #expect(pinIndex == 0)
+        #expect(menu.items[pinIndex + 1].isSeparatorItem)
         let copyIndex = try #require(menu.items.firstIndex { $0.title == "Copy App Name" })
         #expect(menu.items[copyIndex + 1].isSeparatorItem)
         let finderIndex = try #require(menu.items.firstIndex { $0.title == "Show in Finder…" })
@@ -194,7 +197,8 @@ struct SidebarOutlineReloadPolicyTests {
         controller.menuNeedsUpdate(menu)
 
         let nonSeparatorTitles = menu.items.filter { !$0.isSeparatorItem }.map(\.title)
-        #expect(nonSeparatorTitles.first == "Copy Domain Name")
+        #expect(nonSeparatorTitles.first == "Pin")
+        #expect(nonSeparatorTitles.contains("Copy Domain Name"))
         #expect(!nonSeparatorTitles.contains("Copy App Name"))
     }
 


### PR DESCRIPTION
## Summary
- Add a launch-time availability check so skipped Sparkle releases can still surface as a toolbar badge
- Wire the toolbar badge to trigger Sparkle's standard update flow when clicked
- Reuse the shared server endpoint helper for both license and release-check requests
- Adjust sidebar context menu ordering so Pin is offered first when applicable
- Update unit coverage for the new menu order and shared transport type

## Testing
- Unit tests updated for sidebar context menu ordering and transport conformance
- Not run (not requested)