### PR TITLE
Clarify MCP BPF capture filter behavior and confirmation

### DIFF
--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -499,6 +499,7 @@ private final class TCPViewerToolbarViewModel {
     private(set) var helpText = ""
     private(set) var helperError: TCPViewerToolbarHelperError?
     private(set) var isShowingHelperError = false
+    private(set) var bpfCaptureFilter: String?
     private(set) var showsTrialButton = false
 
     // Build toolbar-only presentation state from the root inspector snapshot.
@@ -519,6 +520,7 @@ private final class TCPViewerToolbarViewModel {
         canExport = snapshot.totalPacketCount > 0 && snapshot.base.loadState.progress.phase != .loading
         isInspectorVisible = snapshot.isInspectorVisible
         inspectorPlacement = snapshot.inspectorPlacement
+        bpfCaptureFilter = snapshot.base.filterState.normalizedCaptureFilter
         helperError = Self.helperError(for: viewModel.networkHelperToolSnapshot)
         isShowingHelperError = helperError != nil
         if let helperError {
@@ -653,6 +655,83 @@ private struct TCPViewerToolbarHelperError {
     let message: String
 }
 
+final class TCPViewerBPFFilterPopoverViewController: NSViewController {
+    private let titleLabel = TCPViewerUI.label(
+        "BPF Capture Filter",
+        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+    )
+    private let explanationLabel = NSTextField(wrappingLabelWithString:
+        "Only packets matching this expression are collected during live capture."
+    )
+    private let expressionScrollView = NSScrollView()
+    private let expressionTextView = NSTextView()
+    private let agentNoteLabel = TCPViewerUI.label(
+        "Updated by MCP agents. This setting is read-only.",
+        font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
+        color: .secondaryLabelColor
+    )
+
+    override func loadView() {
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .windowBackgroundColor)
+        setupLayout()
+    }
+
+    // Refresh the read-only expression shown by an already-open popover.
+    func render(expression: String) {
+        expressionTextView.string = expression
+    }
+
+    // Build a compact read-only presentation that still allows copying long filters.
+    private func setupLayout() {
+        preferredContentSize = NSSize(width: 380, height: 190)
+
+        explanationLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        explanationLabel.textColor = .secondaryLabelColor
+        expressionTextView.isEditable = false
+        expressionTextView.isSelectable = true
+        expressionTextView.isRichText = false
+        expressionTextView.font = .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        expressionTextView.textColor = .labelColor
+        expressionTextView.backgroundColor = .textBackgroundColor
+        expressionTextView.textContainerInset = NSSize(width: 7, height: 7)
+        expressionTextView.frame = NSRect(x: 0, y: 0, width: 352, height: 88)
+        expressionTextView.isVerticallyResizable = true
+        expressionTextView.isHorizontallyResizable = false
+        expressionTextView.autoresizingMask = [.width]
+        expressionTextView.textContainer?.widthTracksTextView = true
+        expressionTextView.setAccessibilityLabel("Current BPF capture filter")
+
+        expressionScrollView.borderType = .bezelBorder
+        expressionScrollView.hasVerticalScroller = true
+        expressionScrollView.drawsBackground = true
+        expressionScrollView.documentView = expressionTextView
+        expressionScrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = NSStackView(views: [
+            titleLabel,
+            explanationLabel,
+            expressionScrollView,
+            agentNoteLabel,
+        ])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.setCustomSpacing(5, after: titleLabel)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: 14),
+            stack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -12),
+            explanationLabel.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            expressionScrollView.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            expressionScrollView.heightAnchor.constraint(equalToConstant: 88),
+        ])
+    }
+}
+
 private final class TCPViewerToolbarStatusView: NSView {
     var onOpenHelperToolScreen: (() -> Void)?
     var onCheckForUpdates: (() -> Void)?
@@ -660,9 +739,13 @@ private final class TCPViewerToolbarStatusView: NSView {
     private let dot = NSView()
     private let statusLabel = TCPViewerUI.label("", font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium), color: .secondaryLabelColor)
     private let emphasizedLabel = TCPViewerUI.label("", font: .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold))
+    private let bpfFilterButton = NSButton(title: "", target: nil, action: nil)
     private let helperErrorButton = NSButton(title: "Error", target: nil, action: nil)
     private let updateBadgeButton = TCPViewerToolbarUpdateBadgeButton(title: "", target: nil, action: nil)
+    private let bpfFilterPopover = NSPopover()
+    private let bpfFilterPopoverViewController = TCPViewerBPFFilterPopoverViewController()
     private var helperError: TCPViewerToolbarHelperError?
+    private var bpfCaptureFilter: String?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -684,6 +767,13 @@ private final class TCPViewerToolbarStatusView: NSView {
         statusLabel.textColor = viewModel.isShowingHelperError ? .systemRed : .secondaryLabelColor
         emphasizedLabel.stringValue = viewModel.emphasizedText ?? ""
         emphasizedLabel.isHidden = viewModel.isShowingHelperError || viewModel.emphasizedText == nil
+        bpfCaptureFilter = viewModel.bpfCaptureFilter
+        bpfFilterButton.isHidden = viewModel.bpfCaptureFilter == nil
+        if let bpfCaptureFilter {
+            bpfFilterPopoverViewController.render(expression: bpfCaptureFilter)
+        } else {
+            bpfFilterPopover.close()
+        }
         helperError = viewModel.helperError
         helperErrorButton.isHidden = viewModel.helperError == nil
         helperErrorButton.toolTip = viewModel.helperError.map { "\($0.title): \($0.message)" }
@@ -713,19 +803,29 @@ private final class TCPViewerToolbarStatusView: NSView {
         dot.translatesAutoresizingMaskIntoConstraints = false
         statusLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         emphasizedLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        configureBPFFilterButton()
         configureHelperErrorButton()
         configureUpdateBadgeButton()
         let flexibleSpacer = NSView()
         flexibleSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
         flexibleSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        let stack = NSStackView(views: [dot, statusLabel, emphasizedLabel, helperErrorButton, flexibleSpacer, updateBadgeButton])
+        let stack = NSStackView(views: [
+            dot,
+            statusLabel,
+            emphasizedLabel,
+            bpfFilterButton,
+            helperErrorButton,
+            flexibleSpacer,
+            updateBadgeButton,
+        ])
         stack.orientation = .horizontal
         stack.alignment = .centerY
         stack.spacing = 6
         stack.setCustomSpacing(10, after: dot)
         stack.setCustomSpacing(4, after: statusLabel)
         stack.setCustomSpacing(8, after: emphasizedLabel)
+        stack.setCustomSpacing(8, after: bpfFilterButton)
         stack.setCustomSpacing(8, after: flexibleSpacer)
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
@@ -735,10 +835,34 @@ private final class TCPViewerToolbarStatusView: NSView {
             heightAnchor.constraint(equalToConstant: 28),
             dot.widthAnchor.constraint(equalToConstant: 8),
             dot.heightAnchor.constraint(equalToConstant: 8),
+            bpfFilterButton.widthAnchor.constraint(equalToConstant: 20),
+            bpfFilterButton.heightAnchor.constraint(equalToConstant: 20),
             stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
             stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
             stack.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
+    }
+
+    // Configure the warning-colored affordance for the MCP-managed BPF setting.
+    private func configureBPFFilterButton() {
+        bpfFilterButton.target = self
+        bpfFilterButton.action = #selector(bpfFilterButtonPressed(_:))
+        bpfFilterButton.isBordered = false
+        let filterImage = TCPViewerUI.image("line.3.horizontal.decrease.circle.fill")
+        filterImage?.isTemplate = true
+        bpfFilterButton.image = filterImage
+        bpfFilterButton.imagePosition = .imageOnly
+        bpfFilterButton.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        bpfFilterButton.contentTintColor = .systemYellow
+        bpfFilterButton.toolTip = "BPF capture filter configured"
+        bpfFilterButton.identifier = NSUserInterfaceItemIdentifier("TCPViewer.BPFFilterIndicator")
+        bpfFilterButton.setAccessibilityLabel("BPF capture filter configured")
+        bpfFilterButton.isHidden = true
+        bpfFilterButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        bpfFilterPopover.behavior = .transient
+        bpfFilterPopover.animates = true
+        bpfFilterPopover.contentViewController = bpfFilterPopoverViewController
     }
 
     private func configureHelperErrorButton() {
@@ -786,6 +910,19 @@ private final class TCPViewerToolbarStatusView: NSView {
         }
 
         onOpenHelperToolScreen?()
+    }
+
+    // Toggle the read-only BPF details without exposing an edit action.
+    @objc private func bpfFilterButtonPressed(_ sender: NSButton) {
+        guard let bpfCaptureFilter else {
+            return
+        }
+        if bpfFilterPopover.isShown {
+            bpfFilterPopover.close()
+        } else {
+            bpfFilterPopoverViewController.render(expression: bpfCaptureFilter)
+            bpfFilterPopover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        }
     }
 
     @objc private func updateBadgeButtonPressed(_ sender: NSButton) {

--- a/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
+++ b/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
@@ -432,7 +432,24 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
                 DispatchQueue.main.async {
                     switch result {
                     case .success:
-                        completion(.success(["action": .string(action.rawValue), "completed": .bool(true)]))
+                        var response: [String: TCPViewerMCPValue] = [
+                            "action": .string(action.rawValue),
+                            "completed": .bool(true),
+                        ]
+                        if action == .startCapture {
+                            let captureFilter = request.string("capture_filter")
+                            let filterAction: String
+                            if captureFilter == nil {
+                                filterAction = "preserved"
+                            } else if captureFilter?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+                                filterAction = "cleared"
+                            } else {
+                                filterAction = "set"
+                            }
+                            response["previous_packets_cleared"] = .bool(true)
+                            response["bpf_capture_filter_action"] = .string(filterAction)
+                        }
+                        completion(.success(response))
                     case .failure(let error):
                         completion(self.failure(error))
                     }
@@ -452,6 +469,12 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
                         named: "capture_filter",
                         maximumByteCount: 4_096
                     )
+                    if captureFilter?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
+                       request.bool("confirm_bpf_filter") != true {
+                        throw TCPViewerMCPCommandRouterError.invalidParameter(
+                            "capture_filter is a persistent BPF capture filter that excludes nonmatching future traffic; it is not a packet query or TCP Viewer's Filter field. Explain this distinction and obtain explicit user confirmation, then retry with confirm_bpf_filter=true. For filtering packets already captured, use query_packets."
+                        )
+                    }
                     source.mcpStartCapture(
                         interfaceID: interfaceID,
                         captureFilter: captureFilter,
@@ -564,6 +587,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
             "capture_phase": .string(snapshot.capturePhase),
             "packet_count": .int(snapshot.totalPacketCount),
             "capture_filter": .string(redactsSensitiveData ? redactor.redact(snapshot.captureFilter) : snapshot.captureFilter),
+            "capture_filter_language": .string("libpcap_bpf"),
             "status": .string(protectedStatus),
             "can_start": .bool(snapshot.canStart),
             "can_pause": .bool(snapshot.canPause),

--- a/TCPViewerTests/Features/MCP/TCPViewerMCPCommandRouterTests.swift
+++ b/TCPViewerTests/Features/MCP/TCPViewerMCPCommandRouterTests.swift
@@ -62,6 +62,7 @@ struct TCPViewerMCPCommandRouterTests {
         let overview = await routeMCP(router, command: .getCaptureOverview)
         #expect(overview.value("packet_count") == .int(2))
         #expect(overview.value("dropped_packet_count") == .string("3"))
+        #expect(overview.value("capture_filter_language") == .string("libpcap_bpf"))
 
         let interfaces = await routeMCP(router, command: .listInterfaces)
         #expect(interfaces.value("count") == .int(1))
@@ -168,6 +169,7 @@ struct TCPViewerMCPCommandRouterTests {
         let start = await routeMCP(router, command: .startCapture, params: [
             "interface_id": .string("en0"),
             "capture_filter": .string("tcp port 443"),
+            "confirm_bpf_filter": .bool(true),
         ])
         let pause = await routeMCP(router, command: .pauseCapture)
         let resume = await routeMCP(router, command: .resumeCapture)
@@ -175,6 +177,8 @@ struct TCPViewerMCPCommandRouterTests {
         #expect([start, pause, resume, stop].allSatisfy { $0.success })
         #expect(source.startedInterfaceID == "en0")
         #expect(source.startedCaptureFilter == "tcp port 443")
+        #expect(start.value("previous_packets_cleared") == .bool(true))
+        #expect(start.value("bpf_capture_filter_action") == .string("set"))
         #expect(source.paused && source.resumed && source.stopped)
 
         let reveal = await routeMCP(router, command: .revealPacket, params: ["packet_id": .string("2")])
@@ -188,6 +192,26 @@ struct TCPViewerMCPCommandRouterTests {
         let clear = await routeMCP(router, command: .clearPackets, params: ["confirm": .bool(true)])
         #expect(clear.value("cleared_packet_count") == .int(2))
         #expect(source.cleared)
+    }
+
+    @Test func startCaptureRequiresExplicitConfirmationForNonemptyBPFFilter() async {
+        let source = TCPViewerMCPFakeDataSource()
+        let router = makeRouter(source: source, redactsSensitiveData: { false })
+
+        let unconfirmed = await routeMCP(router, command: .startCapture, params: [
+            "capture_filter": .string("host 1.1.1.1 and port 443"),
+        ])
+        #expect(!unconfirmed.success)
+        #expect(unconfirmed.error?.contains("persistent BPF capture filter") == true)
+        #expect(unconfirmed.error?.contains("query_packets") == true)
+        #expect(source.startedCaptureFilter == nil)
+
+        let clear = await routeMCP(router, command: .startCapture, params: [
+            "capture_filter": .string(""),
+        ])
+        #expect(clear.success)
+        #expect(source.startedCaptureFilter == "")
+        #expect(clear.value("bpf_capture_filter_action") == .string("cleared"))
     }
 
     @Test func rejectsUnauthorizedUnknownUnavailableAndInvalidRequests() async {

--- a/TCPViewerTests/Features/MCP/TCPViewerMCPNodeIntegrationTests.swift
+++ b/TCPViewerTests/Features/MCP/TCPViewerMCPNodeIntegrationTests.swift
@@ -48,6 +48,13 @@ struct TCPViewerMCPNodeIntegrationTests {
         #expect(result["packetID"] as? String == "4242")
         #expect(result["packetProtocol"] as? String == "TLS")
         #expect(result["detailPacketID"] as? String == "4242")
+        #expect((result["serverInstructions"] as? String)?.contains("query_packets") == true)
+        #expect((result["serverInstructions"] as? String)?.contains("explicit confirmation") == true)
+        #expect((result["queryDescription"] as? String)?.contains("already captured") == true)
+        #expect((result["startDescription"] as? String)?.contains("persistent libpcap/BPF") == true)
+        #expect((result["captureFilterDescription"] as? String)?.contains("not a packet query") == true)
+        #expect((result["confirmBPFDescription"] as? String)?.contains("explicitly confirms") == true)
+        #expect(result["startDestructiveHint"] as? Bool == true)
     }
 
     @Test func nodeDiscoveryUsesExecutableFromPATH() throws {
@@ -118,13 +125,15 @@ struct TCPViewerMCPNodeIntegrationTests {
           process.exit(2);
         }, 15000);
         (async () => {
-          await request('initialize', {
+          const initialized = await request('initialize', {
             protocolVersion: '2025-11-25',
             capabilities: {},
             clientInfo: { name: 'tcpviewer-node-integration', version: '1.0.0' }
           });
           notify('notifications/initialized');
           const listed = await request('tools/list', {});
+          const queryTool = listed.tools.find(tool => tool.name === 'query_packets');
+          const startTool = listed.tools.find(tool => tool.name === 'start_capture');
           const queried = await request('tools/call', {
             name: 'query_packets',
             arguments: { protocols: ['TLS'], limit: 1 }
@@ -139,7 +148,13 @@ struct TCPViewerMCPNodeIntegrationTests {
             toolNames: listed.tools.map(tool => tool.name),
             packetID: packet.id,
             packetProtocol: packet.protocol,
-            detailPacketID: detailed.structuredContent.packet.packet_id
+            detailPacketID: detailed.structuredContent.packet.packet_id,
+            serverInstructions: initialized.instructions,
+            queryDescription: queryTool.description,
+            startDescription: startTool.description,
+            captureFilterDescription: startTool.inputSchema.properties.capture_filter.description,
+            confirmBPFDescription: startTool.inputSchema.properties.confirm_bpf_filter.description,
+            startDestructiveHint: startTool.annotations.destructiveHint
           }));
           clearTimeout(timeout);
           child.kill('SIGTERM');
@@ -204,7 +219,26 @@ struct TCPViewerMCPNodeIntegrationTests {
                 $0.appendingPathComponent("bin/node")
             })
         }
-        return try #require(candidates.first(where: { fileManager.isExecutableFile(atPath: $0.path) }))
+        return try #require(candidates.first(where: { runnableNode(at: $0, fileManager: fileManager) }))
+    }
+
+    // Ignore stale executable links so integration tests can use another installed Node runtime.
+    private func runnableNode(at url: URL, fileManager: FileManager) -> Bool {
+        guard fileManager.isExecutableFile(atPath: url.path) else {
+            return false
+        }
+        let process = Process()
+        process.executableURL = url
+        process.arguments = ["--version"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
     }
 
     private func waitForServer(_ server: TCPViewerMCPHTTPServer, handshakeURL: URL) async throws {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -688,6 +688,51 @@ struct NetworkInspectorViewModelTests {
         #expect(filterButton.toolTip == "Show or hide packet filters (⌘F)")
     }
 
+    @Test func toolbarStatusShowsYellowBPFFilterIndicatorOnlyForNondefaultFilter() throws {
+        let inspectorViewModel = NetworkInspectorViewModel(userDefaults: isolatedDefaults())
+        let dataSource = TCPViewerToolbarDataSource()
+        let statusItem = try #require(dataSource.toolbar(
+            dataSource.toolbar,
+            itemForItemIdentifier: NSToolbarItem.Identifier("TCPViewer.Status"),
+            willBeInsertedIntoToolbar: true
+        ))
+        let statusView = try #require(statusItem.view)
+        let indicator = try #require(allSubviews(ofType: NSButton.self, in: statusView).first {
+            $0.identifier?.rawValue == "TCPViewer.BPFFilterIndicator"
+        })
+        var snapshot = inspectorViewModel.snapshot
+
+        dataSource.render(snapshot: snapshot, inspectorViewModel: inspectorViewModel, isLicenseAuthorized: true)
+        #expect(indicator.isHidden)
+
+        snapshot.base.filterState.captureFilterText = "  host 1.1.1.1 and port 443  "
+        dataSource.render(snapshot: snapshot, inspectorViewModel: inspectorViewModel, isLicenseAuthorized: true)
+
+        #expect(!indicator.isHidden)
+        #expect(indicator.contentTintColor == NSColor.systemYellow)
+        #expect(indicator.toolTip == "BPF capture filter configured")
+
+        snapshot.base.filterState.captureFilterText = ""
+        dataSource.render(snapshot: snapshot, inspectorViewModel: inspectorViewModel, isLicenseAuthorized: true)
+        #expect(indicator.isHidden)
+    }
+
+    @Test func bpfFilterPopoverShowsSelectableReadOnlyConfigurationAndAgentNote() throws {
+        let controller = TCPViewerBPFFilterPopoverViewController()
+
+        controller.loadViewIfNeeded()
+        controller.render(expression: "host 1.1.1.1 and port 443")
+
+        let textView = try #require(allSubviews(ofType: NSTextView.self, in: controller.view).first)
+        let labels = allSubviews(ofType: NSTextField.self, in: controller.view).map(\.stringValue)
+        #expect(textView.string == "host 1.1.1.1 and port 443")
+        #expect(!textView.isEditable)
+        #expect(textView.isSelectable)
+        #expect(labels.contains("BPF Capture Filter"))
+        #expect(labels.contains("Updated by MCP agents. This setting is read-only."))
+        #expect(allSubviews(ofType: NSButton.self, in: controller.view).isEmpty)
+    }
+
     @Test func statusStripRendersProcessAndCapturedTrafficMetrics() {
         let viewModel = StatusStripViewModel()
         let metrics = TCPViewerStatusMetricsSnapshot(

--- a/tcpviewer-mcp/TCPViewerMCPToolCatalog.swift
+++ b/tcpviewer-mcp/TCPViewerMCPToolCatalog.swift
@@ -18,7 +18,7 @@ enum TCPViewerMCPToolCatalog {
         readOnlyTool(
             .getCaptureOverview,
             title: "Get Capture Overview",
-            description: "Get the active capture state, packet and issue counts, interface selection, capture filter, and available controls.",
+            description: "Get the active capture state, packet and issue counts, interface selection, persistent BPF capture filter, and available controls.",
             properties: [:]
         ),
         readOnlyTool(
@@ -30,7 +30,7 @@ enum TCPViewerMCPToolCatalog {
         Tool(
             name: TCPViewerMCPCommand.queryPackets.rawValue,
             title: "Query Packets",
-            description: "Query a bounded packet window with multiple AND/OR filters, protocol, domain, packet ID, or stream constraints. Results are paginated and newest-first by default.",
+            description: "Read and filter packets that TCP Viewer has already captured. Use this by default when the user asks to filter, find, or show packets. It does not change packet capture or TCP Viewer's Filter field. Supports bounded AND/OR filters, protocol, domain, packet ID, and stream constraints; results are paginated and newest-first by default.",
             inputSchema: packetQuerySchema(),
             annotations: readOnlyAnnotations,
             outputSchema: objectOutputSchema
@@ -91,11 +91,19 @@ enum TCPViewerMCPToolCatalog {
         controlTool(
             .startCapture,
             title: "Start Capture",
-            description: "Start live capture, optionally selecting an interface and BPF capture filter.",
+            description: "Start a new live capture and clear packets currently in the active window. capture_filter is a persistent libpcap/BPF capture filter for future packet collection, not a packet query or TCP Viewer's Filter field. Use query_packets for ordinary packet filtering. Before setting a non-empty capture_filter, explain the distinction to the user, obtain explicit confirmation, and pass confirm_bpf_filter=true. Omitting capture_filter preserves the current BPF filter; passing an empty string clears it.",
             properties: [
                 "interface_id": stringProperty("Interface ID from list_interfaces.", maximumLength: 256),
-                "capture_filter": stringProperty("Optional BPF capture filter.", maximumLength: 4_096),
-            ]
+                "capture_filter": stringProperty(
+                    "Persistent libpcap/BPF expression controlling which future packets are collected. Nonmatching packets are not captured. This is not a packet query or the TCP Viewer Filter field. A non-empty value requires confirm_bpf_filter=true; omission preserves the current BPF filter and an empty string clears it.",
+                    maximumLength: 4_096
+                ),
+                "confirm_bpf_filter": .object([
+                    "type": "boolean",
+                    "description": "Set true only after the user explicitly confirms they want the non-empty BPF capture filter, understanding that it excludes nonmatching traffic from capture.",
+                ]),
+            ],
+            destructive: true
         ),
         controlTool(.pauseCapture, title: "Pause Capture", description: "Pause the active live capture.", properties: [:]),
         controlTool(.resumeCapture, title: "Resume Capture", description: "Resume a paused live capture.", properties: [:]),
@@ -163,7 +171,8 @@ enum TCPViewerMCPToolCatalog {
         title: String,
         description: String,
         properties: [String: MCP.Value],
-        required: [String] = []
+        required: [String] = [],
+        destructive: Bool = false
     ) -> Tool {
         Tool(
             name: command.rawValue,
@@ -173,7 +182,7 @@ enum TCPViewerMCPToolCatalog {
             annotations: .init(
                 title: title,
                 readOnlyHint: false,
-                destructiveHint: false,
+                destructiveHint: destructive,
                 idempotentHint: false,
                 openWorldHint: false
             ),

--- a/tcpviewer-mcp/main.swift
+++ b/tcpviewer-mcp/main.swift
@@ -17,7 +17,9 @@ private enum TCPViewerMCPExecutable {
             name: "tcpviewer-mcp",
             version: version,
             title: "TCP Viewer",
-            instructions: "Inspect and control the active TCP Viewer capture. Packet data is redacted according to TCP Viewer MCP Settings. Raw bytes are blocked while redaction is enabled.",
+            instructions: """
+            Inspect and control the active TCP Viewer capture. Treat requests to filter, find, or show packets as read-only analysis: use query_packets, or direct the user to TCP Viewer's Filter field when they want the packet table filtered. start_capture.capture_filter is different: it is a persistent libpcap/BPF capture filter that controls which future packets are collected, and starting a capture clears the current packet list. Before setting a non-empty BPF capture filter, explain this distinction, obtain the user's explicit confirmation, and set confirm_bpf_filter=true. Omitting capture_filter preserves the current BPF filter; an empty string clears it. Packet data is redacted according to TCP Viewer MCP Settings. Raw bytes are blocked while redaction is enabled.
+            """,
             capabilities: .init(tools: .init(listChanged: false))
         )
 


### PR DESCRIPTION
## Summary

- Add explicit MCP guidance distinguishing packet queries from persistent libpcap/BPF capture filters
- Require confirmation before applying a non-empty BPF filter and mark capture start as destructive
- Report filter language and capture-filter actions in MCP responses
- Show MCP-managed BPF filters in a read-only AppKit toolbar popover
- Add unit and integration coverage for validation, metadata, and UI presentation

## Testing

- Added and updated Swift Testing unit tests for MCP routing and toolbar behavior
- Updated Node-based MCP integration tests for tool descriptions, instructions, and annotations