### PR TITLE
Add optional Homebrew Cask PR creation to production releases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,6 @@ TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND=false
 TCPVIEWER_RELEASE_BACKEND_URL=
 TCPVIEWER_RELEASE_BACKEND_SCRIPT_SECRET=
 
-# Required only when a production release also creates a Homebrew Cask update PR.
+# Required only when a production release creates an initial or updated Homebrew Cask PR.
+# Use the path printed by: brew --repository homebrew/cask
 TCPVIEWER_HOMEBREW_CASK_REPO=/path/to/homebrew-cask

--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,6 @@ TCPVIEWER_R2_PUBLIC_BASE_URL=https://downloads.example.com
 TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND=false
 TCPVIEWER_RELEASE_BACKEND_URL=
 TCPVIEWER_RELEASE_BACKEND_SCRIPT_SECRET=
+
+# Required only when a production release also creates a Homebrew Cask update PR.
+TCPVIEWER_HOMEBREW_CASK_REPO=/path/to/homebrew-cask

--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ For production releases, add a matching entry to `ReleaseNote.json`, then run:
 npm run release
 ```
 
-Choose `beta` or `production` when prompted. Production releases also create the Sparkle appcast, push the `v<version>` tag, and publish the GitHub release. Artifacts are written under:
+Choose `beta` or `production` when prompted. Production releases also create the Sparkle appcast, push the `v<version>` tag, and publish the GitHub release. They can optionally update `tcpviewer.rb` in the configured `TCPVIEWER_HOMEBREW_CASK_REPO` checkout and open a pull request from `ProxymanApp/homebrew-cask` to `Homebrew/homebrew-cask`. The checkout must be clean, on `master`, and in sync with `origin/master` before the release starts.
+
+For non-interactive production releases, pass `--bump-homebrew` to enable the cask PR or `--no-bump-homebrew` to skip it. `--yes` skips the Homebrew update unless `--bump-homebrew` is also present.
+
+Artifacts are written under:
 
 ```bash
 ~/Desktop/tcpviewer-production/

--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ For production releases, add a matching entry to `ReleaseNote.json`, then run:
 npm run release
 ```
 
-Choose `beta` or `production` when prompted. Production releases also create the Sparkle appcast, push the `v<version>` tag, and publish the GitHub release. They can optionally update `tcpviewer.rb` in the configured `TCPVIEWER_HOMEBREW_CASK_REPO` checkout and open a pull request from `ProxymanApp/homebrew-cask` to `Homebrew/homebrew-cask`. The checkout must be clean, on `master`, and in sync with `origin/master` before the release starts.
-
-For non-interactive production releases, pass `--bump-homebrew` to enable the cask PR or `--no-bump-homebrew` to skip it. `--yes` skips the Homebrew update unless `--bump-homebrew` is also present.
-
-Artifacts are written under:
+Choose `beta` or `production` when prompted. Production releases also create the Sparkle appcast, push the `v<version>` tag, and publish the GitHub release. Artifacts are written under:
 
 ```bash
 ~/Desktop/tcpviewer-production/

--- a/scripts/homebrew/README.md
+++ b/scripts/homebrew/README.md
@@ -1,0 +1,54 @@
+# Homebrew Cask release setup
+
+The production release can create the initial TCP Viewer cask or update the existing cask.
+
+## One-time setup
+
+```bash
+brew tap --force homebrew/cask
+cd "$(brew --repository homebrew/cask)"
+git remote add proxyman git@github.com:ProxymanApp/homebrew-cask.git
+```
+
+Set `TCPVIEWER_HOMEBREW_CASK_REPO` in the local `.env` file to the path printed by:
+
+```bash
+brew --repository homebrew/cask
+```
+
+The release always creates its cask branch from current `origin/main`. It pushes only that branch to the `proxyman` fork remote, so a stale fork default branch cannot enter the pull request.
+
+## Initial cask
+
+The initial cask uses `tcpviewer.rb` in this directory. The release fills in its version, build number, and SHA-256.
+
+The release runs these maintained Homebrew checks:
+
+- `brew style --fix --cask tcpviewer`
+- `brew audit --cask --online --new tcpviewer`
+- `brew livecheck --cask --autobump tcpviewer`
+- `brew lgtm --online`
+
+Before the initial pull request is created, the interactive release pauses for the required install and uninstall checks:
+
+```bash
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask tcpviewer
+brew uninstall --cask tcpviewer
+```
+
+For a non-interactive release, add `--homebrew-install-tested` only after both commands have passed.
+
+Review Homebrew's current [cask acceptance](https://docs.brew.sh/Acceptable-Casks) and [package acceptance](https://docs.brew.sh/Package-Acceptance-Policy) policies before submitting the initial cask. Homebrew maintainers make the final acceptance decision.
+
+## Release flags
+
+- `--bump-homebrew` creates the cask pull request.
+- `--no-bump-homebrew` skips Homebrew.
+- `--yes` skips Homebrew unless `--bump-homebrew` is also present.
+- `--homebrew-install-tested` confirms the initial install and uninstall checks already passed.
+
+After Homebrew merges the initial cask, users can install the app with:
+
+```bash
+brew install --cask tcpviewer
+```

--- a/scripts/homebrew/tcpviewer.rb
+++ b/scripts/homebrew/tcpviewer.rb
@@ -1,0 +1,34 @@
+cask "tcpviewer" do
+  version "0.0.0,0"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://assets-tcpviewer.proxyman.com/release/production/#{version.csv.first}/#{version.csv.second}/tcpviewer_#{version.csv.first}_#{version.csv.second}.dmg"
+  name "TCP Viewer"
+  desc "Packet capture and inspection tool"
+  homepage "https://tcpviewer.proxyman.com/"
+
+  livecheck do
+    url "https://api-tcpviewer.proxyman.com/api/releases/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sequoia
+
+  app "TCP Viewer.app"
+
+  uninstall launchctl: "com.proxyman.tcpviewer.helpertool",
+            quit:      "com.proxyman.tcpviewer",
+            delete:    [
+              "/Library/LaunchDaemons/com.proxyman.tcpviewer.helpertool.plist",
+              "/Library/PrivilegedHelperTools/com.proxyman.tcpviewer.helpertool",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/TCPViewer",
+    "~/Library/Caches/com.proxyman.tcpviewer",
+    "~/Library/Preferences/com.proxyman.tcpviewer.plist",
+    "~/Library/Saved Application State/com.proxyman.tcpviewer.savedState",
+  ]
+end

--- a/scripts/nodejs/index.js
+++ b/scripts/nodejs/index.js
@@ -20,6 +20,10 @@ function parseArgs(argv) {
       args.betaName = arg.slice("--beta-name=".length).trim();
     } else if (arg === "--yes" || arg === "-y") {
       args.yes = true;
+    } else if (arg === "--bump-homebrew") {
+      args.bumpHomebrew = true;
+    } else if (arg === "--no-bump-homebrew") {
+      args.bumpHomebrew = false;
     }
   }
   return args;
@@ -102,6 +106,9 @@ function buildReleaseArgs(type, args) {
   }
   if (args.yes) {
     releaseArgs.push("--yes");
+  }
+  if (typeof args.bumpHomebrew === "boolean") {
+    releaseArgs.push(args.bumpHomebrew ? "--bump-homebrew" : "--no-bump-homebrew");
   }
   return releaseArgs;
 }

--- a/scripts/nodejs/index.js
+++ b/scripts/nodejs/index.js
@@ -24,6 +24,8 @@ function parseArgs(argv) {
       args.bumpHomebrew = true;
     } else if (arg === "--no-bump-homebrew") {
       args.bumpHomebrew = false;
+    } else if (arg === "--homebrew-install-tested") {
+      args.homebrewInstallTested = true;
     }
   }
   return args;
@@ -109,6 +111,9 @@ function buildReleaseArgs(type, args) {
   }
   if (typeof args.bumpHomebrew === "boolean") {
     releaseArgs.push(args.bumpHomebrew ? "--bump-homebrew" : "--no-bump-homebrew");
+  }
+  if (args.homebrewInstallTested) {
+    releaseArgs.push("--homebrew-install-tested");
   }
   return releaseArgs;
 }

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -326,6 +326,42 @@ export function normalizeBetaDMGCustomName(value) {
   return normalizeFileNameSegment(normalized, "Beta DMG custom name");
 }
 
+export function makeHomebrewCaskBranchName({ version, buildNumber }) {
+  const safeVersion = normalizeFileNameSegment(version, "Homebrew Cask version");
+  const safeBuildNumber = normalizeFileNameSegment(buildNumber, "Homebrew Cask build number");
+  return `tcpviewer-${safeVersion}-${safeBuildNumber}`;
+}
+
+export function parseHomebrewCaskVersion(content) {
+  const match = String(content).match(/^  version "([^"]+),([^"]+)"$/m);
+  if (!match) {
+    throw new Error("TCP Viewer Homebrew Cask must contain one version with a version and build number.");
+  }
+
+  return { version: match[1], buildNumber: match[2] };
+}
+
+export function updateHomebrewCaskContent(content, { version, buildNumber, sha256 }) {
+  const current = String(content);
+  parseHomebrewCaskVersion(current);
+  const safeVersion = normalizeFileNameSegment(version, "Homebrew Cask version");
+  const safeBuildNumber = normalizeFileNameSegment(buildNumber, "Homebrew Cask build number");
+  const safeSHA256 = String(sha256 ?? "").trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(safeSHA256)) {
+    throw new Error("Homebrew Cask SHA-256 must contain 64 hexadecimal characters.");
+  }
+
+  const versionMatches = current.match(/^  version ".*"$/gm) ?? [];
+  const shaMatches = current.match(/^  sha256 ".*"$/gm) ?? [];
+  if (versionMatches.length !== 1 || shaMatches.length !== 1) {
+    throw new Error("TCP Viewer Homebrew Cask must contain exactly one version and one SHA-256 stanza.");
+  }
+
+  return current
+    .replace(versionMatches[0], `  version "${safeVersion},${safeBuildNumber}"`)
+    .replace(shaMatches[0], `  sha256 "${safeSHA256}"`);
+}
+
 export function makeR2ObjectKey({ releaseType, version, buildNumber, timestamp, fileName }) {
   const safeFileName = validateDMGFileName(fileName ?? makeDMGFileName({ version, buildNumber }));
 

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -332,6 +332,79 @@ export function makeHomebrewCaskBranchName({ version, buildNumber }) {
   return `tcpviewer-${safeVersion}-${safeBuildNumber}`;
 }
 
+export function makeHomebrewCaskAuditArgs({ isInitialCask, token = "tcpviewer" }) {
+  const args = ["audit", "--cask", "--online"];
+  if (isInitialCask) {
+    args.push("--new");
+  }
+  args.push(token);
+  return args;
+}
+
+export function validateHomebrewLivecheckOutput(output, expectedVersion) {
+  let entries;
+  try {
+    entries = JSON.parse(String(output));
+  } catch {
+    throw new Error("Homebrew livecheck did not return valid JSON.");
+  }
+  const entry = Array.isArray(entries) ? entries[0] : null;
+  if (!entry?.version) {
+    throw new Error(`Homebrew livecheck did not return a version: ${entry?.status ?? "missing result"}.`);
+  }
+  if (entry.version.current !== expectedVersion || entry.version.latest !== expectedVersion) {
+    throw new Error(
+      `Homebrew livecheck must report ${expectedVersion} as current and latest; `
+      + `found ${entry.version.current ?? "unknown"} and ${entry.version.latest ?? "unknown"}.`
+    );
+  }
+}
+
+export function makeHomebrewCaskPullRequestBody({ isInitialCask, githubMetrics, token = "tcpviewer" }) {
+  const lines = [
+    "-----",
+    "",
+    "- [x] The submission is for "
+    + "[a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or documented exception.",
+    `- [x] \`brew audit --cask --online ${token}\` is error-free.`,
+    `- [x] \`brew style --fix ${token}\` reports no offenses.`,
+    ""
+  ];
+  if (isInitialCask) {
+    if (!githubMetrics) {
+      throw new Error("GitHub metrics are required for an initial Homebrew Cask pull request.");
+    }
+    lines.push(
+      "Additionally, for this new cask:",
+      "",
+      "- [x] Named the cask according to the "
+      + "[token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).",
+      "- [x] Checked that the cask was not previously refused.",
+      `- [x] \`brew audit --cask --new ${token}\` worked successfully.`,
+      `- [x] \`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ${token}\` worked successfully.`,
+      `- [x] \`brew uninstall --cask ${token}\` worked successfully.`,
+      "",
+      "Canonical repository: https://github.com/ProxymanApp/TCPViewer ",
+      `(${githubMetrics.stars} stars, ${githubMetrics.forks} forks, `
+      + `${githubMetrics.watchers} watchers when this PR was created).`,
+      ""
+    );
+  }
+  lines.push(
+    "-----",
+    "",
+    "- [x] I disclosed the AI/LLM tool below and reviewed its output, including the "
+    + "[zap stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI "
+    + "and will answer maintainer questions and review comments myself without AI/LLM.",
+    "",
+    "OpenAI Codex assisted with the release automation that updated this cask. The maintainer reviewed the "
+    + "cask, verified the release artifact, and ran the checked Homebrew validation commands.",
+    "",
+    "-----"
+  );
+  return lines.join("\n");
+}
+
 export function parseHomebrewCaskVersion(content) {
   const match = String(content).match(/^  version "([^"]+),([^"]+)"$/m);
   if (!match) {
@@ -341,9 +414,34 @@ export function parseHomebrewCaskVersion(content) {
   return { version: match[1], buildNumber: match[2] };
 }
 
+export function githubRepoFromRemoteURL(remoteURL) {
+  const match = String(remoteURL).trim().match(
+    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/)([^/]+\/[^/]+?)(?:\.git)?$/i
+  );
+  return match ? match[1].toLowerCase() : null;
+}
+
+export function validateHomebrewCaskContent(content) {
+  const current = String(content);
+  const parsedVersion = parseHomebrewCaskVersion(current);
+  const versionMatches = current.match(/^  version ".*"$/gm) ?? [];
+  const shaMatches = current.match(/^  sha256 ".*"$/gm) ?? [];
+  if (versionMatches.length !== 1 || shaMatches.length !== 1) {
+    throw new Error("TCP Viewer Homebrew Cask must contain exactly one version and one SHA-256 stanza.");
+  }
+  if (!/^  depends_on arch: :arm64$/m.test(current)) {
+    throw new Error("TCP Viewer Homebrew Cask must require Apple Silicon.");
+  }
+  if (!/^  app "TCP Viewer\.app"$/m.test(current)) {
+    throw new Error("TCP Viewer Homebrew Cask must install TCP Viewer.app.");
+  }
+
+  return parsedVersion;
+}
+
 export function updateHomebrewCaskContent(content, { version, buildNumber, sha256 }) {
   const current = String(content);
-  parseHomebrewCaskVersion(current);
+  validateHomebrewCaskContent(current);
   const safeVersion = normalizeFileNameSegment(version, "Homebrew Cask version");
   const safeBuildNumber = normalizeFileNameSegment(buildNumber, "Homebrew Cask build number");
   const safeSHA256 = String(sha256 ?? "").trim().toLowerCase();
@@ -351,15 +449,14 @@ export function updateHomebrewCaskContent(content, { version, buildNumber, sha25
     throw new Error("Homebrew Cask SHA-256 must contain 64 hexadecimal characters.");
   }
 
-  const versionMatches = current.match(/^  version ".*"$/gm) ?? [];
-  const shaMatches = current.match(/^  sha256 ".*"$/gm) ?? [];
-  if (versionMatches.length !== 1 || shaMatches.length !== 1) {
-    throw new Error("TCP Viewer Homebrew Cask must contain exactly one version and one SHA-256 stanza.");
-  }
+  const versionMatch = current.match(/^  version ".*"$/m)[0];
+  const shaMatch = current.match(/^  sha256 ".*"$/m)[0];
 
-  return current
-    .replace(versionMatches[0], `  version "${safeVersion},${safeBuildNumber}"`)
-    .replace(shaMatches[0], `  sha256 "${safeSHA256}"`);
+  const updated = current
+    .replace(versionMatch, `  version "${safeVersion},${safeBuildNumber}"`)
+    .replace(shaMatch, `  sha256 "${safeSHA256}"`);
+  validateHomebrewCaskContent(updated);
+  return updated;
 }
 
 export function makeR2ObjectKey({ releaseType, version, buildNumber, timestamp, fileName }) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -24,6 +24,7 @@ import {
   findReleaseNote,
   generateAppcastXML,
   isRetryableHTTPStatus,
+  makeHomebrewCaskBranchName,
   makeGitHubReleaseTagName,
   makeBetaDMGFileName,
   makeDMGFileName,
@@ -37,6 +38,7 @@ import {
   normalizeSparklePrivateKey,
   parseBuildSettings,
   parseEnvFile,
+  parseHomebrewCaskVersion,
   parseReleaseNotes,
   parseSparkleSignatureOutput,
   publicR2URL,
@@ -45,7 +47,8 @@ import {
   releaseBackendRequiredEnvNames,
   releaseNotesToMarkdown,
   requiredEnvNames,
-  signR2Request
+  signR2Request,
+  updateHomebrewCaskContent
 } from "./release-lib.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -55,6 +58,10 @@ const r2UploadMaxAttempts = 3;
 const r2UploadConfirmationAttempts = 3;
 const r2UploadAttemptTimeoutMs = 300_000;
 const r2UploadConfirmationTimeoutMs = 30_000;
+const homebrewCaskForkRepo = "ProxymanApp/homebrew-cask";
+const homebrewCaskUpstreamRepo = "Homebrew/homebrew-cask";
+const homebrewCaskDefaultBranch = "master";
+const homebrewCaskRelativePath = "Casks/t/tcpviewer.rb";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -62,6 +69,8 @@ async function main() {
   if (!["beta", "production"].includes(releaseType)) {
     throw new Error("Release type must be beta or production.");
   }
+  const bumpHomebrew = releaseType === "production"
+    && (args.bumpHomebrew ?? (args.yes ? false : await askHomebrewCaskBump()));
 
   const { env, envFileExists } = await loadReleaseEnv();
   const settings = await readXcodeBuildSettings(env);
@@ -89,6 +98,9 @@ async function main() {
   const downloadURL = publicR2URL(env.TCPVIEWER_R2_PUBLIC_BASE_URL, releaseObjectKey);
   const outputDir = releaseOutputDir({ releaseType, version, buildNumber, timestamp });
   const releaseBackend = resolveReleaseBackend({ env, releaseType });
+  const homebrewRelease = bumpHomebrew
+    ? resolveHomebrewRelease({ env, version, buildNumber })
+    : null;
 
   console.log(`Preparing ${releaseType} release ${version} (${buildNumber})`);
   if (!envFileExists) {
@@ -106,7 +118,17 @@ async function main() {
     };
   }
 
-  await preflight({ env, releaseType, objectKey, settings, releaseBackend, version, buildNumber, githubRelease });
+  await preflight({
+    env,
+    releaseType,
+    objectKey,
+    settings,
+    releaseBackend,
+    version,
+    buildNumber,
+    githubRelease,
+    homebrewRelease
+  });
 
   printReleaseSummary({
     releaseType,
@@ -119,7 +141,8 @@ async function main() {
     envFileExists,
     releaseNote,
     githubRelease,
-    releaseBackend
+    releaseBackend,
+    homebrewRelease
   });
   if (!args.yes && !await askReleaseConfirmation()) {
     console.log("Release cancelled.");
@@ -158,6 +181,9 @@ async function main() {
       dmgPath,
       outputDir
     });
+    if (homebrewRelease) {
+      await createHomebrewCaskPullRequest({ homebrewRelease, dmgPath });
+    }
   }
 
   console.log(`${releaseType === "production" ? "Production" : "BETA"} release is ready: ${downloadURL}`);
@@ -182,7 +208,17 @@ async function loadReleaseEnv() {
   };
 }
 
-async function preflight({ env, releaseType, objectKey, settings, releaseBackend, version, buildNumber, githubRelease }) {
+async function preflight({
+  env,
+  releaseType,
+  objectKey,
+  settings,
+  releaseBackend,
+  version,
+  buildNumber,
+  githubRelease,
+  homebrewRelease
+}) {
   // Keep preflight strict because it runs before long signing and notarization work.
   const missing = missingRequiredEnv(env, requiredEnvNames(releaseType));
   if (missing.length) {
@@ -190,6 +226,9 @@ async function preflight({ env, releaseType, objectKey, settings, releaseBackend
   }
 
   await requireTool("git", ["--version"]);
+  if (homebrewRelease) {
+    await preflightHomebrewRelease(homebrewRelease);
+  }
   await requireTool("node", ["--version"]);
   await requireTool("npm", ["--version"]);
   await ensureCreateDMGTool();
@@ -307,6 +346,219 @@ async function createGitHubRelease({ githubRelease, releaseNote, dmgPath, output
   ], { capture: true });
   const releaseURL = result.stdout.trim() || `https://github.com/${githubRelease.repo}/releases/tag/${githubRelease.tagName}`;
   console.log(`GitHub release created: ${releaseURL}`);
+}
+
+// Resolve the fixed cask and branch locations before release preflight starts.
+function resolveHomebrewRelease({ env, version, buildNumber }) {
+  const configuredPath = String(env.TCPVIEWER_HOMEBREW_CASK_REPO ?? "").trim();
+  if (!configuredPath) {
+    throw new Error("TCPVIEWER_HOMEBREW_CASK_REPO is required when Homebrew Cask publishing is selected.");
+  }
+
+  const repoPath = configuredPath === "~"
+    ? homedir()
+    : configuredPath.startsWith("~/")
+      ? path.join(homedir(), configuredPath.slice(2))
+      : path.resolve(configuredPath);
+  return {
+    version,
+    buildNumber,
+    repoPath,
+    caskPath: path.join(repoPath, homebrewCaskRelativePath),
+    branchName: makeHomebrewCaskBranchName({ version, buildNumber })
+  };
+}
+
+// Reject an unsafe or stale fork checkout before any release side effects occur.
+async function preflightHomebrewRelease(homebrewRelease) {
+  await requireTool("brew", ["--version"]);
+  await requireTool("gh", ["--version"]);
+  await requireTool("gh", ["auth", "status"]);
+
+  let repoStat;
+  try {
+    repoStat = await stat(homebrewRelease.repoPath);
+  } catch {
+    throw new Error(`Homebrew Cask repository was not found: ${homebrewRelease.repoPath}`);
+  }
+  if (!repoStat.isDirectory()) {
+    throw new Error(`Homebrew Cask repository is not a directory: ${homebrewRelease.repoPath}`);
+  }
+
+  const repoRootResult = await runCommand("git", ["rev-parse", "--show-toplevel"], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  });
+  if (path.resolve(repoRootResult.stdout.trim()) !== path.resolve(homebrewRelease.repoPath)) {
+    throw new Error(`TCPVIEWER_HOMEBREW_CASK_REPO must point to the repository root: ${homebrewRelease.repoPath}`);
+  }
+
+  const originURL = (await runCommand("git", ["remote", "get-url", "origin"], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  })).stdout.trim();
+  if (githubRepoFromRemoteURL(originURL) !== homebrewCaskForkRepo.toLowerCase()) {
+    throw new Error(`Homebrew Cask origin must be ${homebrewCaskForkRepo}; found ${originURL}.`);
+  }
+
+  const parentRepo = (await runCommand("gh", [
+    "api",
+    `repos/${homebrewCaskForkRepo}`,
+    "--jq",
+    ".parent.full_name"
+  ], { capture: true })).stdout.trim();
+  if (parentRepo !== homebrewCaskUpstreamRepo) {
+    throw new Error(`${homebrewCaskForkRepo} must be a fork of ${homebrewCaskUpstreamRepo}.`);
+  }
+  try {
+    await runCommand("gh", [
+      "api",
+      `repos/${homebrewCaskUpstreamRepo}/contents/${homebrewCaskRelativePath}`,
+      "--silent"
+    ], { capture: true });
+  } catch {
+    throw new Error(
+      `TCP Viewer is not present in ${homebrewCaskUpstreamRepo}; merge the initial cask before enabling release bumps.`
+    );
+  }
+
+  await runCommand("git", ["fetch", "origin", homebrewCaskDefaultBranch, "--prune"], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  });
+  await ensureHomebrewGitReady(homebrewRelease);
+
+  let caskContent;
+  try {
+    caskContent = await readFile(homebrewRelease.caskPath, "utf8");
+  } catch {
+    throw new Error(`TCP Viewer Homebrew Cask was not found: ${homebrewRelease.caskPath}`);
+  }
+  const currentVersion = parseHomebrewCaskVersion(caskContent);
+  if (
+    currentVersion.version === homebrewRelease.version
+    && currentVersion.buildNumber === homebrewRelease.buildNumber
+  ) {
+    throw new Error(`Homebrew Cask already contains ${homebrewRelease.version},${homebrewRelease.buildNumber}.`);
+  }
+
+  await ensureHomebrewBranchDoesNotExist(homebrewRelease);
+  await runCommand("brew", ["style", homebrewRelease.caskPath]);
+  console.log(`Homebrew Cask check passed for ${homebrewRelease.repoPath}.`);
+}
+
+// Require a clean fork default branch that exactly matches its remote tracking branch.
+async function ensureHomebrewGitReady(homebrewRelease) {
+  const status = await runCommand("git", ["status", "--porcelain"], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  });
+  if (status.stdout.trim()) {
+    throw new Error("Homebrew Cask working tree must be clean before a production release.");
+  }
+
+  const branch = (await runCommand("git", ["branch", "--show-current"], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  })).stdout.trim();
+  if (branch !== homebrewCaskDefaultBranch) {
+    throw new Error(`Homebrew Cask repository must be on ${homebrewCaskDefaultBranch}; current branch is ${branch || "detached HEAD"}.`);
+  }
+
+  const counts = (await runCommand("git", [
+    "rev-list",
+    "--left-right",
+    "--count",
+    `HEAD...origin/${homebrewCaskDefaultBranch}`
+  ], { cwd: homebrewRelease.repoPath, capture: true })).stdout.trim().split(/\s+/);
+  if (counts[0] !== "0" || counts[1] !== "0") {
+    throw new Error(`Homebrew Cask ${homebrewCaskDefaultBranch} must be in sync with origin/${homebrewCaskDefaultBranch}.`);
+  }
+}
+
+async function ensureHomebrewBranchDoesNotExist(homebrewRelease) {
+  try {
+    await runCommand("git", ["show-ref", "--verify", "--quiet", `refs/heads/${homebrewRelease.branchName}`], {
+      cwd: homebrewRelease.repoPath,
+      capture: true
+    });
+    throw new Error(`Homebrew Cask branch already exists locally: ${homebrewRelease.branchName}`);
+  } catch (error) {
+    if (String(error.message).startsWith("Homebrew Cask branch already exists")) {
+      throw error;
+    }
+  }
+
+  const remoteBranch = await runCommand("git", [
+    "ls-remote",
+    "--heads",
+    "origin",
+    `refs/heads/${homebrewRelease.branchName}`
+  ], { cwd: homebrewRelease.repoPath, capture: true });
+  if (remoteBranch.stdout.trim()) {
+    throw new Error(`Homebrew Cask branch already exists on origin: ${homebrewRelease.branchName}`);
+  }
+}
+
+// Publish the minimal version and checksum change from the maintained fork.
+async function createHomebrewCaskPullRequest({ homebrewRelease, dmgPath }) {
+  const sha256 = await sha256File(dmgPath);
+  const currentContent = await readFile(homebrewRelease.caskPath, "utf8");
+  const updatedContent = updateHomebrewCaskContent(currentContent, {
+    version: homebrewRelease.version,
+    buildNumber: homebrewRelease.buildNumber,
+    sha256
+  });
+
+  await runCommand("git", ["switch", "-c", homebrewRelease.branchName], {
+    cwd: homebrewRelease.repoPath
+  });
+  try {
+    await writeFile(homebrewRelease.caskPath, updatedContent);
+    await runCommand("brew", ["style", homebrewRelease.caskPath]);
+    await runCommand("git", ["add", homebrewCaskRelativePath], { cwd: homebrewRelease.repoPath });
+    await runCommand("git", ["diff", "--cached", "--check"], { cwd: homebrewRelease.repoPath });
+    await runCommand("git", ["commit", "-m", `tcpviewer ${homebrewRelease.version}`], {
+      cwd: homebrewRelease.repoPath
+    });
+    await runCommand("git", ["push", "--set-upstream", "origin", homebrewRelease.branchName], {
+      cwd: homebrewRelease.repoPath
+    });
+
+    const result = await runCommand("gh", [
+      "pr",
+      "create",
+      "--repo",
+      homebrewCaskUpstreamRepo,
+      "--base",
+      homebrewCaskDefaultBranch,
+      "--head",
+      `ProxymanApp:${homebrewRelease.branchName}`,
+      "--title",
+      `tcpviewer ${homebrewRelease.version}`,
+      "--body",
+      [
+        "Built and tested locally on macOS.",
+        "",
+        "AI-assisted release automation updated the version and checksum; the maintainer verified the release artifact."
+      ].join("\n")
+    ], { capture: true });
+    const pullRequestURL = result.stdout.trim();
+    console.log(`Homebrew Cask pull request created: ${pullRequestURL}`);
+  } catch (error) {
+    throw new Error(
+      `Homebrew Cask update failed. Branch ${homebrewRelease.branchName} was kept for recovery.\n${error.message}`
+    );
+  }
+
+  await runCommand("git", ["switch", homebrewCaskDefaultBranch], { cwd: homebrewRelease.repoPath });
+}
+
+function githubRepoFromRemoteURL(remoteURL) {
+  const match = String(remoteURL).trim().match(
+    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/)([^/]+\/[^/]+?)(?:\.git)?$/i
+  );
+  return match ? match[1].toLowerCase() : null;
 }
 
 async function signDMG({ env, dmgPath, settings }) {
@@ -898,10 +1150,10 @@ function isNativeModuleVersionMismatch(error) {
   return message.includes("NODE_MODULE_VERSION") || message.includes("ERR_DLOPEN_FAILED");
 }
 
-function runCommand(command, args, { env = {}, capture = false } = {}) {
+function runCommand(command, args, { env = {}, capture = false, cwd = repoRoot } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
-      cwd: repoRoot,
+      cwd,
       env: { ...process.env, ...env },
       stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit"
     });
@@ -961,6 +1213,20 @@ async function askBetaDMGCustomName(version, buildNumber) {
   return requirePromptValue(response.customName, "Beta DMG custom name");
 }
 
+async function askHomebrewCaskBump() {
+  const response = await prompts({
+    type: "confirm",
+    name: "bumpHomebrew",
+    message: "Create a Homebrew Cask update pull request after this production release?",
+    initial: false
+  });
+
+  if (typeof response.bumpHomebrew !== "boolean") {
+    throw new Error("Homebrew Cask selection was cancelled.");
+  }
+  return response.bumpHomebrew;
+}
+
 async function askReleaseConfirmation() {
   const response = await prompts({
     type: "confirm",
@@ -994,7 +1260,8 @@ function printReleaseSummary({
   envFileExists,
   releaseNote,
   githubRelease,
-  releaseBackend
+  releaseBackend,
+  homebrewRelease
 }) {
   console.log("");
   console.log("Release summary:");
@@ -1014,6 +1281,7 @@ function printReleaseSummary({
   if (githubRelease) {
     console.log(`- GitHub release: ${githubRelease.repo} ${githubRelease.tagName}`);
   }
+  console.log(`- Homebrew Cask PR: ${homebrewRelease ? `enabled (${homebrewRelease.repoPath})` : "disabled"}`);
 }
 
 function validateRequiredBuildSettings(settings) {
@@ -1033,6 +1301,10 @@ function parseArgs(argv) {
       args.betaName = arg.slice("--beta-name=".length);
     } else if (arg === "--yes" || arg === "-y") {
       args.yes = true;
+    } else if (arg === "--bump-homebrew") {
+      args.bumpHomebrew = true;
+    } else if (arg === "--no-bump-homebrew") {
+      args.bumpHomebrew = false;
     }
   }
   return args;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -23,8 +23,11 @@ import {
   emptyPayloadSHA256,
   findReleaseNote,
   generateAppcastXML,
+  githubRepoFromRemoteURL,
   isRetryableHTTPStatus,
+  makeHomebrewCaskAuditArgs,
   makeHomebrewCaskBranchName,
+  makeHomebrewCaskPullRequestBody,
   makeGitHubReleaseTagName,
   makeBetaDMGFileName,
   makeDMGFileName,
@@ -38,7 +41,6 @@ import {
   normalizeSparklePrivateKey,
   parseBuildSettings,
   parseEnvFile,
-  parseHomebrewCaskVersion,
   parseReleaseNotes,
   parseSparkleSignatureOutput,
   publicR2URL,
@@ -48,7 +50,9 @@ import {
   releaseNotesToMarkdown,
   requiredEnvNames,
   signR2Request,
-  updateHomebrewCaskContent
+  updateHomebrewCaskContent,
+  validateHomebrewCaskContent,
+  validateHomebrewLivecheckOutput
 } from "./release-lib.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -60,8 +64,12 @@ const r2UploadAttemptTimeoutMs = 300_000;
 const r2UploadConfirmationTimeoutMs = 30_000;
 const homebrewCaskForkRepo = "ProxymanApp/homebrew-cask";
 const homebrewCaskUpstreamRepo = "Homebrew/homebrew-cask";
-const homebrewCaskDefaultBranch = "master";
+const homebrewCaskUpstreamRemote = "origin";
+const homebrewCaskForkRemote = "proxyman";
+const homebrewCaskDefaultBranch = "main";
+const homebrewCaskToken = "tcpviewer";
 const homebrewCaskRelativePath = "Casks/t/tcpviewer.rb";
+const homebrewCaskTemplatePath = path.join(repoRoot, "scripts/homebrew/tcpviewer.rb");
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -129,6 +137,16 @@ async function main() {
     githubRelease,
     homebrewRelease
   });
+  if (
+    homebrewRelease?.isInitialCask
+    && args.yes
+    && args.homebrewInstallTested !== true
+  ) {
+    throw new Error(
+      "Non-interactive initial Homebrew Cask publishing requires --homebrew-install-tested. "
+      + "Use an interactive release to pause and run the required install and uninstall checks."
+    );
+  }
 
   printReleaseSummary({
     releaseType,
@@ -182,7 +200,12 @@ async function main() {
       outputDir
     });
     if (homebrewRelease) {
-      await createHomebrewCaskPullRequest({ homebrewRelease, dmgPath });
+      await createHomebrewCaskPullRequest({
+        homebrewRelease,
+        dmgPath,
+        installTested: args.homebrewInstallTested === true,
+        nonInteractive: args.yes === true
+      });
     }
   }
 
@@ -365,11 +388,12 @@ function resolveHomebrewRelease({ env, version, buildNumber }) {
     buildNumber,
     repoPath,
     caskPath: path.join(repoPath, homebrewCaskRelativePath),
+    templatePath: homebrewCaskTemplatePath,
     branchName: makeHomebrewCaskBranchName({ version, buildNumber })
   };
 }
 
-// Reject an unsafe or stale fork checkout before any release side effects occur.
+// Validate the official tap checkout before any release side effects occur.
 async function preflightHomebrewRelease(homebrewRelease) {
   await requireTool("brew", ["--version"]);
   await requireTool("gh", ["--version"]);
@@ -393,12 +417,31 @@ async function preflightHomebrewRelease(homebrewRelease) {
     throw new Error(`TCPVIEWER_HOMEBREW_CASK_REPO must point to the repository root: ${homebrewRelease.repoPath}`);
   }
 
-  const originURL = (await runCommand("git", ["remote", "get-url", "origin"], {
+  const tapRepoPath = (await runCommand("brew", ["--repository", "homebrew/cask"], {
+    capture: true
+  })).stdout.trim();
+  if (path.resolve(tapRepoPath) !== path.resolve(homebrewRelease.repoPath)) {
+    throw new Error(
+      `TCPVIEWER_HOMEBREW_CASK_REPO must match brew --repository homebrew/cask: ${tapRepoPath}`
+    );
+  }
+
+  const originURL = (await runCommand("git", ["remote", "get-url", homebrewCaskUpstreamRemote], {
     cwd: homebrewRelease.repoPath,
     capture: true
   })).stdout.trim();
-  if (githubRepoFromRemoteURL(originURL) !== homebrewCaskForkRepo.toLowerCase()) {
-    throw new Error(`Homebrew Cask origin must be ${homebrewCaskForkRepo}; found ${originURL}.`);
+  if (githubRepoFromRemoteURL(originURL) !== homebrewCaskUpstreamRepo.toLowerCase()) {
+    throw new Error(`Homebrew Cask origin must be ${homebrewCaskUpstreamRepo}; found ${originURL}.`);
+  }
+
+  const forkURL = (await runCommand("git", ["remote", "get-url", homebrewCaskForkRemote], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  })).stdout.trim();
+  if (githubRepoFromRemoteURL(forkURL) !== homebrewCaskForkRepo.toLowerCase()) {
+    throw new Error(
+      `Homebrew Cask ${homebrewCaskForkRemote} remote must be ${homebrewCaskForkRepo}; found ${forkURL}.`
+    );
   }
 
   const parentRepo = (await runCommand("gh", [
@@ -410,44 +453,47 @@ async function preflightHomebrewRelease(homebrewRelease) {
   if (parentRepo !== homebrewCaskUpstreamRepo) {
     throw new Error(`${homebrewCaskForkRepo} must be a fork of ${homebrewCaskUpstreamRepo}.`);
   }
-  try {
-    await runCommand("gh", [
-      "api",
-      `repos/${homebrewCaskUpstreamRepo}/contents/${homebrewCaskRelativePath}`,
-      "--silent"
-    ], { capture: true });
-  } catch {
-    throw new Error(
-      `TCP Viewer is not present in ${homebrewCaskUpstreamRepo}; merge the initial cask before enabling release bumps.`
-    );
-  }
 
-  await runCommand("git", ["fetch", "origin", homebrewCaskDefaultBranch, "--prune"], {
+  await runCommand("git", ["fetch", homebrewCaskUpstreamRemote, homebrewCaskDefaultBranch, "--prune"], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  });
+  await runCommand("git", ["fetch", homebrewCaskForkRemote, "--prune"], {
     cwd: homebrewRelease.repoPath,
     capture: true
   });
   await ensureHomebrewGitReady(homebrewRelease);
 
-  let caskContent;
-  try {
-    caskContent = await readFile(homebrewRelease.caskPath, "utf8");
-  } catch {
-    throw new Error(`TCP Viewer Homebrew Cask was not found: ${homebrewRelease.caskPath}`);
-  }
-  const currentVersion = parseHomebrewCaskVersion(caskContent);
+  const source = await readHomebrewCaskSource(homebrewRelease);
+  const currentVersion = validateHomebrewCaskContent(source.content);
   if (
+    !source.isInitialCask
+    &&
     currentVersion.version === homebrewRelease.version
     && currentVersion.buildNumber === homebrewRelease.buildNumber
   ) {
     throw new Error(`Homebrew Cask already contains ${homebrewRelease.version},${homebrewRelease.buildNumber}.`);
   }
 
+  homebrewRelease.isInitialCask = source.isInitialCask;
+  if (source.isInitialCask) {
+    await ensureHomebrewCaskWasNotRefused();
+    homebrewRelease.githubMetrics = await loadTCPViewerGitHubMetrics();
+    console.warn(
+      `Review Homebrew's current notability policy before submitting. `
+      + `TCPViewer currently has ${homebrewRelease.githubMetrics.stars} stars, `
+      + `${homebrewRelease.githubMetrics.forks} forks, and ${homebrewRelease.githubMetrics.watchers} watchers.`
+    );
+  }
+
   await ensureHomebrewBranchDoesNotExist(homebrewRelease);
-  await runCommand("brew", ["style", homebrewRelease.caskPath]);
-  console.log(`Homebrew Cask check passed for ${homebrewRelease.repoPath}.`);
+  console.log(
+    `Homebrew Cask ${source.isInitialCask ? "initial submission" : "update"} preflight passed `
+    + `for ${homebrewRelease.repoPath}.`
+  );
 }
 
-// Require a clean fork default branch that exactly matches its remote tracking branch.
+// A clean named branch lets the release restore the maintainer's checkout after publishing.
 async function ensureHomebrewGitReady(homebrewRelease) {
   const status = await runCommand("git", ["status", "--porcelain"], {
     cwd: homebrewRelease.repoPath,
@@ -461,19 +507,65 @@ async function ensureHomebrewGitReady(homebrewRelease) {
     cwd: homebrewRelease.repoPath,
     capture: true
   })).stdout.trim();
-  if (branch !== homebrewCaskDefaultBranch) {
-    throw new Error(`Homebrew Cask repository must be on ${homebrewCaskDefaultBranch}; current branch is ${branch || "detached HEAD"}.`);
+  if (!branch) {
+    throw new Error("Homebrew Cask repository must be on a named branch, not a detached HEAD.");
+  }
+  homebrewRelease.originalBranch = branch;
+}
+
+async function readHomebrewCaskSource(homebrewRelease) {
+  const upstreamRef = `${homebrewCaskUpstreamRemote}/${homebrewCaskDefaultBranch}`;
+  const listing = await runCommand("git", [
+    "ls-tree",
+    "--name-only",
+    upstreamRef,
+    "--",
+    homebrewCaskRelativePath
+  ], { cwd: homebrewRelease.repoPath, capture: true });
+  if (listing.stdout.trim() === homebrewCaskRelativePath) {
+    const upstreamObject = `${upstreamRef}:${homebrewCaskRelativePath}`;
+    const result = await runCommand("git", ["show", upstreamObject], {
+      cwd: homebrewRelease.repoPath,
+      capture: true
+    });
+    return { content: result.stdout, isInitialCask: false };
   }
 
-  const counts = (await runCommand("git", [
-    "rev-list",
-    "--left-right",
-    "--count",
-    `HEAD...origin/${homebrewCaskDefaultBranch}`
-  ], { cwd: homebrewRelease.repoPath, capture: true })).stdout.trim().split(/\s+/);
-  if (counts[0] !== "0" || counts[1] !== "0") {
-    throw new Error(`Homebrew Cask ${homebrewCaskDefaultBranch} must be in sync with origin/${homebrewCaskDefaultBranch}.`);
+  const template = await readFile(homebrewRelease.templatePath, "utf8");
+  return { content: template, isInitialCask: true };
+}
+
+async function ensureHomebrewCaskWasNotRefused() {
+  const result = await runCommand("gh", [
+    "pr",
+    "list",
+    "--repo",
+    homebrewCaskUpstreamRepo,
+    "--state",
+    "closed",
+    "--search",
+    `${homebrewCaskToken} in:title`,
+    "--limit",
+    "100",
+    "--json",
+    "number,title,url,mergedAt"
+  ], { capture: true });
+  const refused = JSON.parse(result.stdout).filter((pullRequest) => !pullRequest.mergedAt);
+  if (refused.length) {
+    throw new Error(
+      `A previous TCP Viewer Homebrew Cask pull request was closed without merging: ${refused[0].url}`
+    );
   }
+}
+
+async function loadTCPViewerGitHubMetrics() {
+  const result = await runCommand("gh", [
+    "api",
+    "repos/ProxymanApp/TCPViewer",
+    "--jq",
+    "{stars: .stargazers_count, forks: .forks_count, watchers: .subscribers_count}"
+  ], { capture: true });
+  return JSON.parse(result.stdout);
 }
 
 async function ensureHomebrewBranchDoesNotExist(homebrewRelease) {
@@ -492,36 +584,52 @@ async function ensureHomebrewBranchDoesNotExist(homebrewRelease) {
   const remoteBranch = await runCommand("git", [
     "ls-remote",
     "--heads",
-    "origin",
+    homebrewCaskForkRemote,
     `refs/heads/${homebrewRelease.branchName}`
   ], { cwd: homebrewRelease.repoPath, capture: true });
   if (remoteBranch.stdout.trim()) {
-    throw new Error(`Homebrew Cask branch already exists on origin: ${homebrewRelease.branchName}`);
+    throw new Error(
+      `Homebrew Cask branch already exists on ${homebrewCaskForkRemote}: ${homebrewRelease.branchName}`
+    );
   }
 }
 
-// Publish the minimal version and checksum change from the maintained fork.
-async function createHomebrewCaskPullRequest({ homebrewRelease, dmgPath }) {
+// Create the cask change from current upstream main so stale fork branches cannot leak into the PR.
+async function createHomebrewCaskPullRequest({ homebrewRelease, dmgPath, installTested, nonInteractive }) {
   const sha256 = await sha256File(dmgPath);
-  const currentContent = await readFile(homebrewRelease.caskPath, "utf8");
-  const updatedContent = updateHomebrewCaskContent(currentContent, {
+  const source = await readHomebrewCaskSource(homebrewRelease);
+  const updatedContent = updateHomebrewCaskContent(source.content, {
     version: homebrewRelease.version,
     buildNumber: homebrewRelease.buildNumber,
     sha256
   });
 
-  await runCommand("git", ["switch", "-c", homebrewRelease.branchName], {
+  await runCommand("git", [
+    "switch",
+    "-c",
+    homebrewRelease.branchName,
+    `${homebrewCaskUpstreamRemote}/${homebrewCaskDefaultBranch}`
+  ], {
     cwd: homebrewRelease.repoPath
   });
   try {
+    await mkdir(path.dirname(homebrewRelease.caskPath), { recursive: true });
     await writeFile(homebrewRelease.caskPath, updatedContent);
-    await runCommand("brew", ["style", homebrewRelease.caskPath]);
+    await runCommand("git", ["add", homebrewCaskRelativePath], { cwd: homebrewRelease.repoPath });
+    await validateHomebrewCaskChange(homebrewRelease);
+    if (source.isInitialCask) {
+      await confirmInitialHomebrewInstallTest({ installTested, nonInteractive });
+    }
+
     await runCommand("git", ["add", homebrewCaskRelativePath], { cwd: homebrewRelease.repoPath });
     await runCommand("git", ["diff", "--cached", "--check"], { cwd: homebrewRelease.repoPath });
-    await runCommand("git", ["commit", "-m", `tcpviewer ${homebrewRelease.version}`], {
+    const commitMessage = source.isInitialCask
+      ? `tcpviewer ${homebrewRelease.version} (new cask)`
+      : `tcpviewer ${homebrewRelease.version}`;
+    await runCommand("git", ["commit", "--no-gpg-sign", "-m", commitMessage], {
       cwd: homebrewRelease.repoPath
     });
-    await runCommand("git", ["push", "--set-upstream", "origin", homebrewRelease.branchName], {
+    await runCommand("git", ["push", "--set-upstream", homebrewCaskForkRemote, homebrewRelease.branchName], {
       cwd: homebrewRelease.repoPath
     });
 
@@ -537,11 +645,10 @@ async function createHomebrewCaskPullRequest({ homebrewRelease, dmgPath }) {
       "--title",
       `tcpviewer ${homebrewRelease.version}`,
       "--body",
-      [
-        "Built and tested locally on macOS.",
-        "",
-        "AI-assisted release automation updated the version and checksum; the maintainer verified the release artifact."
-      ].join("\n")
+      makeHomebrewCaskPullRequestBody({
+        isInitialCask: source.isInitialCask,
+        githubMetrics: homebrewRelease.githubMetrics
+      })
     ], { capture: true });
     const pullRequestURL = result.stdout.trim();
     console.log(`Homebrew Cask pull request created: ${pullRequestURL}`);
@@ -551,14 +658,68 @@ async function createHomebrewCaskPullRequest({ homebrewRelease, dmgPath }) {
     );
   }
 
-  await runCommand("git", ["switch", homebrewCaskDefaultBranch], { cwd: homebrewRelease.repoPath });
+  await runCommand("git", ["switch", homebrewRelease.originalBranch], { cwd: homebrewRelease.repoPath });
 }
 
-function githubRepoFromRemoteURL(remoteURL) {
-  const match = String(remoteURL).trim().match(
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/)([^/]+\/[^/]+?)(?:\.git)?$/i
+async function validateHomebrewCaskChange(homebrewRelease) {
+  const brewEnv = { HOMEBREW_DEVELOPER: "1", HOMEBREW_NO_AUTO_UPDATE: "1" };
+  await runCommand("brew", ["style", "--fix", "--cask", homebrewCaskToken], {
+    cwd: homebrewRelease.repoPath,
+    env: brewEnv
+  });
+  const auditArgs = makeHomebrewCaskAuditArgs({
+    isInitialCask: homebrewRelease.isInitialCask,
+    token: homebrewCaskToken
+  });
+  await runCommand("brew", auditArgs, { cwd: homebrewRelease.repoPath, env: brewEnv });
+  const livecheckResult = await runCommand("brew", [
+    "livecheck",
+    "--json",
+    "--cask",
+    "--autobump",
+    homebrewCaskToken
+  ], {
+    cwd: homebrewRelease.repoPath,
+    env: brewEnv,
+    capture: true
+  });
+  validateHomebrewLivecheckOutput(
+    livecheckResult.stdout,
+    `${homebrewRelease.version},${homebrewRelease.buildNumber}`
   );
-  return match ? match[1].toLowerCase() : null;
+  await runCommand("brew", ["lgtm", "--online"], { cwd: homebrewRelease.repoPath, env: brewEnv });
+
+  validateHomebrewCaskContent(await readFile(homebrewRelease.caskPath, "utf8"));
+}
+
+async function confirmInitialHomebrewInstallTest({ installTested, nonInteractive }) {
+  if (installTested) {
+    return;
+  }
+  const commands = [
+    `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ${homebrewCaskToken}`,
+    `brew uninstall --cask ${homebrewCaskToken}`
+  ];
+  if (nonInteractive) {
+    throw new Error(
+      `Initial Homebrew Cask submissions require manual install and uninstall testing. `
+      + `Run ${commands.join(" and ")}, then rerun with --homebrew-install-tested.`
+    );
+  }
+
+  console.log("Run these commands in another terminal before continuing:");
+  for (const command of commands) {
+    console.log(`- ${command}`);
+  }
+  const response = await prompts({
+    type: "confirm",
+    name: "installTested",
+    message: "Did the Homebrew Cask install and uninstall commands both succeed?",
+    initial: false
+  });
+  if (response.installTested !== true) {
+    throw new Error("Initial Homebrew Cask install validation was not confirmed.");
+  }
 }
 
 async function signDMG({ env, dmgPath, settings }) {
@@ -1281,7 +1442,11 @@ function printReleaseSummary({
   if (githubRelease) {
     console.log(`- GitHub release: ${githubRelease.repo} ${githubRelease.tagName}`);
   }
-  console.log(`- Homebrew Cask PR: ${homebrewRelease ? `enabled (${homebrewRelease.repoPath})` : "disabled"}`);
+  console.log(
+    `- Homebrew Cask PR: ${homebrewRelease
+      ? `enabled (${homebrewRelease.isInitialCask ? "initial cask" : "update"}; ${homebrewRelease.repoPath})`
+      : "disabled"}`
+  );
 }
 
 function validateRequiredBuildSettings(settings) {
@@ -1305,6 +1470,8 @@ function parseArgs(argv) {
       args.bumpHomebrew = true;
     } else if (arg === "--no-bump-homebrew") {
       args.bumpHomebrew = false;
+    } else if (arg === "--homebrew-install-tested") {
+      args.homebrewInstallTested = true;
     }
   }
   return args;

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -7,11 +7,14 @@ import {
   emptyPayloadSHA256,
   findReleaseNote,
   generateAppcastXML,
+  githubRepoFromRemoteURL,
   isRetryableHTTPStatus,
   makeBetaDMGFileName,
   makeDMGFileName,
   makeGitHubReleaseTagName,
+  makeHomebrewCaskAuditArgs,
   makeHomebrewCaskBranchName,
+  makeHomebrewCaskPullRequestBody,
   makeR2ObjectURL,
   makeR2ObjectKey,
   makeR2StorageObjectKey,
@@ -32,7 +35,9 @@ import {
   releaseNotesToHTML,
   requiredEnvNames,
   signR2Request,
-  updateHomebrewCaskContent
+  updateHomebrewCaskContent,
+  validateHomebrewCaskContent,
+  validateHomebrewLivecheckOutput
 } from "../scripts/release-lib.mjs";
 
 test("parses and validates release notes", () => {
@@ -189,6 +194,8 @@ test("updates only Homebrew Cask release metadata", () => {
     '  version "1.9.0,30"',
     `  sha256 "${"a".repeat(64)}"`,
     "",
+    "  depends_on arch: :arm64",
+    "",
     '  app "TCP Viewer.app"',
     "end",
     ""
@@ -202,6 +209,7 @@ test("updates only Homebrew Cask release metadata", () => {
   assert.deepEqual(parseHomebrewCaskVersion(updated), { version: "1.10.0", buildNumber: "31" });
   assert.match(updated, new RegExp(`sha256 "${"b".repeat(64)}"`));
   assert.match(updated, /app "TCP Viewer\.app"/);
+  assert.match(updated, /depends_on arch: :arm64/);
   assert.equal(makeHomebrewCaskBranchName({ version: "1.10.0", buildNumber: "31" }), "tcpviewer-1.10.0-31");
   assert.throws(
     () => updateHomebrewCaskContent(cask, { version: "../1.10.0", buildNumber: "31", sha256: "b".repeat(64) }),
@@ -211,6 +219,68 @@ test("updates only Homebrew Cask release metadata", () => {
     () => updateHomebrewCaskContent(cask, { version: "1.10.0", buildNumber: "31", sha256: "invalid" }),
     /SHA-256/
   );
+  assert.throws(
+    () => validateHomebrewCaskContent(cask.replace("  depends_on arch: :arm64\n", "")),
+    /Apple Silicon/
+  );
+});
+
+test("ships an initial Homebrew Cask template for the ARM64 release", () => {
+  const content = readFileSync(new URL("../scripts/homebrew/tcpviewer.rb", import.meta.url), "utf8");
+  const documentation = readFileSync(new URL("../scripts/homebrew/README.md", import.meta.url), "utf8");
+
+  assert.deepEqual(validateHomebrewCaskContent(content), { version: "0.0.0", buildNumber: "0" });
+  assert.match(content, /depends_on macos: :sequoia/);
+  assert.match(content, /homepage "https:\/\/tcpviewer\.proxyman\.com\/"/);
+  assert.match(content, /strategy :sparkle/);
+  assert.match(content, /uninstall launchctl: "com\.proxyman\.tcpviewer\.helpertool"/);
+  assert.doesNotMatch(content, /verified:/);
+  assert.match(documentation, /brew tap --force homebrew\/cask/);
+  assert.match(documentation, /--homebrew-install-tested/);
+});
+
+test("recognizes supported GitHub remote URLs", () => {
+  assert.equal(githubRepoFromRemoteURL("git@github.com:Homebrew/homebrew-cask.git"), "homebrew/homebrew-cask");
+  assert.equal(githubRepoFromRemoteURL("https://github.com/ProxymanApp/homebrew-cask"), "proxymanapp/homebrew-cask");
+  assert.equal(githubRepoFromRemoteURL("ssh://git@github.com/ProxymanApp/homebrew-cask.git"), "proxymanapp/homebrew-cask");
+  assert.equal(githubRepoFromRemoteURL("https://example.com/Homebrew/homebrew-cask.git"), null);
+});
+
+test("builds Homebrew validation and pull request metadata", () => {
+  assert.deepEqual(
+    makeHomebrewCaskAuditArgs({ isInitialCask: true }),
+    ["audit", "--cask", "--online", "--new", "tcpviewer"]
+  );
+  assert.deepEqual(
+    makeHomebrewCaskAuditArgs({ isInitialCask: false }),
+    ["audit", "--cask", "--online", "tcpviewer"]
+  );
+
+  const initialBody = makeHomebrewCaskPullRequestBody({
+    isInitialCask: true,
+    githubMetrics: { stars: 163, forks: 7, watchers: 0 }
+  });
+  assert.match(initialBody, /brew install --cask tcpviewer/);
+  assert.match(initialBody, /163 stars, 7 forks, 0 watchers/);
+  assert.match(initialBody, /OpenAI Codex assisted/);
+
+  const updateBody = makeHomebrewCaskPullRequestBody({ isInitialCask: false });
+  assert.doesNotMatch(updateBody, /brew install --cask tcpviewer/);
+  assert.throws(
+    () => makeHomebrewCaskPullRequestBody({ isInitialCask: true }),
+    /GitHub metrics/
+  );
+
+  const livecheck = JSON.stringify([{
+    cask: "tcpviewer",
+    version: { current: "1.12.0,36", latest: "1.12.0,36", outdated: false }
+  }]);
+  assert.doesNotThrow(() => validateHomebrewLivecheckOutput(livecheck, "1.12.0,36"));
+  assert.throws(
+    () => validateHomebrewLivecheckOutput(livecheck, "1.13.0,37"),
+    /current and latest/
+  );
+  assert.throws(() => validateHomebrewLivecheckOutput("not json", "1.12.0,36"), /valid JSON/);
 });
 
 test("parses xcconfig-style env files and redacts secrets", () => {

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -11,6 +11,7 @@ import {
   makeBetaDMGFileName,
   makeDMGFileName,
   makeGitHubReleaseTagName,
+  makeHomebrewCaskBranchName,
   makeR2ObjectURL,
   makeR2ObjectKey,
   makeR2StorageObjectKey,
@@ -20,6 +21,7 @@ import {
   normalizeReleaseBackendURL,
   normalizeSparklePrivateKey,
   parseEnvFile,
+  parseHomebrewCaskVersion,
   parseReleaseNotes,
   parseSparkleSignatureOutput,
   publicR2URL,
@@ -29,7 +31,8 @@ import {
   releaseNotesToMarkdown,
   releaseNotesToHTML,
   requiredEnvNames,
-  signR2Request
+  signR2Request,
+  updateHomebrewCaskContent
 } from "../scripts/release-lib.mjs";
 
 test("parses and validates release notes", () => {
@@ -180,6 +183,36 @@ test("builds versioned DMG file names", () => {
   );
 });
 
+test("updates only Homebrew Cask release metadata", () => {
+  const cask = [
+    'cask "tcpviewer" do',
+    '  version "1.9.0,30"',
+    `  sha256 "${"a".repeat(64)}"`,
+    "",
+    '  app "TCP Viewer.app"',
+    "end",
+    ""
+  ].join("\n");
+  const updated = updateHomebrewCaskContent(cask, {
+    version: "1.10.0",
+    buildNumber: "31",
+    sha256: "B".repeat(64)
+  });
+
+  assert.deepEqual(parseHomebrewCaskVersion(updated), { version: "1.10.0", buildNumber: "31" });
+  assert.match(updated, new RegExp(`sha256 "${"b".repeat(64)}"`));
+  assert.match(updated, /app "TCP Viewer\.app"/);
+  assert.equal(makeHomebrewCaskBranchName({ version: "1.10.0", buildNumber: "31" }), "tcpviewer-1.10.0-31");
+  assert.throws(
+    () => updateHomebrewCaskContent(cask, { version: "../1.10.0", buildNumber: "31", sha256: "b".repeat(64) }),
+    /Homebrew Cask version/
+  );
+  assert.throws(
+    () => updateHomebrewCaskContent(cask, { version: "1.10.0", buildNumber: "31", sha256: "invalid" }),
+    /SHA-256/
+  );
+});
+
 test("parses xcconfig-style env files and redacts secrets", () => {
   const parsed = parseEnvFile([
     "TCPVIEWER_APPCAST_URL=https:/$()/updates.example.com/appcast.xml",
@@ -218,7 +251,8 @@ test("documents required release env values with safe placeholders", () => {
   const documentedNames = [
     ...requiredEnvNames("production"),
     "TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND",
-    ...releaseBackendRequiredEnvNames
+    ...releaseBackendRequiredEnvNames,
+    "TCPVIEWER_HOMEBREW_CASK_REPO"
   ];
 
   assert.doesNotMatch(content, /^\s*\/\//m);


### PR DESCRIPTION
## Summary
- Add optional Homebrew Cask update flow for production releases
- Validate the configured Homebrew cask checkout before release work starts
- Update the cask version and SHA-256, then create a PR against `Homebrew/homebrew-cask`
- Document the new environment variable and non-interactive flags
- Add unit coverage for Homebrew cask parsing and update helpers

## Testing
- Unit tests added for Homebrew cask content updates and branch naming
- Existing release helper tests updated to cover the new environment documentation