### PR TITLE
Add packet color styling and session export support

### DIFF
--- a/PcapPlusPlusCore/Dissection/SwiftPacketDissector.swift
+++ b/PcapPlusPlusCore/Dissection/SwiftPacketDissector.swift
@@ -24,6 +24,7 @@ struct NativePacketRecord: Sendable {
     let pcapNGTimestampResolution: UInt8?
     let pcapNGTimestampOffsetSeconds: Int64
     let pcapNGTimestampRawValue: UInt64?
+    let textStyle: PacketTextStyle
 
     init(
         identifier: UInt64,
@@ -39,7 +40,8 @@ struct NativePacketRecord: Sendable {
         sectionNumber: UInt32 = 0,
         pcapNGTimestampResolution: UInt8? = nil,
         pcapNGTimestampOffsetSeconds: Int64 = 0,
-        pcapNGTimestampRawValue: UInt64? = nil
+        pcapNGTimestampRawValue: UInt64? = nil,
+        textStyle: PacketTextStyle = .plain
     ) {
         self.identifier = identifier
         self.packetNumber = packetNumber
@@ -55,6 +57,7 @@ struct NativePacketRecord: Sendable {
         self.pcapNGTimestampResolution = pcapNGTimestampResolution
         self.pcapNGTimestampOffsetSeconds = pcapNGTimestampOffsetSeconds
         self.pcapNGTimestampRawValue = pcapNGTimestampRawValue
+        self.textStyle = textStyle
     }
 
     var capturedLength: Int {
@@ -162,7 +165,8 @@ enum SwiftPacketDissector {
             layers: packet.layers.map { PCPPNativePacketLayerDescriptor(name: $0.name, detailSummary: $0.detailSummary) },
             decodeStatus: decodeDescriptor,
             captureMetadata: captureMetadata,
-            sniDomainName: packet.sniDomainName
+            sniDomainName: packet.sniDomainName,
+            textStyle: record.textStyle
         )
         let inspection = PCPPNativePacketInspectionDescriptor(
             packetIdentifier: record.identifier,

--- a/PcapPlusPlusCore/Models/CoreProtocols.swift
+++ b/PcapPlusPlusCore/Models/CoreProtocols.swift
@@ -73,6 +73,15 @@ public protocol LiveCaptureSessionProviding: AnyObject {
         shouldCancel: PacketExportCancellationCheck?,
         completion: @escaping TCPViewerVoidCompletion
     )
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    )
     func healthSnapshot(completion: @escaping (CaptureHealthSnapshot) -> Void)
     #if DEBUG
     func debugMemorySnapshot() -> LiveCaptureSessionDebugSnapshot
@@ -104,6 +113,15 @@ public protocol OfflineCaptureDocumentProviding: AnyObject {
         shouldCancel: PacketExportCancellationCheck?,
         completion: @escaping TCPViewerVoidCompletion
     )
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    )
     func currentURL() -> URL
     func currentMetadata() -> CaptureDocumentMetadata
     func packetSummaries() -> [PacketSummary]
@@ -114,11 +132,49 @@ public extension LiveCaptureSessionProviding {
     func exportPackets(withIDs identifiers: [PacketSummary.ID], to url: URL, format: CaptureFileFormat, completion: @escaping TCPViewerVoidCompletion) {
         exportPackets(withIDs: identifiers, to: url, format: format, progress: nil, shouldCancel: nil, completion: completion)
     }
+
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        exportPackets(
+            withIDs: identifiers,
+            to: url,
+            format: format,
+            progress: progress,
+            shouldCancel: shouldCancel,
+            completion: completion
+        )
+    }
 }
 
 public extension OfflineCaptureDocumentProviding {
     func exportPackets(withIDs identifiers: [PacketSummary.ID], to url: URL, format: CaptureFileFormat, completion: @escaping TCPViewerVoidCompletion) {
         exportPackets(withIDs: identifiers, to: url, format: format, progress: nil, shouldCancel: nil, completion: completion)
+    }
+
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        exportPackets(
+            withIDs: identifiers,
+            to: url,
+            format: format,
+            progress: progress,
+            shouldCancel: shouldCancel,
+            completion: completion
+        )
     }
 }
 

--- a/PcapPlusPlusCore/Models/PacketModels.swift
+++ b/PcapPlusPlusCore/Models/PacketModels.swift
@@ -313,6 +313,7 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
     public let captureMetadata: PacketCaptureMetadata
     public let sniDomainName: String?
     public let client: PacketClient?
+    public let textStyle: PacketTextStyle?
 
     public init(
         id: UInt64? = nil,
@@ -334,7 +335,8 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
         decodeStatus: PacketDecodeStatus,
         captureMetadata: PacketCaptureMetadata,
         sniDomainName: String? = nil,
-        client: PacketClient? = nil
+        client: PacketClient? = nil,
+        textStyle: PacketTextStyle? = nil
     ) {
         self.id = id ?? packetNumber
         self.packetNumber = packetNumber
@@ -356,6 +358,11 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
         self.captureMetadata = captureMetadata
         self.sniDomainName = sniDomainName
         self.client = client
+        self.textStyle = textStyle?.isPlain == true ? nil : textStyle
+    }
+
+    public var resolvedTextStyle: PacketTextStyle {
+        textStyle ?? .plain
     }
 }
 

--- a/PcapPlusPlusCore/Models/PacketTextStyle.swift
+++ b/PcapPlusPlusCore/Models/PacketTextStyle.swift
@@ -1,0 +1,106 @@
+//
+//  PacketTextStyle.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 26/7/26.
+//
+
+import Foundation
+
+public enum PacketHighlightColor: String, CaseIterable, Sendable, Codable, Hashable {
+    case red
+    case orange
+    case yellow
+    case green
+    case teal
+    case blue
+    case indigo
+    case purple
+    case pink
+    case brown
+    case gray
+}
+
+public struct PacketTextStyle: Sendable, Codable, Hashable {
+    public let highlightColor: PacketHighlightColor?
+    public let isStrikethrough: Bool
+
+    public static let plain = PacketTextStyle()
+
+    public init(highlightColor: PacketHighlightColor? = nil, isStrikethrough: Bool = false) {
+        self.highlightColor = highlightColor
+        self.isStrikethrough = isStrikethrough
+    }
+
+    public var isPlain: Bool {
+        highlightColor == nil && !isStrikethrough
+    }
+
+    public func withHighlightColor(_ color: PacketHighlightColor?) -> PacketTextStyle {
+        PacketTextStyle(highlightColor: color, isStrikethrough: isStrikethrough)
+    }
+
+    public func togglingStrikethrough() -> PacketTextStyle {
+        PacketTextStyle(highlightColor: highlightColor, isStrikethrough: !isStrikethrough)
+    }
+}
+
+public enum PacketTextStyleMutation: Sendable, Hashable {
+    case setHighlightColor(PacketHighlightColor)
+    case toggleStrikethrough
+    case reset
+    case replace(PacketTextStyle)
+
+    // Resolve the next style without coupling callers to where packets are stored.
+    public func applying(to currentStyle: PacketTextStyle) -> PacketTextStyle {
+        switch self {
+        case .setHighlightColor(let color):
+            return currentStyle.withHighlightColor(color)
+        case .toggleStrikethrough:
+            return currentStyle.togglingStrikethrough()
+        case .reset:
+            return .plain
+        case .replace(let style):
+            return style
+        }
+    }
+}
+
+public struct PacketExportMetadata: Sendable {
+    public let textStylesByPacketID: [PacketSummary.ID: PacketTextStyle]
+
+    public static let empty = PacketExportMetadata()
+
+    public init(textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:]) {
+        self.textStylesByPacketID = textStylesByPacketID
+    }
+}
+
+public extension PacketSummary {
+    // Return a packet copy with only its presentation style changed.
+    func applying(textStyle: PacketTextStyle) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: packetNumber,
+            timestamp: timestamp,
+            source: source,
+            interfaceID: interfaceID,
+            transportHint: transportHint,
+            protocolSummary: protocolSummary,
+            endpoints: endpoints,
+            originalLength: originalLength,
+            capturedLength: capturedLength,
+            streamID: streamID,
+            direction: direction,
+            tcpFlags: tcpFlags,
+            tcpPayloadLength: tcpPayloadLength,
+            infoSummary: infoSummary,
+            layers: layers,
+            decodeStatus: decodeStatus,
+            captureMetadata: captureMetadata,
+            sniDomainName: sniDomainName,
+            client: client,
+            textStyle: textStyle
+        )
+    }
+}

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
@@ -393,7 +393,8 @@ enum NativeBridgeMapper {
             layers: descriptor.layers.map(packetLayer),
             decodeStatus: decodeStatus(descriptor.decodeStatus),
             captureMetadata: packetCaptureMetadata(descriptor.captureMetadata),
-            sniDomainName: descriptor.sniDomainName
+            sniDomainName: descriptor.sniDomainName,
+            textStyle: descriptor.textStyle
         )
     }
 

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeTypes.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeTypes.swift
@@ -220,6 +220,7 @@ final class PCPPNativePacketSummaryDescriptor {
     let decodeStatus: PCPPNativeDecodeStatusDescriptor
     let captureMetadata: PCPPNativePacketCaptureMetadataDescriptor
     let sniDomainName: String?
+    let textStyle: PacketTextStyle
 
     init(
         identifier: UInt64,
@@ -239,7 +240,8 @@ final class PCPPNativePacketSummaryDescriptor {
         layers: [PCPPNativePacketLayerDescriptor],
         decodeStatus: PCPPNativeDecodeStatusDescriptor,
         captureMetadata: PCPPNativePacketCaptureMetadataDescriptor,
-        sniDomainName: String?
+        sniDomainName: String?,
+        textStyle: PacketTextStyle = .plain
     ) {
         self.identifier = identifier
         self.packetNumber = packetNumber
@@ -259,6 +261,7 @@ final class PCPPNativePacketSummaryDescriptor {
         self.decodeStatus = decodeStatus
         self.captureMetadata = captureMetadata
         self.sniDomainName = sniDomainName
+        self.textStyle = textStyle
     }
 }
 

--- a/PcapPlusPlusCore/Services/Core/NativeCaptureFile.swift
+++ b/PcapPlusPlusCore/Services/Core/NativeCaptureFile.swift
@@ -5,6 +5,7 @@
 //  Created by Proxyman LLC on 28/5/26.
 //
 
+import Darwin
 import Foundation
 
 struct NativeCaptureFile {
@@ -44,7 +45,15 @@ struct NativeCaptureFile {
         return try PcapReader(url: url, data: data).read()
     }
 
-    static func write(records: [NativePacketRecord], to url: URL, format: CaptureFileFormat) throws {
+    static func write(
+        records: [NativePacketRecord],
+        to url: URL,
+        format: CaptureFileFormat,
+        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:]
+    ) throws {
+        let outputRecords = records.map { record in
+            record.withTextStyle(textStylesByPacketID[record.identifier] ?? record.textStyle)
+        }
         let temporaryURL = url.deletingLastPathComponent()
             .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
         guard FileManager.default.createFile(
@@ -59,14 +68,17 @@ struct NativeCaptureFile {
             do {
                 switch format {
                 case .pcap:
-                    try PcapWriter(records: records).write(to: handle)
+                    try PcapWriter(records: outputRecords).write(to: handle)
                 case .pcapng:
-                    try PcapNGWriter(records: records).write(to: handle)
+                    try PcapNGWriter(records: outputRecords).write(to: handle)
                 }
                 try handle.close()
             } catch {
                 try? handle.close()
                 throw error
+            }
+            if format == .pcap {
+                try PcapTextStyleExtendedAttribute.write(stylesFrom: outputRecords, to: temporaryURL)
             }
             if FileManager.default.fileExists(atPath: url.path) {
                 _ = try FileManager.default.replaceItemAt(url, withItemAt: temporaryURL)
@@ -127,7 +139,7 @@ private struct PcapReader {
                 return NativeCaptureFile(
                     url: url,
                     format: .pcap,
-                    records: records,
+                    records: styledRecords(records),
                     metadata: metadata(),
                     skippedPacketCount: 1,
                     partialLoadReason: "Stopped at a truncated packet record."
@@ -155,7 +167,7 @@ private struct PcapReader {
         return NativeCaptureFile(
             url: url,
             format: .pcap,
-            records: records,
+            records: styledRecords(records),
             metadata: metadata(),
             skippedPacketCount: trailingByteCount > 0 ? 1 : 0,
             partialLoadReason: trailingByteCount > 0 ? "Stopped at an incomplete packet header." : nil
@@ -170,6 +182,16 @@ private struct PcapReader {
             captureApplication: nil,
             fileComment: nil
         )
+    }
+
+    private func styledRecords(_ records: [NativePacketRecord]) -> [NativePacketRecord] {
+        let styles = PcapTextStyleExtendedAttribute.read(from: url, packetCount: records.count)
+        guard !styles.isEmpty else {
+            return records
+        }
+        return records.enumerated().map { index, record in
+            record.withTextStyle(styles[index] ?? .plain)
+        }
     }
 
     private func readUInt32(at offset: Int, littleEndian: Bool) -> UInt32? {
@@ -294,6 +316,12 @@ private struct PcapNGReader {
                     continue
                 }
                 let packetData = data.subdata(in: packetOffset..<(packetOffset + capturedLength))
+                let optionsOffset = packetOffset + paddedLength(capturedLength)
+                let packetOptions = optionsOffset <= bodyEnd
+                    ? readOptions(offset: optionsOffset, end: bodyEnd, littleEndian: littleEndian)
+                    : [:]
+                let comment = packetOptions[1].flatMap { String(data: $0, encoding: .utf8) }
+                let decodedComment = PcapNGTextStyleComment.decode(comment)
                 let interface = interfaces[metadataKey(interfaceID: interfaceID, section: section)]
                 let timestampRaw = (timestampHigh << 32) | timestampLow
                 let timestampResolution = interface?.timestampResolution ?? 6
@@ -308,12 +336,13 @@ private struct PcapNGReader {
                     linkLayerType: interface?.linkType ?? Libpcap.dltEthernet,
                     interfaceIdentifier: interface?.name,
                     interfaceName: interface?.name ?? interface?.description,
-                    packetComment: nil,
+                    packetComment: decodedComment.packetComment,
                     interfaceID: interfaceID,
                     sectionNumber: section,
                     pcapNGTimestampResolution: timestampResolution,
                     pcapNGTimestampOffsetSeconds: timestampOffset,
-                    pcapNGTimestampRawValue: timestampRaw
+                    pcapNGTimestampRawValue: timestampRaw,
+                    textStyle: decodedComment.textStyle
                 ))
                 packetNumber += 1
             } else if blockType == 3 {
@@ -585,7 +614,19 @@ private struct PcapNGWriter {
                 throw NativeNSError(.fileWriteFailed, "Packet \(record.identifier) is too large for PCAPNG.")
             }
             let timestamp = try timestampValue(for: record, interface: interface)
-            let bodyLength = 20 + record.rawBytes.count + paddingCount + 4
+            var options = Data()
+            if let comment = PcapNGTextStyleComment.encode(
+                packetComment: record.packetComment,
+                textStyle: record.textStyle
+            ) {
+                try appendOption(code: 1, value: Data(comment.utf8), to: &options)
+            }
+            options.appendLittleEndian(UInt16(0))
+            options.appendLittleEndian(UInt16(0))
+            let bodyLength = 20 + record.rawBytes.count + paddingCount + options.count
+            guard bodyLength <= Int(UInt32.max) - 12 else {
+                throw NativeNSError(.fileWriteFailed, "Packet \(record.identifier) metadata is too large for PCAPNG.")
+            }
             let totalLength = UInt32(12 + bodyLength)
             var packetHeader = Data()
             packetHeader.appendLittleEndian(UInt32(6))
@@ -600,9 +641,8 @@ private struct PcapNGWriter {
             if paddingCount > 0 {
                 try handle.write(contentsOf: Data(repeating: 0, count: paddingCount))
             }
+            try handle.write(contentsOf: options)
             var trailer = Data()
-            trailer.appendLittleEndian(UInt16(0))
-            trailer.appendLittleEndian(UInt16(0))
             trailer.appendLittleEndian(totalLength)
             try handle.write(contentsOf: trailer)
         }
@@ -684,12 +724,160 @@ private struct PcapNGWriter {
     }
 }
 
+private enum PcapNGTextStyleComment {
+    private static let markerPrefix = "[TCPViewer:text-style:v1:"
+    private static let markerSuffix = "]"
+
+    static func encode(packetComment: String?, textStyle: PacketTextStyle) -> String? {
+        let comment = packetComment
+        guard !textStyle.isPlain else {
+            return comment?.isEmpty == false ? comment : nil
+        }
+
+        let color = textStyle.highlightColor?.rawValue ?? "none"
+        let marker = "\(markerPrefix)\(color):\(textStyle.isStrikethrough ? 1 : 0)\(markerSuffix)"
+        guard let comment, !comment.isEmpty else {
+            return marker
+        }
+        return "\(comment)\n\(marker)"
+    }
+
+    static func decode(_ value: String?) -> (packetComment: String?, textStyle: PacketTextStyle) {
+        guard let value else {
+            return (nil, .plain)
+        }
+
+        var style = PacketTextStyle.plain
+        let retainedLines = value.split(separator: "\n", omittingEmptySubsequences: false).filter { line in
+            guard line.hasPrefix(markerPrefix), line.hasSuffix(markerSuffix) else {
+                return true
+            }
+            let payload = line.dropFirst(markerPrefix.count).dropLast(markerSuffix.count)
+            let components = payload.split(separator: ":", omittingEmptySubsequences: false)
+            guard components.count == 2,
+                  components[1] == "0" || components[1] == "1" else {
+                return true
+            }
+            let color = components[0] == "none" ? nil : PacketHighlightColor(rawValue: String(components[0]))
+            guard components[0] == "none" || color != nil else {
+                return true
+            }
+            style = PacketTextStyle(highlightColor: color, isStrikethrough: components[1] == "1")
+            return false
+        }
+        let packetComment = retainedLines.joined(separator: "\n")
+        return (packetComment.isEmpty ? nil : packetComment, style)
+    }
+}
+
+private enum PcapTextStyleExtendedAttribute {
+    private static let name = "com.proxyman.TCPViewer.packet-text-styles"
+    private static let magic = Data("TCPVSTY1".utf8)
+    private static let headerLength = magic.count + 8
+    private static let entryLength = 9
+
+    static func write(stylesFrom records: [NativePacketRecord], to url: URL) throws {
+        var data = magic
+        data.appendLittleEndian(UInt64(records.count))
+        for (index, record) in records.enumerated() where !record.textStyle.isPlain {
+            data.appendLittleEndian(UInt64(index))
+            data.append(styleByte(record.textStyle))
+        }
+
+        let result = data.withUnsafeBytes { bytes in
+            setxattr(url.path, name, bytes.baseAddress, bytes.count, 0, 0)
+        }
+        guard result == 0 else {
+            throw NativeNSError(.fileWriteFailed, "TCP Viewer could not store packet styles in the PCAP export.")
+        }
+    }
+
+    static func read(from url: URL, packetCount: Int) -> [Int: PacketTextStyle] {
+        let length = getxattr(url.path, name, nil, 0, 0, 0)
+        guard length >= headerLength else {
+            return [:]
+        }
+        var data = Data(count: length)
+        let result = data.withUnsafeMutableBytes { bytes in
+            getxattr(url.path, name, bytes.baseAddress, bytes.count, 0, 0)
+        }
+        guard result == length, data.starts(with: magic),
+              data.readLittleEndianUInt64(at: magic.count) == UInt64(packetCount),
+              (data.count - headerLength).isMultiple(of: entryLength) else {
+            return [:]
+        }
+
+        var styles: [Int: PacketTextStyle] = [:]
+        var offset = headerLength
+        while offset + entryLength <= data.count {
+            guard let ordinal = data.readLittleEndianUInt64(at: offset),
+                  ordinal < UInt64(packetCount),
+                  let style = textStyle(from: data[offset + 8]) else {
+                return [:]
+            }
+            styles[Int(ordinal)] = style
+            offset += entryLength
+        }
+        return styles
+    }
+
+    private static func styleByte(_ style: PacketTextStyle) -> UInt8 {
+        let colorValue = style.highlightColor
+            .flatMap { PacketHighlightColor.allCases.firstIndex(of: $0) }
+            .map { UInt8($0 + 1) } ?? 0
+        return colorValue | (style.isStrikethrough ? 0x80 : 0)
+    }
+
+    private static func textStyle(from byte: UInt8) -> PacketTextStyle? {
+        let colorValue = Int(byte & 0x7f)
+        guard colorValue <= PacketHighlightColor.allCases.count else {
+            return nil
+        }
+        let color = colorValue == 0 ? nil : PacketHighlightColor.allCases[colorValue - 1]
+        let style = PacketTextStyle(highlightColor: color, isStrikethrough: byte & 0x80 != 0)
+        return style.isPlain ? nil : style
+    }
+}
+
+private extension NativePacketRecord {
+    func withTextStyle(_ textStyle: PacketTextStyle) -> NativePacketRecord {
+        NativePacketRecord(
+            identifier: identifier,
+            packetNumber: packetNumber,
+            timestamp: timestamp,
+            rawBytes: rawBytes,
+            originalLength: originalLength,
+            linkLayerType: linkLayerType,
+            interfaceIdentifier: interfaceIdentifier,
+            interfaceName: interfaceName,
+            packetComment: packetComment,
+            interfaceID: interfaceID,
+            sectionNumber: sectionNumber,
+            pcapNGTimestampResolution: pcapNGTimestampResolution,
+            pcapNGTimestampOffsetSeconds: pcapNGTimestampOffsetSeconds,
+            pcapNGTimestampRawValue: pcapNGTimestampRawValue,
+            textStyle: textStyle
+        )
+    }
+}
+
 private extension Data {
     mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
         var littleEndian = value.littleEndian
         Swift.withUnsafeBytes(of: &littleEndian) { buffer in
             append(buffer.bindMemory(to: UInt8.self))
         }
+    }
+
+    func readLittleEndianUInt64(at offset: Int) -> UInt64? {
+        guard offset >= 0, offset + 8 <= count else {
+            return nil
+        }
+        var value: UInt64 = 0
+        for index in 0..<8 {
+            value |= UInt64(self[offset + index]) << UInt64(index * 8)
+        }
+        return value
     }
 
 }

--- a/PcapPlusPlusCore/Services/Core/NativeCaptureFile.swift
+++ b/PcapPlusPlusCore/Services/Core/NativeCaptureFile.swift
@@ -77,13 +77,17 @@ struct NativeCaptureFile {
                 try? handle.close()
                 throw error
             }
-            if format == .pcap {
-                try PcapTextStyleExtendedAttribute.write(stylesFrom: outputRecords, to: temporaryURL)
-            }
             if FileManager.default.fileExists(atPath: url.path) {
                 _ = try FileManager.default.replaceItemAt(url, withItemAt: temporaryURL)
             } else {
                 try FileManager.default.moveItem(at: temporaryURL, to: url)
+            }
+            if format == .pcap {
+                // Classic PCAP has no metadata field, so keep its optional file metadata best-effort.
+                let hasStyles = outputRecords.contains { !$0.textStyle.isPlain }
+                if !hasStyles || !PcapTextStyleExtendedAttribute.write(stylesFrom: outputRecords, to: url) {
+                    PcapTextStyleExtendedAttribute.remove(from: url)
+                }
             }
         } catch let error as NSError where error.domain == TCPViewerNativeErrorDomain {
             try? FileManager.default.removeItem(at: temporaryURL)
@@ -235,6 +239,8 @@ private struct PcapNGReader {
         var packetNumber: UInt64 = 1
         var skippedPacketCount = 0
         var partialLoadReason: String?
+        var captureApplication: String?
+        var sectionSupportsTextStyles = false
 
         while offset + 12 <= data.count {
             let blockStart = offset
@@ -259,6 +265,10 @@ private struct PcapNGReader {
                 }
                 hasSection = true
                 nextInterfaceID = 0
+                captureApplication = captureApplication ?? sectionHeader.userApplication
+                sectionSupportsTextStyles = PcapNGTextStyleComment.supports(
+                    userApplication: sectionHeader.userApplication
+                )
                 offset = blockStart + sectionHeader.totalLength
                 continue
             }
@@ -321,7 +331,10 @@ private struct PcapNGReader {
                     ? readOptions(offset: optionsOffset, end: bodyEnd, littleEndian: littleEndian)
                     : [:]
                 let comment = packetOptions[1].flatMap { String(data: $0, encoding: .utf8) }
-                let decodedComment = PcapNGTextStyleComment.decode(comment)
+                let decodedComment = PcapNGTextStyleComment.decode(
+                    comment,
+                    allowsTextStyleMetadata: sectionSupportsTextStyles
+                )
                 let interface = interfaces[metadataKey(interfaceID: interfaceID, section: section)]
                 let timestampRaw = (timestampHigh << 32) | timestampLow
                 let timestampResolution = interface?.timestampResolution ?? 6
@@ -387,7 +400,7 @@ private struct PcapNGReader {
                 format: CaptureFileFormat.pcapng.rawValue,
                 operatingSystem: nil,
                 hardware: nil,
-                captureApplication: nil,
+                captureApplication: captureApplication,
                 fileComment: nil
             ),
             skippedPacketCount: skippedPacketCount,
@@ -398,6 +411,7 @@ private struct PcapNGReader {
     private struct SectionHeaderBlock {
         let totalLength: Int
         let littleEndian: Bool
+        let userApplication: String?
     }
 
     private func isSectionHeaderBlock(at offset: Int) -> Bool {
@@ -435,7 +449,16 @@ private struct PcapNGReader {
             throw NativeNSError(.fileReadFailed, "The PCAPNG section header has an invalid trailing length.")
         }
 
-        return SectionHeaderBlock(totalLength: totalLength, littleEndian: littleEndian)
+        let options = readOptions(
+            offset: offset + 24,
+            end: trailingLengthOffset,
+            littleEndian: littleEndian
+        )
+        return SectionHeaderBlock(
+            totalLength: totalLength,
+            littleEndian: littleEndian,
+            userApplication: options[4].flatMap { String(data: $0, encoding: .utf8) }
+        )
     }
 
     private func readOptions(offset: Int, end: Int, littleEndian: Bool) -> [UInt16: Data] {
@@ -567,6 +590,13 @@ private struct PcapNGWriter {
         sectionBody.appendLittleEndian(UInt16(1))
         sectionBody.appendLittleEndian(UInt16(0))
         sectionBody.appendLittleEndian(UInt64.max)
+        try appendOption(
+            code: 4,
+            value: Data(PcapNGTextStyleComment.userApplication.utf8),
+            to: &sectionBody
+        )
+        sectionBody.appendLittleEndian(UInt16(0))
+        sectionBody.appendLittleEndian(UInt16(0))
         try writeBlock(type: 0x0a0d0d0a, body: sectionBody, to: handle)
 
         let defaultInterface = InterfaceKey(
@@ -725,11 +755,17 @@ private struct PcapNGWriter {
 }
 
 private enum PcapNGTextStyleComment {
-    private static let markerPrefix = "[TCPViewer:text-style:v1:"
+    static let userApplication = "TCPViewer"
+
+    private static let markerPrefix = "[TCPViewer:text-style:v2:"
     private static let markerSuffix = "]"
 
+    static func supports(userApplication: String?) -> Bool {
+        userApplication == Self.userApplication
+    }
+
     static func encode(packetComment: String?, textStyle: PacketTextStyle) -> String? {
-        let comment = packetComment
+        let comment = packetComment.map(escapingMarkerLines(in:))
         guard !textStyle.isPlain else {
             return comment?.isEmpty == false ? comment : nil
         }
@@ -742,31 +778,63 @@ private enum PcapNGTextStyleComment {
         return "\(comment)\n\(marker)"
     }
 
-    static func decode(_ value: String?) -> (packetComment: String?, textStyle: PacketTextStyle) {
+    static func decode(
+        _ value: String?,
+        allowsTextStyleMetadata: Bool
+    ) -> (packetComment: String?, textStyle: PacketTextStyle) {
         guard let value else {
             return (nil, .plain)
         }
+        guard allowsTextStyleMetadata else {
+            return (value.isEmpty ? nil : value, .plain)
+        }
 
         var style = PacketTextStyle.plain
-        let retainedLines = value.split(separator: "\n", omittingEmptySubsequences: false).filter { line in
-            guard line.hasPrefix(markerPrefix), line.hasSuffix(markerSuffix) else {
-                return true
-            }
-            let payload = line.dropFirst(markerPrefix.count).dropLast(markerSuffix.count)
-            let components = payload.split(separator: ":", omittingEmptySubsequences: false)
-            guard components.count == 2,
-                  components[1] == "0" || components[1] == "1" else {
-                return true
-            }
-            let color = components[0] == "none" ? nil : PacketHighlightColor(rawValue: String(components[0]))
-            guard components[0] == "none" || color != nil else {
-                return true
-            }
-            style = PacketTextStyle(highlightColor: color, isStrikethrough: components[1] == "1")
-            return false
+        var retainedLines = value.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if let marker = retainedLines.last,
+           let decodedStyle = textStyle(fromMarker: marker) {
+            style = decodedStyle
+            retainedLines.removeLast()
         }
-        let packetComment = retainedLines.joined(separator: "\n")
+        let packetComment = retainedLines
+            .map(unescapingMarkerLine(_:))
+            .joined(separator: "\n")
         return (packetComment.isEmpty ? nil : packetComment, style)
+    }
+
+    private static func escapingMarkerLines(in comment: String) -> String {
+        comment
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in
+                let line = String(line)
+                return hasMarkerPrefixAfterEscapes(line) ? "\\\(line)" : line
+            }
+            .joined(separator: "\n")
+    }
+
+    private static func unescapingMarkerLine(_ line: String) -> String {
+        line.first == "\\" && hasMarkerPrefixAfterEscapes(line) ? String(line.dropFirst()) : line
+    }
+
+    private static func hasMarkerPrefixAfterEscapes(_ line: String) -> Bool {
+        line.drop(while: { $0 == "\\" }).hasPrefix(markerPrefix)
+    }
+
+    private static func textStyle(fromMarker line: String) -> PacketTextStyle? {
+        guard line.hasPrefix(markerPrefix), line.hasSuffix(markerSuffix) else {
+            return nil
+        }
+        let payload = line.dropFirst(markerPrefix.count).dropLast(markerSuffix.count)
+        let components = payload.split(separator: ":", omittingEmptySubsequences: false)
+        guard components.count == 2,
+              components[1] == "0" || components[1] == "1" else {
+            return nil
+        }
+        let color = components[0] == "none" ? nil : PacketHighlightColor(rawValue: String(components[0]))
+        guard components[0] == "none" || color != nil else {
+            return nil
+        }
+        return PacketTextStyle(highlightColor: color, isStrikethrough: components[1] == "1")
     }
 }
 
@@ -776,20 +844,18 @@ private enum PcapTextStyleExtendedAttribute {
     private static let headerLength = magic.count + 8
     private static let entryLength = 9
 
-    static func write(stylesFrom records: [NativePacketRecord], to url: URL) throws {
+    static func write(stylesFrom records: [NativePacketRecord], to url: URL) -> Bool {
         var data = magic
         data.appendLittleEndian(UInt64(records.count))
         for (index, record) in records.enumerated() where !record.textStyle.isPlain {
             data.appendLittleEndian(UInt64(index))
-            data.append(styleByte(record.textStyle))
+            data.append(PacketTextStyleBinaryCodec.encode(record.textStyle))
         }
 
         let result = data.withUnsafeBytes { bytes in
             setxattr(url.path, name, bytes.baseAddress, bytes.count, 0, 0)
         }
-        guard result == 0 else {
-            throw NativeNSError(.fileWriteFailed, "TCP Viewer could not store packet styles in the PCAP export.")
-        }
+        return result == 0
     }
 
     static func read(from url: URL, packetCount: Int) -> [Int: PacketTextStyle] {
@@ -812,7 +878,7 @@ private enum PcapTextStyleExtendedAttribute {
         while offset + entryLength <= data.count {
             guard let ordinal = data.readLittleEndianUInt64(at: offset),
                   ordinal < UInt64(packetCount),
-                  let style = textStyle(from: data[offset + 8]) else {
+                  let style = PacketTextStyleBinaryCodec.decode(data[offset + 8]) else {
                 return [:]
             }
             styles[Int(ordinal)] = style
@@ -821,21 +887,63 @@ private enum PcapTextStyleExtendedAttribute {
         return styles
     }
 
-    private static func styleByte(_ style: PacketTextStyle) -> UInt8 {
-        let colorValue = style.highlightColor
-            .flatMap { PacketHighlightColor.allCases.firstIndex(of: $0) }
-            .map { UInt8($0 + 1) } ?? 0
-        return colorValue | (style.isStrikethrough ? 0x80 : 0)
+    static func remove(from url: URL) {
+        _ = removexattr(url.path, name, 0)
     }
 
-    private static func textStyle(from byte: UInt8) -> PacketTextStyle? {
+}
+
+enum PacketTextStyleBinaryCodec {
+    static func encode(_ style: PacketTextStyle) -> UInt8 {
+        colorCode(style.highlightColor) | (style.isStrikethrough ? 0x80 : 0)
+    }
+
+    static func decode(_ byte: UInt8) -> PacketTextStyle? {
         let colorValue = Int(byte & 0x7f)
-        guard colorValue <= PacketHighlightColor.allCases.count else {
+        let decodedColor = color(from: UInt8(colorValue))
+        guard decodedColor.isValid else {
             return nil
         }
-        let color = colorValue == 0 ? nil : PacketHighlightColor.allCases[colorValue - 1]
-        let style = PacketTextStyle(highlightColor: color, isStrikethrough: byte & 0x80 != 0)
+        let style = PacketTextStyle(
+            highlightColor: decodedColor.color,
+            isStrikethrough: byte & 0x80 != 0
+        )
         return style.isPlain ? nil : style
+    }
+
+    private static func colorCode(_ color: PacketHighlightColor?) -> UInt8 {
+        switch color {
+        case nil: 0
+        case .red: 1
+        case .orange: 2
+        case .yellow: 3
+        case .green: 4
+        case .teal: 5
+        case .blue: 6
+        case .indigo: 7
+        case .purple: 8
+        case .pink: 9
+        case .brown: 10
+        case .gray: 11
+        }
+    }
+
+    private static func color(from code: UInt8) -> (isValid: Bool, color: PacketHighlightColor?) {
+        switch code {
+        case 0: (true, nil)
+        case 1: (true, .red)
+        case 2: (true, .orange)
+        case 3: (true, .yellow)
+        case 4: (true, .green)
+        case 5: (true, .teal)
+        case 6: (true, .blue)
+        case 7: (true, .indigo)
+        case 8: (true, .purple)
+        case 9: (true, .pink)
+        case 10: (true, .brown)
+        case 11: (true, .gray)
+        default: (false, nil)
+        }
     }
 }
 

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -276,6 +276,7 @@ final class PCPPNativeOfflineDocument {
         withIdentifiers identifiers: [NSNumber],
         to url: URL,
         format: String,
+        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
         progressHandler: PCPPNativePacketExportProgressHandler?,
         cancellationCheck: PCPPNativeCancellationHandler?
     ) throws {
@@ -283,7 +284,14 @@ final class PCPPNativeOfflineDocument {
         let records = state.read {
             $0.file.records.filter { idSet.contains($0.identifier) }
         }
-        try Exporter.export(records: records, to: url, format: CaptureFileFormat(exportRawValue: format), progressHandler: progressHandler, cancellationCheck: cancellationCheck)
+        try Exporter.export(
+            records: records,
+            to: url,
+            format: CaptureFileFormat(exportRawValue: format),
+            textStylesByPacketID: textStylesByPacketID,
+            progressHandler: progressHandler,
+            cancellationCheck: cancellationCheck
+        )
     }
 
     private func loadIncrementally(
@@ -760,6 +768,7 @@ final class PCPPNativeLiveSession {
         withIdentifiers identifiers: [NSNumber],
         to url: URL,
         format: String,
+        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
         progressHandler: PCPPNativePacketExportProgressHandler?,
         cancellationCheck: PCPPNativeCancellationHandler?
     ) throws {
@@ -767,7 +776,14 @@ final class PCPPNativeLiveSession {
         let selected = try state.read {
             try $0.packetStore.records(matching: idSet)
         }
-        try Exporter.export(records: selected, to: url, format: CaptureFileFormat(exportRawValue: format), progressHandler: progressHandler, cancellationCheck: cancellationCheck)
+        try Exporter.export(
+            records: selected,
+            to: url,
+            format: CaptureFileFormat(exportRawValue: format),
+            textStylesByPacketID: textStylesByPacketID,
+            progressHandler: progressHandler,
+            cancellationCheck: cancellationCheck
+        )
     }
 
     private func captureLoop(handle: OpaquePointer) {
@@ -936,7 +952,8 @@ private func makePacketSummaryDescriptor(
         layers: analyzed.layers.map { PCPPNativePacketLayerDescriptor(name: $0.name, detailSummary: $0.detailSummary) },
         decodeStatus: decodeStatusDescriptor(analyzed.decodeStatus),
         captureMetadata: captureMetadataDescriptor(record),
-        sniDomainName: wireshark.sniDomainName
+        sniDomainName: wireshark.sniDomainName,
+        textStyle: record.textStyle
     )
 }
 
@@ -1112,6 +1129,7 @@ enum Exporter {
         records: [NativePacketRecord],
         to url: URL,
         format: CaptureFileFormat,
+        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
         progressHandler: PCPPNativePacketExportProgressHandler?,
         cancellationCheck: PCPPNativeCancellationHandler?
     ) throws {
@@ -1124,7 +1142,12 @@ enum Exporter {
             }
             progressHandler?(UInt(index), UInt(records.count))
         }
-        try NativeCaptureFile.write(records: records, to: url, format: format)
+        try NativeCaptureFile.write(
+            records: records,
+            to: url,
+            format: format,
+            textStylesByPacketID: textStylesByPacketID
+        )
         progressHandler?(UInt(records.count), UInt(records.count))
     }
 }

--- a/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
+++ b/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
@@ -60,6 +60,26 @@ public final class NativeLiveCaptureSession: LiveCaptureSessionProviding, @unche
         state.exportPackets(withIDs: identifiers, to: url, format: format, progress: progress, shouldCancel: shouldCancel, completion: completion)
     }
 
+    public func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        state.exportPackets(
+            withIDs: identifiers,
+            to: url,
+            format: format,
+            metadata: metadata,
+            progress: progress,
+            shouldCancel: shouldCancel,
+            completion: completion
+        )
+    }
+
     public func healthSnapshot(completion: @escaping (CaptureHealthSnapshot) -> Void) {
         state.healthSnapshot(completion: completion)
     }
@@ -380,6 +400,7 @@ private final class NativeLiveCaptureSessionState: @unchecked Sendable {
         withIDs identifiers: [PacketSummary.ID],
         to url: URL,
         format: CaptureFileFormat,
+        metadata: PacketExportMetadata = .empty,
         progress: PacketExportProgressHandler?,
         shouldCancel: PacketExportCancellationCheck?,
         completion: @escaping TCPViewerVoidCompletion
@@ -395,6 +416,7 @@ private final class NativeLiveCaptureSessionState: @unchecked Sendable {
                         withIdentifiers: identifiers.map { NSNumber(value: $0) },
                         to: url,
                         format: format.rawValue,
+                        textStylesByPacketID: metadata.textStylesByPacketID,
                         progressHandler: { exportedPacketCount, totalPacketCount in
                             progress?(PacketExportProgress(
                                 exportedPacketCount: Int(exportedPacketCount),

--- a/PcapPlusPlusCore/Services/OfflineCapture/NativeOfflineCaptureDocument.swift
+++ b/PcapPlusPlusCore/Services/OfflineCapture/NativeOfflineCaptureDocument.swift
@@ -55,6 +55,26 @@ public final class NativeOfflineCaptureDocument: OfflineCaptureDocumentProviding
         state.exportPackets(withIDs: identifiers, to: url, format: format, progress: progress, shouldCancel: shouldCancel, completion: completion)
     }
 
+    public func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        state.exportPackets(
+            withIDs: identifiers,
+            to: url,
+            format: format,
+            metadata: metadata,
+            progress: progress,
+            shouldCancel: shouldCancel,
+            completion: completion
+        )
+    }
+
     public func currentURL() -> URL {
         state.currentURL()
     }
@@ -247,6 +267,7 @@ private final class NativeOfflineCaptureDocumentState: @unchecked Sendable {
         withIDs identifiers: [PacketSummary.ID],
         to url: URL,
         format: CaptureFileFormat,
+        metadata: PacketExportMetadata = .empty,
         progress: PacketExportProgressHandler?,
         shouldCancel: PacketExportCancellationCheck?,
         completion: @escaping TCPViewerVoidCompletion
@@ -262,6 +283,7 @@ private final class NativeOfflineCaptureDocumentState: @unchecked Sendable {
                         withIdentifiers: identifiers.map { NSNumber(value: $0) },
                         to: url,
                         format: format.rawValue,
+                        textStylesByPacketID: metadata.textStylesByPacketID,
                         progressHandler: { exportedPacketCount, totalPacketCount in
                             progress?(PacketExportProgress(
                                 exportedPacketCount: Int(exportedPacketCount),

--- a/PcapPlusPlusCoreTests/Services/Core/PcapNGFidelityTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/PcapNGFidelityTests.swift
@@ -73,6 +73,106 @@ struct PcapNGFidelityTests {
         }
     }
 
+    @Test func pcapNGExportRoundTripsPacketCommentAndTextStyle() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapNGStyle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("styled.pcapng")
+        let style = PacketTextStyle(highlightColor: .indigo, isStrikethrough: true)
+        let record = makeRecord(
+            identifier: 7,
+            linkLayerType: Libpcap.dltEthernet,
+            packetComment: "Keep this comment\n"
+        )
+
+        try NativeCaptureFile.write(
+            records: [record],
+            to: url,
+            format: .pcapng,
+            textStylesByPacketID: [record.identifier: style]
+        )
+        let capture = try NativeCaptureFile.load(from: url)
+        let exportedBytes = try Data(contentsOf: url)
+
+        #expect(capture.records.count == 1)
+        #expect(capture.records[0].rawBytes == record.rawBytes)
+        #expect(capture.records[0].packetComment == "Keep this comment\n")
+        #expect(capture.records[0].textStyle == style)
+        #expect(exportedBytes.range(of: Data("[TCPViewer:text-style:v1:indigo:1]".utf8)) != nil)
+    }
+
+    @Test func pcapExportKeepsCanonicalBytesAndRoundTripsStyleInFileMetadata() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapStyle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let plainURL = directory.appendingPathComponent("plain.pcap")
+        let styledURL = directory.appendingPathComponent("styled.pcap")
+        let record = makeRecord(identifier: 1, linkLayerType: Libpcap.dltEthernet)
+        let style = PacketTextStyle(highlightColor: .pink, isStrikethrough: true)
+
+        try NativeCaptureFile.write(records: [record], to: plainURL, format: .pcap)
+        try NativeCaptureFile.write(
+            records: [record],
+            to: styledURL,
+            format: .pcap,
+            textStylesByPacketID: [record.identifier: style]
+        )
+        let capture = try NativeCaptureFile.load(from: styledURL)
+
+        #expect(try Data(contentsOf: plainURL) == Data(contentsOf: styledURL))
+        #expect(capture.records.map(\.textStyle) == [style])
+        #expect(capture.records[0].rawBytes == record.rawBytes)
+    }
+
+    @Test func explicitPlainExportMetadataResetsAnImportedStyle() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapNGStyleReset-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("reset.pcapng")
+        let record = makeRecord(
+            identifier: 3,
+            linkLayerType: Libpcap.dltEthernet,
+            textStyle: PacketTextStyle(highlightColor: .red)
+        )
+
+        try NativeCaptureFile.write(
+            records: [record],
+            to: url,
+            format: .pcapng,
+            textStylesByPacketID: [record.identifier: .plain]
+        )
+        let capture = try NativeCaptureFile.load(from: url)
+
+        #expect(capture.records.map(\.textStyle) == [.plain])
+    }
+
+    @Test func replacingAnExistingPcapReplacesItsStyleMetadata() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapStyleReplace-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("replaced.pcap")
+        let record = makeRecord(identifier: 1, linkLayerType: Libpcap.dltEthernet)
+
+        try NativeCaptureFile.write(
+            records: [record],
+            to: url,
+            format: .pcap,
+            textStylesByPacketID: [record.identifier: PacketTextStyle(highlightColor: .green)]
+        )
+        try NativeCaptureFile.write(
+            records: [record],
+            to: url,
+            format: .pcap,
+            textStylesByPacketID: [record.identifier: .plain]
+        )
+
+        #expect(try NativeCaptureFile.load(from: url).records.map(\.textStyle) == [.plain])
+    }
+
     private func makeRecord(
         identifier: UInt64,
         timestamp: Date = Date(timeIntervalSince1970: 1),
@@ -81,7 +181,9 @@ struct PcapNGFidelityTests {
         interfaceName: String? = nil,
         resolution: UInt8? = nil,
         offset: Int64 = 0,
-        rawTimestamp: UInt64? = nil
+        rawTimestamp: UInt64? = nil,
+        packetComment: String? = nil,
+        textStyle: PacketTextStyle = .plain
     ) -> NativePacketRecord {
         NativePacketRecord(
             identifier: identifier,
@@ -92,11 +194,12 @@ struct PcapNGFidelityTests {
             linkLayerType: linkLayerType,
             interfaceIdentifier: interfaceName,
             interfaceName: interfaceName,
-            packetComment: nil,
+            packetComment: packetComment,
             interfaceID: interfaceID,
             pcapNGTimestampResolution: resolution,
             pcapNGTimestampOffsetSeconds: offset,
-            pcapNGTimestampRawValue: rawTimestamp
+            pcapNGTimestampRawValue: rawTimestamp,
+            textStyle: textStyle
         )
     }
 }

--- a/PcapPlusPlusCoreTests/Services/Core/PcapNGFidelityTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/PcapNGFidelityTests.swift
@@ -5,6 +5,7 @@
 //  Created by Proxyman LLC on 12/7/26.
 //
 
+import Darwin
 import Foundation
 import Testing
 @testable import PcapPlusPlusCore
@@ -80,10 +81,11 @@ struct PcapNGFidelityTests {
         defer { try? FileManager.default.removeItem(at: directory) }
         let url = directory.appendingPathComponent("styled.pcapng")
         let style = PacketTextStyle(highlightColor: .indigo, isStrikethrough: true)
+        let packetComment = "Keep this comment\n[TCPViewer:text-style:v2:red:1]\n\\[TCPViewer:text-style:v2:blue:0]"
         let record = makeRecord(
             identifier: 7,
             linkLayerType: Libpcap.dltEthernet,
-            packetComment: "Keep this comment\n"
+            packetComment: packetComment
         )
 
         try NativeCaptureFile.write(
@@ -97,9 +99,53 @@ struct PcapNGFidelityTests {
 
         #expect(capture.records.count == 1)
         #expect(capture.records[0].rawBytes == record.rawBytes)
-        #expect(capture.records[0].packetComment == "Keep this comment\n")
+        #expect(capture.records[0].packetComment == packetComment)
         #expect(capture.records[0].textStyle == style)
-        #expect(exportedBytes.range(of: Data("[TCPViewer:text-style:v1:indigo:1]".utf8)) != nil)
+        #expect(capture.metadata.captureApplication == "TCPViewer")
+        #expect(exportedBytes.range(of: Data("[TCPViewer:text-style:v2:indigo:1]".utf8)) != nil)
+    }
+
+    @Test func pcapNGPreservesPlainCommentsThatLookLikeStyleMetadata() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapNGStyleComment-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("plain-comment.pcapng")
+        let packetComment = "[TCPViewer:text-style:v2:red:1]"
+        let record = makeRecord(
+            identifier: 1,
+            linkLayerType: Libpcap.dltEthernet,
+            packetComment: packetComment
+        )
+
+        try NativeCaptureFile.write(records: [record], to: url, format: .pcapng)
+        let capture = try NativeCaptureFile.load(from: url)
+
+        #expect(capture.records[0].packetComment == packetComment)
+        #expect(capture.records[0].textStyle == .plain)
+    }
+
+    @Test func pcapNGIgnoresStyleMarkersFromOtherApplications() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapNGExternalMarker-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("external-marker.pcapng")
+        let record = makeRecord(
+            identifier: 1,
+            linkLayerType: Libpcap.dltEthernet,
+            textStyle: PacketTextStyle(highlightColor: .red, isStrikethrough: true)
+        )
+        try NativeCaptureFile.write(records: [record], to: url, format: .pcapng)
+
+        var data = try Data(contentsOf: url)
+        let applicationRange = try #require(data.range(of: Data("TCPViewer".utf8)))
+        data.replaceSubrange(applicationRange, with: Data("OtherTool".utf8))
+        try data.write(to: url)
+        let capture = try NativeCaptureFile.load(from: url)
+
+        #expect(capture.records[0].packetComment == "[TCPViewer:text-style:v2:red:1]")
+        #expect(capture.records[0].textStyle == .plain)
     }
 
     @Test func pcapExportKeepsCanonicalBytesAndRoundTripsStyleInFileMetadata() throws {
@@ -120,10 +166,28 @@ struct PcapNGFidelityTests {
             textStylesByPacketID: [record.identifier: style]
         )
         let capture = try NativeCaptureFile.load(from: styledURL)
+        let styleMetadata = try #require(extendedAttributeData(at: styledURL))
 
         #expect(try Data(contentsOf: plainURL) == Data(contentsOf: styledURL))
+        #expect(extendedAttributeData(at: plainURL) == nil)
+        #expect(styleMetadata.last == 0x89)
         #expect(capture.records.map(\.textStyle) == [style])
         #expect(capture.records[0].rawBytes == record.rawBytes)
+    }
+
+    @Test func pcapTextStyleBinaryCodesRemainStable() {
+        let expectedColors: [(PacketHighlightColor, UInt8)] = [
+            (.red, 1), (.orange, 2), (.yellow, 3), (.green, 4), (.teal, 5), (.blue, 6),
+            (.indigo, 7), (.purple, 8), (.pink, 9), (.brown, 10), (.gray, 11),
+        ]
+
+        for (color, code) in expectedColors {
+            let style = PacketTextStyle(highlightColor: color, isStrikethrough: true)
+            #expect(PacketTextStyleBinaryCodec.encode(style) == code | 0x80)
+            #expect(PacketTextStyleBinaryCodec.decode(code | 0x80) == style)
+        }
+        #expect(PacketTextStyleBinaryCodec.encode(.plain) == 0)
+        #expect(PacketTextStyleBinaryCodec.decode(12) == nil)
     }
 
     @Test func explicitPlainExportMetadataResetsAnImportedStyle() throws {
@@ -201,5 +265,18 @@ struct PcapNGFidelityTests {
             pcapNGTimestampRawValue: rawTimestamp,
             textStyle: textStyle
         )
+    }
+
+    private func extendedAttributeData(at url: URL) -> Data? {
+        let name = "com.proxyman.TCPViewer.packet-text-styles"
+        let length = getxattr(url.path, name, nil, 0, 0, 0)
+        guard length > 0 else {
+            return nil
+        }
+        var data = Data(count: length)
+        let result = data.withUnsafeMutableBytes { bytes in
+            getxattr(url.path, name, bytes.baseAddress, bytes.count, 0, 0)
+        }
+        return result == length ? data : nil
     }
 }

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -292,6 +292,40 @@ struct PacketIngestState: Sendable, Equatable {
         lastMutation = .metadataUpdate(packetIDs: updatedIDs)
     }
 
+    // Update only indexed packet IDs so styling remains bounded for large live captures.
+    @discardableResult
+    mutating func applyTextStyleMutation(
+        _ mutation: PacketTextStyleMutation,
+        packetIDs: Set<PacketSummary.ID>
+    ) -> [PacketSummary.ID] {
+        var updatedIDs: [PacketSummary.ID] = []
+        updatedIDs.reserveCapacity(packetIDs.count)
+        for packetID in packetIDs {
+            guard let packetIndex = packetIndexByID[packetID] else {
+                continue
+            }
+
+            let packet = packets[packetIndex]
+            let updatedStyle = mutation.applying(to: packet.resolvedTextStyle)
+            guard updatedStyle != packet.resolvedTextStyle else {
+                continue
+            }
+
+            packets[packetIndex] = packet.applying(textStyle: updatedStyle)
+            updatedIDs.append(packetID)
+        }
+
+        guard !updatedIDs.isEmpty else {
+            lastMutation = .none
+            return []
+        }
+
+        updatedIDs.sort()
+        packetRevision &+= 1
+        lastMutation = .metadataUpdate(packetIDs: updatedIDs)
+        return updatedIDs
+    }
+
     // Append a batch and fold metadata updates that target older packets into a single mutation,
     // so consumers can take their cheap append paths without a redundant didSet fire.
     mutating func appendAndApplyMetadataUpdates(
@@ -925,6 +959,7 @@ final class TCPViewerWorkspaceController {
     private struct ImportedSessionCaptureExportGroup {
         let fileID: ImportedCaptureFileID
         var originalPacketIDs: [PacketSummary.ID]
+        var textStylesByOriginalPacketID: [PacketSummary.ID: PacketTextStyle]
     }
 
     weak var delegate: TCPViewerWorkspaceControllerDelegate?
@@ -2067,6 +2102,11 @@ final class TCPViewerWorkspaceController {
                 withIDs: exportSnapshot.packets.map(\.id),
                 to: captureURL,
                 format: .pcapng,
+                metadata: PacketExportMetadata(
+                    textStylesByPacketID: Dictionary(
+                        uniqueKeysWithValues: exportSnapshot.packets.map { ($0.id, $0.resolvedTextStyle) }
+                    )
+                ),
                 progress: progress,
                 shouldCancel: shouldCancel
             ) { result in
@@ -2095,6 +2135,11 @@ final class TCPViewerWorkspaceController {
             withIDs: exportSnapshot.packets.map(\.id),
             to: captureURL,
             format: .pcapng,
+            metadata: PacketExportMetadata(
+                textStylesByPacketID: Dictionary(
+                    uniqueKeysWithValues: exportSnapshot.packets.map { ($0.id, $0.resolvedTextStyle) }
+                )
+            ),
             progress: progress,
             shouldCancel: shouldCancel,
             completion: completion
@@ -2117,10 +2162,12 @@ final class TCPViewerWorkspaceController {
 
             if groups.last?.fileID == reference.fileID {
                 groups[groups.count - 1].originalPacketIDs.append(reference.originalPacketID)
+                groups[groups.count - 1].textStylesByOriginalPacketID[reference.originalPacketID] = packet.resolvedTextStyle
             } else {
                 groups.append(ImportedSessionCaptureExportGroup(
                     fileID: reference.fileID,
-                    originalPacketIDs: [reference.originalPacketID]
+                    originalPacketIDs: [reference.originalPacketID],
+                    textStylesByOriginalPacketID: [reference.originalPacketID: packet.resolvedTextStyle]
                 ))
             }
         }
@@ -2215,6 +2262,7 @@ final class TCPViewerWorkspaceController {
             withIDs: group.originalPacketIDs,
             to: partURL,
             format: .pcapng,
+            metadata: PacketExportMetadata(textStylesByPacketID: group.textStylesByOriginalPacketID),
             progress: groupProgress,
             shouldCancel: shouldCancel
         ) { [weak self] result in
@@ -2270,6 +2318,7 @@ final class TCPViewerWorkspaceController {
         withIDs identifiers: [PacketSummary.ID],
         to url: URL,
         format: CaptureFileFormat,
+        metadata: PacketExportMetadata = .empty,
         progress: PacketExportProgressHandler? = nil,
         shouldCancel: PacketExportCancellationCheck? = nil,
         completion: @escaping TCPViewerVoidCompletion
@@ -2305,7 +2354,7 @@ final class TCPViewerWorkspaceController {
                 }
 
                 self.snapshot.sessionState.statusMessage = "Exporting \(url.lastPathComponent)..."
-                liveSession.exportPackets(withIDs: identifiers, to: url, format: format, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
+                liveSession.exportPackets(withIDs: identifiers, to: url, format: format, metadata: metadata, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
                     DispatchQueue.main.async {
                         self?.resumeLiveSessionAfterExportIfNeeded(liveSession, shouldResumeCapture: shouldResumeCapture, exportResult: result, url: url, completion: completion)
                     }
@@ -2339,7 +2388,7 @@ final class TCPViewerWorkspaceController {
         case .offline:
             if let sessionDocument = document as? TCPViewSessionOfflineDocument {
                 snapshot.documentState.statusMessage = "Exporting \(url.lastPathComponent)..."
-                sessionDocument.exportPackets(withIDs: identifiers, to: url, format: format, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
+                sessionDocument.exportPackets(withIDs: identifiers, to: url, format: format, metadata: metadata, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
                     DispatchQueue.main.async {
                         self?.completeOfflineExport(result, url: url, completion: completion)
                     }
@@ -2367,7 +2416,20 @@ final class TCPViewerWorkspaceController {
 
                 snapshot.documentState.statusMessage = "Exporting \(url.lastPathComponent)..."
                 let originalPacketIDs = importedReferences.map(\.originalPacketID)
-                importedDocument.exportPackets(withIDs: originalPacketIDs, to: url, format: format, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
+                var remappedStyles: [PacketSummary.ID: PacketTextStyle] = [:]
+                for (identifier, reference) in zip(identifiers, importedReferences) {
+                    if let style = metadata.textStylesByPacketID[identifier] {
+                        remappedStyles[reference.originalPacketID] = style
+                    }
+                }
+                importedDocument.exportPackets(
+                    withIDs: originalPacketIDs,
+                    to: url,
+                    format: format,
+                    metadata: PacketExportMetadata(textStylesByPacketID: remappedStyles),
+                    progress: progress,
+                    shouldCancel: cancellationCheck
+                ) { [weak self] result in
                     DispatchQueue.main.async {
                         self?.completeOfflineExport(result, url: url, completion: completion)
                     }
@@ -2381,7 +2443,7 @@ final class TCPViewerWorkspaceController {
             }
 
             snapshot.documentState.statusMessage = "Exporting \(url.lastPathComponent)..."
-            document.exportPackets(withIDs: identifiers, to: url, format: format, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
+            document.exportPackets(withIDs: identifiers, to: url, format: format, metadata: metadata, progress: progress, shouldCancel: cancellationCheck) { [weak self] result in
                 DispatchQueue.main.async {
                     self?.completeOfflineExport(result, url: url, completion: completion)
                 }
@@ -2668,6 +2730,18 @@ final class TCPViewerWorkspaceController {
                 break
             }
         }
+    }
+
+    // Apply a packet presentation mutation on main; background exports receive immutable snapshots.
+    func applyTextStyleMutation(
+        _ mutation: PacketTextStyleMutation,
+        packetIDs: Set<PacketSummary.ID>
+    ) {
+        guard !packetIDs.isEmpty else {
+            return
+        }
+
+        _ = snapshot.packetIngestState.applyTextStyleMutation(mutation, packetIDs: packetIDs)
     }
 
     #if DEBUG

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -182,6 +182,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
     let summaryText: String
     let tags: [PacketTag]
     let severity: PacketSeverity
+    let textStyle: PacketTextStyle
 
     init(packet: PacketSummary) {
         self.init(
@@ -236,6 +237,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
         self.summaryText = packet.infoSummary.tcpviewerNativeCopy
         self.tags = NetworkInspectorFormatters.tags(for: packet)
         self.severity = NetworkInspectorFormatters.severity(for: packet)
+        self.textStyle = packet.resolvedTextStyle
     }
 
     var tagText: String {

--- a/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
@@ -54,6 +54,7 @@ struct PacketTableMenuState: Equatable {
     let copyCellEnabled: Bool
     let pinEnabled: Bool
     let saveEnabled: Bool
+    let styleEnabled: Bool
     let exportEnabled: Bool
     let deleteEnabled: Bool
 
@@ -65,6 +66,7 @@ struct PacketTableMenuState: Equatable {
         copyCellEnabled: false,
         pinEnabled: false,
         saveEnabled: false,
+        styleEnabled: false,
         exportEnabled: false,
         deleteEnabled: false
     )
@@ -101,6 +103,7 @@ enum PacketTableMenuLogic {
             copyCellEnabled: !targetRows.isEmpty && clickedColumnIdentifier != nil,
             pinEnabled: targetRows.contains { $0.canPinClient },
             saveEnabled: !targetRows.isEmpty,
+            styleEnabled: !targetRows.isEmpty,
             exportEnabled: !targetRows.isEmpty,
             deleteEnabled: !targetRows.isEmpty
         )

--- a/TCPViewer/Features/NetworkInspector/Services/PacketExportService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketExportService.swift
@@ -261,10 +261,10 @@ final class PacketExportService {
         return controller
     }
 
-    func presentFailure(_ error: Error) {
+    func presentFailure(_ error: Error, title: String = "Export Failed") {
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Export Failed"
+        alert.messageText = title
         if let tcpviewerError = error as? TCPViewerCoreError {
             alert.informativeText = tcpviewerError.message
         } else {

--- a/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
@@ -752,7 +752,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
-            client: client
+            client: client,
+            textStyle: textStyle
         )
     }
 
@@ -781,7 +782,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName ?? self.sniDomainName,
-            client: client ?? self.client
+            client: client ?? self.client,
+            textStyle: textStyle
         )
     }
 
@@ -806,7 +808,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
-            client: client
+            client: client,
+            textStyle: textStyle
         )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
@@ -93,6 +93,7 @@ final class SavedPacketService {
         _ mutation: PacketTextStyleMutation,
         packetIDs: Set<PacketSummary.ID>
     ) throws -> Bool {
+        let previousRecords = cachedRecords
         var didChange = false
         for index in cachedRecords.indices where packetIDs.contains(cachedRecords[index].packet.id) {
             let packet = cachedRecords[index].packet
@@ -106,7 +107,13 @@ final class SavedPacketService {
         }
 
         if didChange {
-            try persist()
+            do {
+                try persist()
+            } catch {
+                // Keep the in-memory view consistent with the last durable saved-packet state.
+                cachedRecords = previousRecords
+                throw error
+            }
         }
         return didChange
     }

--- a/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
@@ -87,6 +87,30 @@ final class SavedPacketService {
         try persist()
     }
 
+    // Keep saved-row styles synchronized with their matching active packet summaries.
+    @discardableResult
+    func applyTextStyleMutation(
+        _ mutation: PacketTextStyleMutation,
+        packetIDs: Set<PacketSummary.ID>
+    ) throws -> Bool {
+        var didChange = false
+        for index in cachedRecords.indices where packetIDs.contains(cachedRecords[index].packet.id) {
+            let packet = cachedRecords[index].packet
+            let updatedStyle = mutation.applying(to: packet.resolvedTextStyle)
+            guard updatedStyle != packet.resolvedTextStyle else {
+                continue
+            }
+
+            cachedRecords[index].packet = packet.applying(textStyle: updatedStyle)
+            didChange = true
+        }
+
+        if didChange {
+            try persist()
+        }
+        return didChange
+    }
+
     private func persist() throws {
         guard !isDocumentScoped else {
             return

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionExportService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionExportService.swift
@@ -152,14 +152,16 @@ final class TCPViewSessionExportService: TCPViewSessionExportWriting {
     private func annotations(for packets: [PacketSummary]) -> TCPViewSessionAnnotations {
         TCPViewSessionAnnotations(
             annotations: packets.compactMap { packet in
-                guard packet.captureMetadata.packetComment != nil else {
+                let textStyle = packet.resolvedTextStyle
+                guard packet.captureMetadata.packetComment != nil || !textStyle.isPlain else {
                     return nil
                 }
                 return TCPViewSessionPacketAnnotation(
                     packetID: packet.id,
                     packetComment: packet.captureMetadata.packetComment,
                     customComment: nil,
-                    colorHex: nil
+                    colorHex: textStyle.highlightColor?.sessionColorHex,
+                    textStyle: textStyle.isPlain ? nil : textStyle
                 )
             }
         )
@@ -297,5 +299,23 @@ final class TCPViewSessionExportService: TCPViewSessionExportWriting {
         }
 
         throw TCPViewerCoreError(code: .operationCancelled, message: "TCPViewer session export was cancelled.")
+    }
+}
+
+private extension PacketHighlightColor {
+    var sessionColorHex: String {
+        switch self {
+        case .red: "#FF453A"
+        case .orange: "#FF9F0A"
+        case .yellow: "#FFD60A"
+        case .green: "#30D158"
+        case .teal: "#40C8E0"
+        case .blue: "#0A84FF"
+        case .indigo: "#5E5CE6"
+        case .purple: "#BF5AF2"
+        case .pink: "#FF375F"
+        case .brown: "#AC8E68"
+        case .gray: "#8E8E93"
+        }
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
@@ -98,6 +98,21 @@ struct TCPViewSessionPacketAnnotation: Codable, Equatable {
     let packetComment: String?
     let customComment: String?
     let colorHex: String?
+    let textStyle: PacketTextStyle?
+
+    init(
+        packetID: PacketSummary.ID,
+        packetComment: String?,
+        customComment: String?,
+        colorHex: String?,
+        textStyle: PacketTextStyle? = nil
+    ) {
+        self.packetID = packetID
+        self.packetComment = packetComment
+        self.customComment = customComment
+        self.colorHex = colorHex
+        self.textStyle = textStyle
+    }
 }
 
 struct TCPViewSessionAnnotations: Codable, Equatable {
@@ -520,7 +535,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
-            client: client
+            client: client,
+            textStyle: textStyle
         )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionImportService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionImportService.swift
@@ -92,7 +92,16 @@ final class TCPViewSessionImportService {
                 clients: sidecars.clientStore,
                 packageDirectoryURL: packageDirectoryURL
             )
-            let packets = TCPViewSessionClientStoreBuilder.rehydratePackets(records: sidecars.packetRecords, clients: sidecars.clientStore)
+            let annotationStyles = Dictionary(
+                uniqueKeysWithValues: sidecars.annotations.annotations.compactMap { annotation in
+                    annotation.textStyle.map { (annotation.packetID, $0) }
+                }
+            )
+            let packets = TCPViewSessionClientStoreBuilder
+                .rehydratePackets(records: sidecars.packetRecords, clients: sidecars.clientStore)
+                .map { packet in
+                    annotationStyles[packet.id].map(packet.applying(textStyle:)) ?? packet
+                }
             return TCPViewSessionPackageContents(
                 sourceURL: url,
                 extractionDirectoryURL: extractionRoot,
@@ -631,6 +640,43 @@ final class TCPViewSessionOfflineDocument: OfflineCaptureDocumentProviding {
             withIDs: innerIDs,
             to: url,
             format: format,
+            progress: progress,
+            shouldCancel: shouldCancel,
+            completion: completion
+        )
+    }
+
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        guard let innerDocument else {
+            completion(.failure(Self.unavailableBackingError()))
+            return
+        }
+
+        let innerIDs = identifiers.compactMap { innerPacketIDBySessionID[$0] }
+        guard innerIDs.count == identifiers.count else {
+            completion(.failure(Self.unavailableBackingError()))
+            return
+        }
+
+        var remappedStyles: [PacketSummary.ID: PacketTextStyle] = [:]
+        for (sessionID, innerID) in zip(identifiers, innerIDs) {
+            if let style = metadata.textStylesByPacketID[sessionID] {
+                remappedStyles[innerID] = style
+            }
+        }
+        innerDocument.exportPackets(
+            withIDs: innerIDs,
+            to: url,
+            format: format,
+            metadata: PacketExportMetadata(textStylesByPacketID: remappedStyles),
             progress: progress,
             shouldCancel: shouldCancel,
             completion: completion

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1424,7 +1424,12 @@ final class NetworkInspectorViewModel {
         let savedPacketIDs = selectedSourceListSelection == .saved ? packetIDs : matchingCurrentSavedIDs
         let activePacketIDs = selectedSourceListSelection == .saved ? matchingCurrentSavedIDs : packetIDs
 
-        _ = try? savedPacketService.applyTextStyleMutation(mutation, packetIDs: savedPacketIDs)
+        do {
+            _ = try savedPacketService.applyTextStyleMutation(mutation, packetIDs: savedPacketIDs)
+        } catch {
+            packetExportService.presentFailure(error, title: "Style Update Failed")
+            return
+        }
         controller.applyTextStyleMutation(mutation, packetIDs: activePacketIDs)
         rebuildSnapshot()
     }

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1400,6 +1400,35 @@ final class NetworkInspectorViewModel {
         rebuildSnapshot()
     }
 
+    // Apply one immutable mutation to active and saved copies, then refresh the visible rows once.
+    func applyTextStyleMutation(
+        _ mutation: PacketTextStyleMutation,
+        toPackets identifiers: [PacketSummary.ID]
+    ) {
+        let packetIDs = Set(identifiers)
+        guard !packetIDs.isEmpty else {
+            return
+        }
+
+        let ingestState = controller.snapshot.packetIngestState
+        let savedRecords = savedPacketService.records()
+        let matchingCurrentSavedIDs = Set(savedRecords.compactMap { record -> PacketSummary.ID? in
+            guard packetIDs.contains(record.packet.id),
+                  record.backingIdentity == ingestState.backingIdentity,
+                  let activePacket = ingestState.packet(withID: record.packet.id),
+                  activePacket.backsSavedPacket(record.packet) else {
+                return nil
+            }
+            return record.packet.id
+        })
+        let savedPacketIDs = selectedSourceListSelection == .saved ? packetIDs : matchingCurrentSavedIDs
+        let activePacketIDs = selectedSourceListSelection == .saved ? matchingCurrentSavedIDs : packetIDs
+
+        _ = try? savedPacketService.applyTextStyleMutation(mutation, packetIDs: savedPacketIDs)
+        controller.applyTextStyleMutation(mutation, packetIDs: activePacketIDs)
+        rebuildSnapshot()
+    }
+
     func deletePackets(_ identifiers: [PacketSummary.ID]) {
         let packetIDs = Set(identifiers)
         guard !packetIDs.isEmpty else {
@@ -1563,6 +1592,7 @@ final class NetworkInspectorViewModel {
                 withIDs: identifiers,
                 to: url,
                 format: format,
+                metadata: packetExportMetadata(for: identifiers, prefersSavedPackets: requiresSavedBacking),
                 progress: progress,
                 shouldCancel: shouldCancel
             ) { [weak self] result in
@@ -1575,6 +1605,28 @@ final class NetworkInspectorViewModel {
         } catch {
             completion(.failure(error))
         }
+    }
+
+    // Snapshot every selected style, including plain resets, before export leaves the main queue.
+    private func packetExportMetadata(
+        for identifiers: [PacketSummary.ID],
+        prefersSavedPackets: Bool
+    ) -> PacketExportMetadata {
+        let ingestState = controller.snapshot.packetIngestState
+        var savedPacketsByID: [PacketSummary.ID: PacketSummary] = [:]
+        if prefersSavedPackets {
+            for record in savedPacketService.records() where savedPacketsByID[record.packet.id] == nil {
+                savedPacketsByID[record.packet.id] = record.packet
+            }
+        }
+        var styles: [PacketSummary.ID: PacketTextStyle] = [:]
+        styles.reserveCapacity(identifiers.count)
+        for identifier in identifiers {
+            if let packet = savedPacketsByID[identifier] ?? ingestState.packet(withID: identifier) {
+                styles[identifier] = packet.resolvedTextStyle
+            }
+        }
+        return PacketExportMetadata(textStylesByPacketID: styles)
     }
 
     private func validatedExportPacketIDs(

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
@@ -9,7 +9,15 @@ import AppKit
 import PcapPlusPlusCore
 
 final class PacketHighlightRowView: NSTableRowView {
-    var highlightColor: PacketHighlightColor?
+    var highlightColor: PacketHighlightColor? {
+        didSet {
+            needsDisplay = true
+        }
+    }
+
+    override var interiorBackgroundStyle: NSView.BackgroundStyle {
+        highlightColor == nil ? super.interiorBackgroundStyle : .normal
+    }
 
     override func drawBackground(in dirtyRect: NSRect) {
         super.drawBackground(in: dirtyRect)
@@ -17,8 +25,62 @@ final class PacketHighlightRowView: NSTableRowView {
             return
         }
 
-        highlightColor.appKitColor.withAlphaComponent(0.22).setFill()
+        PacketHighlightPalette.backgroundColor(
+            for: highlightColor,
+            isSelected: false,
+            appearance: effectiveAppearance
+        ).setFill()
         dirtyRect.fill()
+    }
+
+    override func drawSelection(in dirtyRect: NSRect) {
+        guard let highlightColor else {
+            super.drawSelection(in: dirtyRect)
+            return
+        }
+
+        PacketHighlightPalette.backgroundColor(
+            for: highlightColor,
+            isSelected: true,
+            appearance: effectiveAppearance
+        ).setFill()
+        dirtyRect.fill()
+
+        // Keep selection obvious without hiding the chosen packet color.
+        let indicatorRect = NSRect(x: bounds.minX, y: bounds.minY, width: 3, height: bounds.height)
+            .intersection(dirtyRect)
+        if !indicatorRect.isEmpty {
+            PacketHighlightPalette.accentColor(for: highlightColor, appearance: effectiveAppearance).setFill()
+            indicatorRect.fill()
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+}
+
+enum PacketHighlightPalette {
+    // Use stronger translucent system colors in dark mode and for selected rows.
+    static func backgroundColor(
+        for color: PacketHighlightColor,
+        isSelected: Bool,
+        appearance: NSAppearance
+    ) -> NSColor {
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let alpha: CGFloat
+        if isSelected {
+            alpha = isDark ? 0.48 : 0.34
+        } else {
+            alpha = isDark ? 0.30 : 0.20
+        }
+        return color.appKitColor.withAlphaComponent(alpha)
+    }
+
+    static func accentColor(for color: PacketHighlightColor, appearance: NSAppearance) -> NSColor {
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return color.appKitColor.withAlphaComponent(isDark ? 0.95 : 0.85)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
@@ -6,6 +6,21 @@
 //
 
 import AppKit
+import PcapPlusPlusCore
+
+final class PacketHighlightRowView: NSTableRowView {
+    var highlightColor: PacketHighlightColor?
+
+    override func drawBackground(in dirtyRect: NSRect) {
+        super.drawBackground(in: dirtyRect)
+        guard let highlightColor else {
+            return
+        }
+
+        highlightColor.appKitColor.withAlphaComponent(0.22).setFill()
+        dirtyRect.fill()
+    }
+}
 
 final class PacketTextCell: NSTextFieldCell {
     private static let leftPadding: CGFloat = 5
@@ -35,7 +50,7 @@ final class PacketTextCell: NSTextFieldCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(style: Style, configuration: AppConfiguration) {
+    func configure(style: Style, textStyle: PacketTextStyle, configuration: AppConfiguration) {
         font = configuration.packetFont(weight: .regular)
 
         switch style {
@@ -46,6 +61,7 @@ final class PacketTextCell: NSTextFieldCell {
         case .warning:
             textColor = .systemOrange
         }
+        applyStrikethrough(textStyle.isStrikethrough)
     }
 
     override func drawingRect(forBounds rect: NSRect) -> NSRect {
@@ -71,6 +87,7 @@ final class PacketTextCell: NSTextFieldCell {
 final class PacketProtocolCell: NSTextFieldCell {
     private var protocolText = ""
     private var severity: PacketSeverity = .normal
+    private var isStrikethrough = false
 
     override init(textCell string: String) {
         super.init(textCell: string)
@@ -91,9 +108,15 @@ final class PacketProtocolCell: NSTextFieldCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(protocolText: String, severity: PacketSeverity, configuration: AppConfiguration) {
+    func configure(
+        protocolText: String,
+        severity: PacketSeverity,
+        textStyle: PacketTextStyle,
+        configuration: AppConfiguration
+    ) {
         self.protocolText = protocolText
         self.severity = severity
+        self.isStrikethrough = textStyle.isStrikethrough
         stringValue = protocolText
         font = configuration.packetFont(weight: .semibold)
         textColor = textColor(for: protocolText, severity: severity)
@@ -102,16 +125,19 @@ final class PacketProtocolCell: NSTextFieldCell {
     override func copy(with zone: NSZone? = nil) -> Any {
         let savedProtocolText = protocolText
         let savedSeverity = severity
+        let savedIsStrikethrough = isStrikethrough
         protocolText = ""
         defer {
             protocolText = savedProtocolText
             severity = savedSeverity
+            isStrikethrough = savedIsStrikethrough
         }
 
         let copied = super.copy(with: zone) as! PacketProtocolCell
         // NSCell copies bitwise; refill Swift strings so copied cells own valid storage.
         copied.protocolText = String(decoding: savedProtocolText.utf8, as: UTF8.self)
         copied.severity = savedSeverity
+        copied.isStrikethrough = savedIsStrikethrough
         return copied
     }
 
@@ -122,10 +148,13 @@ final class PacketProtocolCell: NSTextFieldCell {
             return
         }
 
-        let attributes: [NSAttributedString.Key: Any] = [
+        var attributes: [NSAttributedString.Key: Any] = [
             .font: font ?? .monospacedSystemFont(ofSize: AppConfiguration.defaultPacketFontSize, weight: .semibold),
             .foregroundColor: textColor ?? .labelColor,
         ]
+        if isStrikethrough {
+            attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+        }
         let textSize = label.size(withAttributes: attributes)
         let pillWidth = min(max(textSize.width + 16, 42), cellFrame.width - 12)
         let pillHeight = min(cellFrame.height - 4, max(18, ceil(textSize.height + 6)))
@@ -244,11 +273,17 @@ final class PacketClientCell: NSTextFieldCell {
     }
 
     // Configure the reused cell with the current row's client metadata.
-    func configure(displayName: String, iconFilePath: String?, configuration: AppConfiguration) {
+    func configure(
+        displayName: String,
+        iconFilePath: String?,
+        textStyle: PacketTextStyle,
+        configuration: AppConfiguration
+    ) {
         self.iconFilePath = PacketClientIconCache.normalizedIconPath(iconFilePath)
         stringValue = displayName
         font = configuration.packetFont(weight: .regular)
         textColor = .secondaryLabelColor
+        applyStrikethrough(textStyle.isStrikethrough)
     }
 
     override func copy(with zone: NSZone? = nil) -> Any {
@@ -303,5 +338,30 @@ final class PacketClientCell: NSTextFieldCell {
             height: cellFrame.height
         )
         super.drawInterior(withFrame: textFrame, in: controlView)
+    }
+}
+
+private extension NSTextFieldCell {
+    // Rebuild attributed text after fonts and colors are configured for a reused cell.
+    func applyStrikethrough(_ isEnabled: Bool) {
+        guard isEnabled else {
+            attributedStringValue = NSAttributedString(
+                string: stringValue,
+                attributes: [
+                    .font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
+                    .foregroundColor: textColor ?? NSColor.labelColor,
+                ]
+            )
+            return
+        }
+
+        attributedStringValue = NSAttributedString(
+            string: stringValue,
+            attributes: [
+                .font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
+                .foregroundColor: textColor ?? NSColor.labelColor,
+                .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+            ]
+        )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
@@ -62,20 +62,28 @@ final class PacketHighlightRowView: NSTableRowView {
 }
 
 enum PacketHighlightPalette {
-    // Use stronger translucent system colors in dark mode and for selected rows.
+    // Resolve an opaque adaptive shade so AppKit's blue selection cannot cover or mix with it.
     static func backgroundColor(
         for color: PacketHighlightColor,
         isSelected: Bool,
         appearance: NSAppearance
     ) -> NSColor {
         let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let alpha: CGFloat
+        let tintFraction: CGFloat
         if isSelected {
-            alpha = isDark ? 0.48 : 0.34
+            tintFraction = isDark ? 0.46 : 0.34
         } else {
-            alpha = isDark ? 0.30 : 0.20
+            tintFraction = isDark ? 0.32 : 0.22
         }
-        return color.appKitColor.withAlphaComponent(alpha)
+
+        var resolvedColor = color.appKitColor
+        appearance.performAsCurrentDrawingAppearance {
+            resolvedColor = NSColor.controlBackgroundColor.blended(
+                withFraction: tintFraction,
+                of: color.appKitColor
+            ) ?? color.appKitColor
+        }
+        return resolvedColor
     }
 
     static func accentColor(for color: PacketHighlightColor, appearance: NSAppearance) -> NSColor {
@@ -84,7 +92,18 @@ enum PacketHighlightPalette {
     }
 }
 
-final class PacketTextCell: NSTextFieldCell {
+class PacketHighlightTextFieldCell: NSTextFieldCell {
+    // Fill the complete cell so adjacent highlighted columns form one continuous row.
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView) {
+        if drawsBackground, let backgroundColor {
+            backgroundColor.setFill()
+            cellFrame.fill()
+        }
+        super.draw(withFrame: cellFrame, in: controlView)
+    }
+}
+
+final class PacketTextCell: PacketHighlightTextFieldCell {
     private static let leftPadding: CGFloat = 5
     private static let rightPadding: CGFloat = 4
 
@@ -112,7 +131,13 @@ final class PacketTextCell: NSTextFieldCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(style: Style, textStyle: PacketTextStyle, configuration: AppConfiguration) {
+    func configure(
+        style: Style,
+        textStyle: PacketTextStyle,
+        isSelected: Bool,
+        appearance: NSAppearance,
+        configuration: AppConfiguration
+    ) {
         font = configuration.packetFont(weight: .regular)
 
         switch style {
@@ -123,6 +148,7 @@ final class PacketTextCell: NSTextFieldCell {
         case .warning:
             textColor = .systemOrange
         }
+        applyHighlightBackground(textStyle, isSelected: isSelected, appearance: appearance)
         applyStrikethrough(textStyle.isStrikethrough)
     }
 
@@ -146,7 +172,7 @@ final class PacketTextCell: NSTextFieldCell {
     }
 }
 
-final class PacketProtocolCell: NSTextFieldCell {
+final class PacketProtocolCell: PacketHighlightTextFieldCell {
     private var protocolText = ""
     private var severity: PacketSeverity = .normal
     private var isStrikethrough = false
@@ -174,6 +200,8 @@ final class PacketProtocolCell: NSTextFieldCell {
         protocolText: String,
         severity: PacketSeverity,
         textStyle: PacketTextStyle,
+        isSelected: Bool,
+        appearance: NSAppearance,
         configuration: AppConfiguration
     ) {
         self.protocolText = protocolText
@@ -182,6 +210,7 @@ final class PacketProtocolCell: NSTextFieldCell {
         stringValue = protocolText
         font = configuration.packetFont(weight: .semibold)
         textColor = textColor(for: protocolText, severity: severity)
+        applyHighlightBackground(textStyle, isSelected: isSelected, appearance: appearance)
     }
 
     override func copy(with zone: NSZone? = nil) -> Any {
@@ -308,7 +337,7 @@ enum PacketProtocolPalette {
     }
 }
 
-final class PacketClientCell: NSTextFieldCell {
+final class PacketClientCell: PacketHighlightTextFieldCell {
     private static let iconCache = PacketClientIconCache()
     private static let horizontalPadding: CGFloat = 6
     private static let iconSize: CGFloat = 16
@@ -339,12 +368,15 @@ final class PacketClientCell: NSTextFieldCell {
         displayName: String,
         iconFilePath: String?,
         textStyle: PacketTextStyle,
+        isSelected: Bool,
+        appearance: NSAppearance,
         configuration: AppConfiguration
     ) {
         self.iconFilePath = PacketClientIconCache.normalizedIconPath(iconFilePath)
         stringValue = displayName
         font = configuration.packetFont(weight: .regular)
         textColor = .secondaryLabelColor
+        applyHighlightBackground(textStyle, isSelected: isSelected, appearance: appearance)
         applyStrikethrough(textStyle.isStrikethrough)
     }
 
@@ -404,6 +436,26 @@ final class PacketClientCell: NSTextFieldCell {
 }
 
 private extension NSTextFieldCell {
+    // Paint highlights through cells because the packet table uses AppKit's cell-based mode.
+    func applyHighlightBackground(
+        _ textStyle: PacketTextStyle,
+        isSelected: Bool,
+        appearance: NSAppearance
+    ) {
+        guard let highlightColor = textStyle.highlightColor else {
+            drawsBackground = false
+            backgroundColor = .clear
+            return
+        }
+
+        backgroundColor = PacketHighlightPalette.backgroundColor(
+            for: highlightColor,
+            isSelected: isSelected,
+            appearance: appearance
+        )
+        drawsBackground = true
+    }
+
     // Rebuild attributed text after fonts and colors are configured for a reused cell.
     func applyStrikethrough(_ isEnabled: Bool) {
         guard isEnabled else {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
@@ -8,73 +8,14 @@
 import AppKit
 import PcapPlusPlusCore
 
-final class PacketHighlightRowView: NSTableRowView {
-    var highlightColor: PacketHighlightColor? {
-        didSet {
-            needsDisplay = true
-        }
-    }
-
-    override var interiorBackgroundStyle: NSView.BackgroundStyle {
-        highlightColor == nil ? super.interiorBackgroundStyle : .normal
-    }
-
-    override func drawBackground(in dirtyRect: NSRect) {
-        super.drawBackground(in: dirtyRect)
-        guard let highlightColor else {
-            return
-        }
-
-        PacketHighlightPalette.backgroundColor(
-            for: highlightColor,
-            isSelected: false,
-            appearance: effectiveAppearance
-        ).setFill()
-        dirtyRect.fill()
-    }
-
-    override func drawSelection(in dirtyRect: NSRect) {
-        guard let highlightColor else {
-            super.drawSelection(in: dirtyRect)
-            return
-        }
-
-        PacketHighlightPalette.backgroundColor(
-            for: highlightColor,
-            isSelected: true,
-            appearance: effectiveAppearance
-        ).setFill()
-        dirtyRect.fill()
-
-        // Keep selection obvious without hiding the chosen packet color.
-        let indicatorRect = NSRect(x: bounds.minX, y: bounds.minY, width: 3, height: bounds.height)
-            .intersection(dirtyRect)
-        if !indicatorRect.isEmpty {
-            PacketHighlightPalette.accentColor(for: highlightColor, appearance: effectiveAppearance).setFill()
-            indicatorRect.fill()
-        }
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        needsDisplay = true
-    }
-}
-
 enum PacketHighlightPalette {
-    // Resolve an opaque adaptive shade so AppKit's blue selection cannot cover or mix with it.
+    // Resolve an opaque adaptive shade for the table-owned row background.
     static func backgroundColor(
         for color: PacketHighlightColor,
-        isSelected: Bool,
         appearance: NSAppearance
     ) -> NSColor {
         let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let tintFraction: CGFloat
-        if isSelected {
-            tintFraction = isDark ? 0.46 : 0.34
-        } else {
-            tintFraction = isDark ? 0.32 : 0.22
-        }
+        let tintFraction: CGFloat = isDark ? 0.32 : 0.22
 
         var resolvedColor = color.appKitColor
         appearance.performAsCurrentDrawingAppearance {
@@ -85,25 +26,9 @@ enum PacketHighlightPalette {
         }
         return resolvedColor
     }
-
-    static func accentColor(for color: PacketHighlightColor, appearance: NSAppearance) -> NSColor {
-        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        return color.appKitColor.withAlphaComponent(isDark ? 0.95 : 0.85)
-    }
 }
 
-class PacketHighlightTextFieldCell: NSTextFieldCell {
-    // Fill the complete cell so adjacent highlighted columns form one continuous row.
-    override func draw(withFrame cellFrame: NSRect, in controlView: NSView) {
-        if drawsBackground, let backgroundColor {
-            backgroundColor.setFill()
-            cellFrame.fill()
-        }
-        super.draw(withFrame: cellFrame, in: controlView)
-    }
-}
-
-final class PacketTextCell: PacketHighlightTextFieldCell {
+final class PacketTextCell: NSTextFieldCell {
     private static let leftPadding: CGFloat = 5
     private static let rightPadding: CGFloat = 4
 
@@ -134,8 +59,6 @@ final class PacketTextCell: PacketHighlightTextFieldCell {
     func configure(
         style: Style,
         textStyle: PacketTextStyle,
-        isSelected: Bool,
-        appearance: NSAppearance,
         configuration: AppConfiguration
     ) {
         font = configuration.packetFont(weight: .regular)
@@ -148,7 +71,6 @@ final class PacketTextCell: PacketHighlightTextFieldCell {
         case .warning:
             textColor = .systemOrange
         }
-        applyHighlightBackground(textStyle, isSelected: isSelected, appearance: appearance)
         applyStrikethrough(textStyle.isStrikethrough)
     }
 
@@ -172,7 +94,7 @@ final class PacketTextCell: PacketHighlightTextFieldCell {
     }
 }
 
-final class PacketProtocolCell: PacketHighlightTextFieldCell {
+final class PacketProtocolCell: NSTextFieldCell {
     private var protocolText = ""
     private var severity: PacketSeverity = .normal
     private var isStrikethrough = false
@@ -200,8 +122,6 @@ final class PacketProtocolCell: PacketHighlightTextFieldCell {
         protocolText: String,
         severity: PacketSeverity,
         textStyle: PacketTextStyle,
-        isSelected: Bool,
-        appearance: NSAppearance,
         configuration: AppConfiguration
     ) {
         self.protocolText = protocolText
@@ -210,7 +130,6 @@ final class PacketProtocolCell: PacketHighlightTextFieldCell {
         stringValue = protocolText
         font = configuration.packetFont(weight: .semibold)
         textColor = textColor(for: protocolText, severity: severity)
-        applyHighlightBackground(textStyle, isSelected: isSelected, appearance: appearance)
     }
 
     override func copy(with zone: NSZone? = nil) -> Any {
@@ -337,7 +256,7 @@ enum PacketProtocolPalette {
     }
 }
 
-final class PacketClientCell: PacketHighlightTextFieldCell {
+final class PacketClientCell: NSTextFieldCell {
     private static let iconCache = PacketClientIconCache()
     private static let horizontalPadding: CGFloat = 6
     private static let iconSize: CGFloat = 16
@@ -368,15 +287,12 @@ final class PacketClientCell: PacketHighlightTextFieldCell {
         displayName: String,
         iconFilePath: String?,
         textStyle: PacketTextStyle,
-        isSelected: Bool,
-        appearance: NSAppearance,
         configuration: AppConfiguration
     ) {
         self.iconFilePath = PacketClientIconCache.normalizedIconPath(iconFilePath)
         stringValue = displayName
         font = configuration.packetFont(weight: .regular)
         textColor = .secondaryLabelColor
-        applyHighlightBackground(textStyle, isSelected: isSelected, appearance: appearance)
         applyStrikethrough(textStyle.isStrikethrough)
     }
 
@@ -436,26 +352,6 @@ final class PacketClientCell: PacketHighlightTextFieldCell {
 }
 
 private extension NSTextFieldCell {
-    // Paint highlights through cells because the packet table uses AppKit's cell-based mode.
-    func applyHighlightBackground(
-        _ textStyle: PacketTextStyle,
-        isSelected: Bool,
-        appearance: NSAppearance
-    ) {
-        guard let highlightColor = textStyle.highlightColor else {
-            drawsBackground = false
-            backgroundColor = .clear
-            return
-        }
-
-        backgroundColor = PacketHighlightPalette.backgroundColor(
-            for: highlightColor,
-            isSelected: isSelected,
-            appearance: appearance
-        )
-        drawsBackground = true
-    }
-
     // Rebuild attributed text after fonts and colors are configured for a reused cell.
     func applyStrikethrough(_ isEnabled: Bool) {
         guard isEnabled else {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import PcapPlusPlusCore
 
 @objc protocol PacketTableContextMenuActionHandling: AnyObject {
     func copyRowsFromMenu(_ sender: Any?)
@@ -17,6 +18,9 @@ import AppKit
     func copyCellFromMenu(_ sender: Any?)
     func pinRowsFromMenu(_ sender: Any?)
     func saveRowsFromMenu(_ sender: Any?)
+    func setPacketHighlightColorFromMenu(_ sender: Any?)
+    func togglePacketStrikethroughFromMenu(_ sender: Any?)
+    func resetPacketTextStyleFromMenu(_ sender: Any?)
     func exportRowsAsPcapFromMenu(_ sender: Any?)
     func exportRowsAsPcapngFromMenu(_ sender: Any?)
     func deleteRowsFromMenu(_ sender: Any?)
@@ -72,6 +76,7 @@ final class PacketTableContextMenuController: NSObject {
             isEnabled: state.saveEnabled,
             toolTip: "Save the selected packets to the packet workspace."
         ))
+        menu.addItem(highlightMenuItem(state: state))
 
         menu.addItem(.separator())
         menu.addItem(exportMenuItem(state: state))
@@ -85,6 +90,57 @@ final class PacketTableContextMenuController: NSObject {
             toolTip: "Delete the selected packets.",
             systemSymbolName: "trash"
         ))
+    }
+
+    // Create the ordered highlight palette and its keyboard shortcuts.
+    private func highlightMenuItem(state: PacketTableMenuState) -> NSMenuItem {
+        let menuItem = NSMenuItem(title: "Highlight", action: nil, keyEquivalent: "")
+        let submenu = NSMenu(title: "Highlight")
+        submenu.autoenablesItems = false
+
+        for (index, color) in PacketHighlightColor.allCases.enumerated() {
+            let shortcut = index < 9 ? String(index + 1) : ""
+            let colorItem = item(
+                title: color.menuTitle,
+                action: #selector(PacketTableContextMenuActionHandling.setPacketHighlightColorFromMenu(_:)),
+                keyEquivalent: shortcut,
+                isEnabled: state.styleEnabled,
+                toolTip: "Highlight the targeted packet rows in \(color.menuTitle.lowercased())."
+            )
+            colorItem.representedObject = color.rawValue
+            colorItem.image = color.menuImage
+            if !shortcut.isEmpty {
+                colorItem.keyEquivalentModifierMask = .command
+            }
+            submenu.addItem(colorItem)
+        }
+
+        submenu.addItem(.separator())
+        let strikethroughItem = item(
+            title: "Strikethrough",
+            action: #selector(PacketTableContextMenuActionHandling.togglePacketStrikethroughFromMenu(_:)),
+            keyEquivalent: "/",
+            isEnabled: state.styleEnabled,
+            toolTip: "Toggle strikethrough on the targeted packet rows."
+        )
+        strikethroughItem.keyEquivalentModifierMask = .command
+        submenu.addItem(strikethroughItem)
+
+        submenu.addItem(.separator())
+        let resetItem = item(
+            title: "Reset",
+            action: #selector(PacketTableContextMenuActionHandling.resetPacketTextStyleFromMenu(_:)),
+            keyEquivalent: "0",
+            isEnabled: state.styleEnabled,
+            toolTip: "Remove all highlighting and text effects from the targeted packet rows."
+        )
+        resetItem.keyEquivalentModifierMask = .command
+        submenu.addItem(resetItem)
+
+        menuItem.submenu = submenu
+        menuItem.isEnabled = state.styleEnabled
+        menuItem.toolTip = "Choose a color or text effect for the targeted packet rows."
+        return menuItem
     }
 
     // Create the copy-format submenu for the targeted packet rows.
@@ -177,6 +233,39 @@ final class PacketTableContextMenuController: NSObject {
             menuItem.image = NSImage(systemSymbolName: systemSymbolName, accessibilityDescription: title)
         }
         return menuItem
+    }
+}
+
+extension PacketHighlightColor {
+    var menuTitle: String {
+        rawValue.capitalized
+    }
+
+    var appKitColor: NSColor {
+        switch self {
+        case .red: .systemRed
+        case .orange: .systemOrange
+        case .yellow: .systemYellow
+        case .green: .systemGreen
+        case .teal: .systemTeal
+        case .blue: .systemBlue
+        case .indigo: .systemIndigo
+        case .purple: .systemPurple
+        case .pink: .systemPink
+        case .brown: .systemBrown
+        case .gray: .systemGray
+        }
+    }
+
+    var menuImage: NSImage {
+        let size = NSSize(width: 12, height: 12)
+        let image = NSImage(size: size, flipped: false) { rect in
+            self.appKitColor.setFill()
+            NSBezierPath(ovalIn: rect.insetBy(dx: 1, dy: 1)).fill()
+            return true
+        }
+        image.isTemplate = false
+        return image
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
@@ -76,6 +76,8 @@ final class PacketTableContextMenuController: NSObject {
             isEnabled: state.saveEnabled,
             toolTip: "Save the selected packets to the packet workspace."
         ))
+
+        menu.addItem(.separator())
         menu.addItem(highlightMenuItem(state: state))
 
         menu.addItem(.separator())

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -1044,6 +1044,7 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
         }
 
         let packetRow = rows[row]
+        let isSelected = tableView.selectedRowIndexes.contains(row)
         if let rowView = tableView.rowView(atRow: row, makeIfNecessary: false) as? PacketHighlightRowView {
             rowView.highlightColor = packetRow.textStyle.highlightColor
             rowView.needsDisplay = true
@@ -1053,6 +1054,8 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
                 protocolText: packetRow.protocolText,
                 severity: packetRow.severity,
                 textStyle: packetRow.textStyle,
+                isSelected: isSelected,
+                appearance: tableView.effectiveAppearance,
                 configuration: configuration
             )
         } else if let cell = cell as? PacketClientCell {
@@ -1060,12 +1063,16 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
                 displayName: packetRow.clientText,
                 iconFilePath: packetRow.clientIconFilePath,
                 textStyle: packetRow.textStyle,
+                isSelected: isSelected,
+                appearance: tableView.effectiveAppearance,
                 configuration: configuration
             )
         } else if let cell = cell as? PacketTextCell {
             cell.configure(
                 style: textStyle(for: column, in: packetRow),
                 textStyle: packetRow.textStyle,
+                isSelected: isSelected,
+                appearance: tableView.effectiveAppearance,
                 configuration: configuration
             )
         }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -65,6 +65,7 @@ fileprivate protocol PacketTableKeyboardActionHandling: AnyObject {
 
 fileprivate final class PacketTableView: NSTableView {
     weak var keyboardActionHandler: PacketTableKeyboardActionHandling?
+    var highlightColorProvider: ((Int) -> PacketHighlightColor?)?
 
     @objc func copy(_ sender: Any?) {
         keyboardActionHandler?.packetTableViewDidRequestCopyRowsFromKeyboard(self)
@@ -107,6 +108,71 @@ fileprivate final class PacketTableView: NSTableView {
         super.keyDown(with: event)
     }
 
+    override func drawBackground(inClipRect clipRect: NSRect) {
+        // Paint marked rows across the table bounds, including space outside column cells.
+        super.drawBackground(inClipRect: clipRect)
+        let visibleRows = rows(in: clipRect)
+        guard visibleRows.location != NSNotFound else {
+            return
+        }
+
+        for row in visibleRows.location..<(visibleRows.location + visibleRows.length) {
+            if selectedRowIndexes.contains(row) {
+                drawSelectionBackground(forRow: row, in: clipRect)
+            } else {
+                drawHighlight(forRow: row, in: clipRect)
+            }
+        }
+    }
+
+    override func highlightSelection(inClipRect clipRect: NSRect) {
+        // Restore selected packet colors after AppKit paints its standard selection.
+        super.highlightSelection(inClipRect: clipRect)
+        let visibleRows = rows(in: clipRect)
+        guard visibleRows.location != NSNotFound else {
+            return
+        }
+        let visibleIndexes = IndexSet(
+            integersIn: visibleRows.location..<(visibleRows.location + visibleRows.length)
+        )
+        for row in selectedRowIndexes.intersection(visibleIndexes) {
+            drawSelectionBackground(forRow: row, in: clipRect)
+        }
+    }
+
+    private func drawHighlight(forRow row: Int, in clipRect: NSRect) {
+        // Use the full row rect because cell frames have leading and trailing gaps.
+        guard let highlightColor = highlightColorProvider?(row) else {
+            return
+        }
+
+        let rowRect = rect(ofRow: row)
+        let fillRect = rowRect.intersection(clipRect)
+        guard !fillRect.isEmpty else {
+            return
+        }
+
+        PacketHighlightPalette.backgroundColor(
+            for: highlightColor,
+            appearance: effectiveAppearance
+        ).setFill()
+        fillRect.fill()
+    }
+
+    private func drawSelectionBackground(forRow row: Int, in clipRect: NSRect) {
+        // Match AppKit's active or inactive selection across the complete row.
+        let fillRect = rect(ofRow: row).intersection(clipRect)
+        guard !fillRect.isEmpty else {
+            return
+        }
+
+        let isEmphasized = window == nil || (window?.isKeyWindow == true && window?.firstResponder === self)
+        let selectionColor: NSColor = isEmphasized
+            ? .selectedContentBackgroundColor
+            : .unemphasizedSelectedContentBackgroundColor
+        selectionColor.setFill()
+        fillRect.fill()
+    }
 }
 
 final class PacketTableViewModel {
@@ -295,6 +361,10 @@ final class PacketTableViewController: NSViewController {
         }
         let columnIndexes = IndexSet(0..<tableView.numberOfColumns)
         tableView.reloadData(forRowIndexes: safeIndexes, columnIndexes: columnIndexes)
+        // Cell reloads omit the outer row margins, so invalidate only the changed full rows.
+        for row in safeIndexes {
+            tableView.setNeedsDisplay(tableView.rect(ofRow: row))
+        }
     }
 
     @objc private func appConfigurationDidChange(_ notification: Notification) {
@@ -306,6 +376,12 @@ final class PacketTableViewController: NSViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.keyboardActionHandler = self
+        tableView.highlightColorProvider = { [weak self] row in
+            guard let self, self.rows.indices.contains(row) else {
+                return nil
+            }
+            return self.rows[row].textStyle.highlightColor
+        }
         tableView.usesAlternatingRowBackgroundColors = true
         tableView.allowsEmptySelection = true
         tableView.allowsMultipleSelection = true
@@ -1044,18 +1120,11 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
         }
 
         let packetRow = rows[row]
-        let isSelected = tableView.selectedRowIndexes.contains(row)
-        if let rowView = tableView.rowView(atRow: row, makeIfNecessary: false) as? PacketHighlightRowView {
-            rowView.highlightColor = packetRow.textStyle.highlightColor
-            rowView.needsDisplay = true
-        }
         if let cell = cell as? PacketProtocolCell {
             cell.configure(
                 protocolText: packetRow.protocolText,
                 severity: packetRow.severity,
                 textStyle: packetRow.textStyle,
-                isSelected: isSelected,
-                appearance: tableView.effectiveAppearance,
                 configuration: configuration
             )
         } else if let cell = cell as? PacketClientCell {
@@ -1063,29 +1132,15 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
                 displayName: packetRow.clientText,
                 iconFilePath: packetRow.clientIconFilePath,
                 textStyle: packetRow.textStyle,
-                isSelected: isSelected,
-                appearance: tableView.effectiveAppearance,
                 configuration: configuration
             )
         } else if let cell = cell as? PacketTextCell {
             cell.configure(
                 style: textStyle(for: column, in: packetRow),
                 textStyle: packetRow.textStyle,
-                isSelected: isSelected,
-                appearance: tableView.effectiveAppearance,
                 configuration: configuration
             )
         }
-    }
-
-    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        guard rows.indices.contains(row) else {
-            return nil
-        }
-
-        let rowView = PacketHighlightRowView()
-        rowView.highlightColor = rows[row].textStyle.highlightColor
-        return rowView
     }
 
     func tableViewColumnDidMove(_ notification: Notification) {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -16,6 +16,11 @@ protocol PacketTableViewControllerDelegate: AnyObject {
         didRequestPinPackets identifiers: [PacketSummary.ID]
     )
     func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        didRequestApplyTextStyle mutation: PacketTextStyleMutation,
+        toPackets identifiers: [PacketSummary.ID]
+    )
     func packetTableViewController(_ controller: PacketTableViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
     func packetTableViewController(_ controller: PacketTableViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
     func packetTableViewController(
@@ -55,6 +60,7 @@ enum PacketTableSelectionSyncPlanner {
 fileprivate protocol PacketTableKeyboardActionHandling: AnyObject {
     func packetTableViewDidRequestCopyRowsFromKeyboard(_ tableView: PacketTableView)
     func packetTableViewDidRequestDeleteFromKeyboard(_ tableView: PacketTableView)
+    func packetTableView(_ tableView: PacketTableView, didRequestTextStyle mutation: PacketTextStyleMutation)
 }
 
 fileprivate final class PacketTableView: NSTableView {
@@ -73,6 +79,24 @@ fileprivate final class PacketTableView: NSTableView {
         if flags.contains(.command), event.charactersIgnoringModifiers?.lowercased() == "c" {
             copy(nil)
             return
+        }
+
+        if flags.contains(.command), let character = event.charactersIgnoringModifiers {
+            if character == "0" {
+                keyboardActionHandler?.packetTableView(self, didRequestTextStyle: .reset)
+                return
+            }
+            if character == "/" {
+                keyboardActionHandler?.packetTableView(self, didRequestTextStyle: .toggleStrikethrough)
+                return
+            }
+            if let index = Int(character), (1...9).contains(index) {
+                keyboardActionHandler?.packetTableView(
+                    self,
+                    didRequestTextStyle: .setHighlightColor(PacketHighlightColor.allCases[index - 1])
+                )
+                return
+            }
         }
 
         if event.keyCode == 51 || event.keyCode == 117 {
@@ -924,6 +948,23 @@ final class PacketTableViewController: NSViewController {
         delegate?.packetTableViewController(self, didRequestSavePackets: identifiers)
     }
 
+    @objc func setPacketHighlightColorFromMenu(_ sender: Any?) {
+        guard let menuItem = sender as? NSMenuItem,
+              let rawValue = menuItem.representedObject as? String,
+              let color = PacketHighlightColor(rawValue: rawValue) else {
+            return
+        }
+        applyTextStyle(.setHighlightColor(color))
+    }
+
+    @objc func togglePacketStrikethroughFromMenu(_ sender: Any?) {
+        applyTextStyle(.toggleStrikethrough)
+    }
+
+    @objc func resetPacketTextStyleFromMenu(_ sender: Any?) {
+        applyTextStyle(.reset)
+    }
+
     @objc func exportRowsAsPcapFromMenu(_ sender: Any?) {
         exportTargetRows(format: .pcap)
     }
@@ -958,6 +999,19 @@ final class PacketTableViewController: NSViewController {
         delegate?.packetTableViewController(self, didRequestExportPackets: identifiers, format: format)
     }
 
+    private func applyTextStyle(_ mutation: PacketTextStyleMutation) {
+        let identifiers = targetPacketIDs()
+        guard !identifiers.isEmpty else {
+            return
+        }
+
+        delegate?.packetTableViewController(
+            self,
+            didRequestApplyTextStyle: mutation,
+            toPackets: identifiers
+        )
+    }
+
     private func requestPin() {
         let identifiers = targetPacketIDs()
         guard !identifiers.isEmpty else {
@@ -990,17 +1044,41 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
         }
 
         let packetRow = rows[row]
+        if let rowView = tableView.rowView(atRow: row, makeIfNecessary: false) as? PacketHighlightRowView {
+            rowView.highlightColor = packetRow.textStyle.highlightColor
+            rowView.needsDisplay = true
+        }
         if let cell = cell as? PacketProtocolCell {
-            cell.configure(protocolText: packetRow.protocolText, severity: packetRow.severity, configuration: configuration)
+            cell.configure(
+                protocolText: packetRow.protocolText,
+                severity: packetRow.severity,
+                textStyle: packetRow.textStyle,
+                configuration: configuration
+            )
         } else if let cell = cell as? PacketClientCell {
             cell.configure(
                 displayName: packetRow.clientText,
                 iconFilePath: packetRow.clientIconFilePath,
+                textStyle: packetRow.textStyle,
                 configuration: configuration
             )
         } else if let cell = cell as? PacketTextCell {
-            cell.configure(style: textStyle(for: column, in: packetRow), configuration: configuration)
+            cell.configure(
+                style: textStyle(for: column, in: packetRow),
+                textStyle: packetRow.textStyle,
+                configuration: configuration
+            )
         }
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        guard rows.indices.contains(row) else {
+            return nil
+        }
+
+        let rowView = PacketHighlightRowView()
+        rowView.highlightColor = rows[row].textStyle.highlightColor
+        return rowView
     }
 
     func tableViewColumnDidMove(_ notification: Notification) {
@@ -1044,6 +1122,12 @@ extension PacketTableViewController: PacketTableKeyboardActionHandling {
         clickedRowIndex = nil
         clickedColumnIdentifier = nil
         deleteTargetRows()
+    }
+
+    fileprivate func packetTableView(_ tableView: PacketTableView, didRequestTextStyle mutation: PacketTextStyleMutation) {
+        clickedRowIndex = nil
+        clickedColumnIdentifier = nil
+        applyTextStyle(mutation)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -15,6 +15,11 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
         didRequestPinPackets identifiers: [PacketSummary.ID]
     )
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestApplyTextStyle mutation: PacketTextStyleMutation,
+        toPackets identifiers: [PacketSummary.ID]
+    )
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat)
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestDeletePackets identifiers: [PacketSummary.ID])
     func packetWorkspaceViewController(
@@ -380,6 +385,18 @@ extension PacketWorkspaceViewController: PacketTableViewControllerDelegate {
 
     func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID]) {
         delegate?.packetWorkspaceViewController(self, didRequestSavePackets: identifiers)
+    }
+
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        didRequestApplyTextStyle mutation: PacketTextStyleMutation,
+        toPackets identifiers: [PacketSummary.ID]
+    ) {
+        delegate?.packetWorkspaceViewController(
+            self,
+            didRequestApplyTextStyle: mutation,
+            toPackets: identifiers
+        )
     }
 
     func packetTableViewController(_ controller: PacketTableViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat) {

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -1293,6 +1293,14 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         viewModel.savePackets(identifiers)
     }
 
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestApplyTextStyle mutation: PacketTextStyleMutation,
+        toPackets identifiers: [PacketSummary.ID]
+    ) {
+        viewModel.applyTextStyleMutation(mutation, toPackets: identifiers)
+    }
+
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestExportPackets identifiers: [PacketSummary.ID], format: CaptureFileFormat) {
         viewModel.presentPacketExportPanel(identifiers: identifiers, format: format, attachedTo: view.window)
     }

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -1873,6 +1873,27 @@ struct PacketIngestStateMutationTests {
         }
     }
 
+    @Test func textStyleMutationsUpdateOnlyIndexedPacketsAndComposeEffects() {
+        var state = PacketIngestState.empty
+        let packets = (1...3).map { makePacket(packetNumber: UInt64($0)) }
+        state.append(packets, source: .live)
+
+        let coloredIDs = state.applyTextStyleMutation(.setHighlightColor(.red), packetIDs: [1, 3, 99])
+
+        #expect(coloredIDs == [1, 3])
+        #expect(state.packets[0].resolvedTextStyle == PacketTextStyle(highlightColor: .red))
+        #expect(state.packets[1].resolvedTextStyle == .plain)
+        #expect(state.packets[2].resolvedTextStyle == PacketTextStyle(highlightColor: .red))
+        #expect(state.lastMutation == .metadataUpdate(packetIDs: [1, 3]))
+
+        state.applyTextStyleMutation(.toggleStrikethrough, packetIDs: [1])
+        #expect(state.packets[0].resolvedTextStyle == PacketTextStyle(highlightColor: .red, isStrikethrough: true))
+
+        state.applyTextStyleMutation(.reset, packetIDs: [3])
+        #expect(state.packets[2].resolvedTextStyle == .plain)
+        #expect(state.packets[2].textStyle == nil)
+    }
+
     private func makePacket(packetNumber: UInt64) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -2134,6 +2134,41 @@ struct NetworkInspectorViewModelTests {
         #expect(document.exportRequests.first?.2 == .pcapng)
     }
 
+    @Test func packetExportSnapshotsComposedTextStyles() async {
+        let packet = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let document = InspectorFakeDocument(
+            url: URL(fileURLWithPath: "/tmp/style-export-source.pcapng"),
+            packets: [packet]
+        )
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.openDocument(at: document.currentURL())
+        await waitUntil { viewModel.snapshot.packetRows.count == 1 }
+        viewModel.applyTextStyleMutation(.setHighlightColor(.purple), toPackets: [packet.id])
+        viewModel.applyTextStyleMutation(.toggleStrikethrough, toPackets: [packet.id])
+
+        let result = await viewModel.exportPackets(
+            [packet.id],
+            to: URL(fileURLWithPath: "/tmp/style-export.pcapng"),
+            format: .pcapng
+        )
+
+        guard case .success = result else {
+            Issue.record("Expected styled packet export to succeed.")
+            return
+        }
+        #expect(document.exportMetadataRequests.first?.textStylesByPacketID[packet.id] == PacketTextStyle(
+            highlightColor: .purple,
+            isStrikethrough: true
+        ))
+    }
+
     @Test func clearTablePacketsRemovesOnlyVisibleRows() async {
         let packets = [
             makePacket(packetNumber: 1, source: .offline, transportHint: .tcp),
@@ -2217,6 +2252,39 @@ struct NetworkInspectorViewModelTests {
         }
         #expect(error.code == .offlineFileSaveFailed)
         #expect(staleDocument.exportRequests.isEmpty)
+    }
+
+    @Test func styleRoutingDoesNotCrossStaleSavedAndActivePacketIDCollisions() async throws {
+        let directory = temporaryDirectory()
+        let savedService = SavedPacketService(storageURL: directory.appendingPathComponent("Saved.json"))
+        let staleSavedPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .udp)
+        try savedService.save([staleSavedPacket], backingIdentity: "stale-backing")
+        let activePacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let document = InspectorFakeDocument(
+            url: URL(fileURLWithPath: "/tmp/style-collision.pcapng"),
+            packets: [activePacket]
+        )
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults(),
+            savedPacketService: savedService
+        )
+
+        await viewModel.openDocument(at: document.currentURL())
+        await waitUntil { viewModel.snapshot.packetRows.count == 1 }
+        viewModel.applyTextStyleMutation(.setHighlightColor(.red), toPackets: [activePacket.id])
+
+        #expect(viewModel.snapshot.base.packetIngestState.packet(withID: activePacket.id)?.resolvedTextStyle == PacketTextStyle(highlightColor: .red))
+        #expect(savedService.records().first?.packet.resolvedTextStyle == .plain)
+
+        viewModel.selectSourceList(.saved)
+        viewModel.applyTextStyleMutation(.toggleStrikethrough, toPackets: [staleSavedPacket.id])
+
+        #expect(savedService.records().first?.packet.resolvedTextStyle == PacketTextStyle(isStrikethrough: true))
+        #expect(viewModel.snapshot.base.packetIngestState.packet(withID: activePacket.id)?.resolvedTextStyle == PacketTextStyle(highlightColor: .red))
     }
 
     @Test func pinnedAndSavedSelectionsFilterRowsAndReloadFromDisk() async throws {
@@ -3589,6 +3657,7 @@ private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unc
     private(set) var saveCount = 0
     private(set) var saveAsRequests: [(URL, CaptureFileFormat)] = []
     private(set) var exportRequests: [([PacketSummary.ID], URL, CaptureFileFormat)] = []
+    private(set) var exportMetadataRequests: [PacketExportMetadata] = []
     private var progress: PacketLoadProgress = .idle
 
     init(url: URL, packets: [PacketSummary]) {
@@ -3671,6 +3740,26 @@ private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unc
         progress?(PacketExportProgress(exportedPacketCount: identifiers.count, totalPacketCount: identifiers.count))
         exportRequests.append((identifiers, url, format))
         completion(.success(()))
+    }
+
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        metadata: PacketExportMetadata,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        exportMetadataRequests.append(metadata)
+        exportPackets(
+            withIDs: identifiers,
+            to: url,
+            format: format,
+            progress: progress,
+            shouldCancel: shouldCancel,
+            completion: completion
+        )
     }
 
     func currentURL() -> URL {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -2153,6 +2153,11 @@ struct NetworkInspectorViewModelTests {
         viewModel.applyTextStyleMutation(.setHighlightColor(.purple), toPackets: [packet.id])
         viewModel.applyTextStyleMutation(.toggleStrikethrough, toPackets: [packet.id])
 
+        #expect(viewModel.snapshot.packetRows.first?.textStyle == PacketTextStyle(
+            highlightColor: .purple,
+            isStrikethrough: true
+        ))
+
         let result = await viewModel.exportPackets(
             [packet.id],
             to: URL(fileURLWithPath: "/tmp/style-export.pcapng"),

--- a/TCPViewerTests/Features/NetworkInspector/PacketClientIconPathResolverTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketClientIconPathResolverTests.swift
@@ -86,15 +86,12 @@ struct PacketClientIconPathResolverTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let configuration = AppConfiguration(defaults: defaults)
-        let appearance = try #require(NSAppearance(named: .aqua))
         let cell = PacketClientCell()
 
         cell.configure(
             displayName: "Example",
             iconFilePath: "/Applications/Example.app",
             textStyle: .plain,
-            isSelected: false,
-            appearance: appearance,
             configuration: configuration
         )
         let copiedCell = try #require(cell.copy() as? PacketClientCell)

--- a/TCPViewerTests/Features/NetworkInspector/PacketClientIconPathResolverTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketClientIconPathResolverTests.swift
@@ -80,17 +80,21 @@ struct PacketClientIconPathResolverTests {
         #expect(sampledColor.blueComponent < 0.2)
     }
 
+    @MainActor
     @Test func packetClientCellCopyKeepsConfiguredSwiftState() throws {
         let suiteName = "PacketClientCellCopy-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let configuration = AppConfiguration(defaults: defaults)
+        let appearance = try #require(NSAppearance(named: .aqua))
         let cell = PacketClientCell()
 
         cell.configure(
             displayName: "Example",
             iconFilePath: "/Applications/Example.app",
             textStyle: .plain,
+            isSelected: false,
+            appearance: appearance,
             configuration: configuration
         )
         let copiedCell = try #require(cell.copy() as? PacketClientCell)

--- a/TCPViewerTests/Features/NetworkInspector/PacketClientIconPathResolverTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketClientIconPathResolverTests.swift
@@ -90,6 +90,7 @@ struct PacketClientIconPathResolverTests {
         cell.configure(
             displayName: "Example",
             iconFilePath: "/Applications/Example.app",
+            textStyle: .plain,
             configuration: configuration
         )
         let copiedCell = try #require(cell.copy() as? PacketClientCell)

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -302,8 +302,37 @@ struct PacketTableMenuLogicTests {
         #expect(highlightSubmenu.items.first { $0.title == "Strikethrough" }?.keyEquivalent == "/")
         #expect(highlightSubmenu.items.first { $0.title == "Reset" }?.keyEquivalent == "0")
         #expect(menu.items.contains { $0.title == "Pin" && $0.submenu == nil })
+        let highlightIndex = try #require(menu.items.firstIndex(where: { $0.title == "Highlight" }))
+        #expect(highlightIndex > 0 && menu.items[highlightIndex - 1].isSeparatorItem)
         #expect(!items.isEmpty)
         #expect(items.allSatisfy { item in item.toolTip?.isEmpty == false })
+    }
+
+    @MainActor
+    @Test func highlightedRowPaletteKeepsSelectedColorsVisibleAcrossAppearances() throws {
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+        let darkAppearance = try #require(NSAppearance(named: .darkAqua))
+
+        for appearance in [lightAppearance, darkAppearance] {
+            let regularColor = PacketHighlightPalette.backgroundColor(
+                for: .green,
+                isSelected: false,
+                appearance: appearance
+            )
+            let selectedColor = PacketHighlightPalette.backgroundColor(
+                for: .green,
+                isSelected: true,
+                appearance: appearance
+            )
+
+            #expect(selectedColor.alphaComponent > regularColor.alphaComponent)
+            #expect(selectedColor.alphaComponent < 0.5)
+        }
+
+        let rowView = PacketHighlightRowView()
+        rowView.highlightColor = .green
+        rowView.isSelected = true
+        #expect(rowView.interiorBackgroundStyle == .normal)
     }
 
     private func makePacket(

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -309,35 +309,21 @@ struct PacketTableMenuLogicTests {
     }
 
     @MainActor
-    @Test func highlightedRowPaletteKeepsSelectedColorsVisibleAcrossAppearances() throws {
+    @Test func highlightedRowPaletteResolvesOpaqueColorsAcrossAppearances() throws {
         let lightAppearance = try #require(NSAppearance(named: .aqua))
         let darkAppearance = try #require(NSAppearance(named: .darkAqua))
 
         for appearance in [lightAppearance, darkAppearance] {
-            let regularColor = PacketHighlightPalette.backgroundColor(
+            let color = PacketHighlightPalette.backgroundColor(
                 for: .green,
-                isSelected: false,
                 appearance: appearance
             )
-            let selectedColor = PacketHighlightPalette.backgroundColor(
-                for: .green,
-                isSelected: true,
-                appearance: appearance
-            )
-
-            #expect(regularColor.alphaComponent == 1)
-            #expect(selectedColor.alphaComponent == 1)
-            #expect(selectedColor != regularColor)
+            #expect(color.alphaComponent == 1)
         }
-
-        let rowView = PacketHighlightRowView()
-        rowView.highlightColor = .green
-        rowView.isSelected = true
-        #expect(rowView.interiorBackgroundStyle == .normal)
     }
 
     @MainActor
-    @Test func cellBasedPacketTablePaintsSelectedHighlightColor() throws {
+    @Test func packetTableUsesOneBackgroundAcrossCellsAndFullRow() throws {
         let defaults = Self.makeUserDefaults()
         let controller = PacketTableViewController(configuration: AppConfiguration(defaults: defaults))
         controller.loadViewIfNeeded()
@@ -348,20 +334,35 @@ struct PacketTableMenuLogicTests {
         controller.render(snapshot: makeSnapshot(packets: [packet]))
         tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
 
-        let column = try #require(tableView.tableColumns.first)
-        let cell = try #require(column.dataCell as? PacketTextCell)
-        controller.tableView(tableView, willDisplayCell: cell, for: column, row: 0)
-        let backgroundColor = try #require(cell.backgroundColor)
-        let color = try #require(backgroundColor.usingColorSpace(.deviceRGB))
+        for column in tableView.tableColumns {
+            guard let cell = column.dataCell as? NSTextFieldCell else {
+                continue
+            }
+            controller.tableView(tableView, willDisplayCell: cell, for: column, row: 0)
+            #expect(!cell.drawsBackground)
+        }
 
-        #expect(cell.drawsBackground)
-        #expect(color.alphaComponent == 1)
-        #expect(color.redComponent > color.greenComponent)
-        #expect(color.redComponent > color.blueComponent)
+        tableView.columnAutoresizingStyle = .noColumnAutoresizing
+        let columnsMaxX = tableView.tableColumns.indices
+            .map { tableView.rect(ofColumn: $0).maxX }
+            .max() ?? 0
+        tableView.setFrameSize(NSSize(width: columnsMaxX + 40, height: tableView.rowHeight))
 
-        let edgeColor = try Self.renderedEdgeColor(of: cell)
-        #expect(edgeColor.redComponent > edgeColor.greenComponent)
-        #expect(edgeColor.redComponent > edgeColor.blueComponent)
+        tableView.deselectAll(nil)
+        let rowEdgeColors = try Self.renderedRowEdgeColors(in: tableView, row: 0)
+        for edgeColor in rowEdgeColors {
+            #expect(edgeColor.redComponent > edgeColor.greenComponent)
+            #expect(edgeColor.redComponent > edgeColor.blueComponent)
+        }
+
+        tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+        let selectedEdgeColors = try Self.renderedRowEdgeColors(in: tableView, row: 0)
+        let selectedColor = try #require(NSColor.selectedContentBackgroundColor.usingColorSpace(.deviceRGB))
+        for edgeColor in selectedEdgeColors {
+            #expect(abs(edgeColor.redComponent - selectedColor.redComponent) < 0.01)
+            #expect(abs(edgeColor.greenComponent - selectedColor.greenComponent) < 0.01)
+            #expect(abs(edgeColor.blueComponent - selectedColor.blueComponent) < 0.01)
+        }
     }
 
     private func makeSnapshot(packets: [PacketSummary]) -> NetworkInspectorSnapshot {
@@ -444,12 +445,12 @@ struct PacketTableMenuLogicTests {
     }
 
     @MainActor
-    private static func renderedEdgeColor(of cell: NSCell) throws -> NSColor {
-        let size = NSSize(width: 80, height: 24)
+    private static func renderedRowEdgeColors(in tableView: NSTableView, row: Int) throws -> [NSColor] {
+        let rowRect = tableView.rect(ofRow: row)
         let bitmap = try #require(NSBitmapImageRep(
             bitmapDataPlanes: nil,
-            pixelsWide: Int(size.width),
-            pixelsHigh: Int(size.height),
+            pixelsWide: Int(ceil(tableView.bounds.width)),
+            pixelsHigh: Int(ceil(rowRect.height)),
             bitsPerSample: 8,
             samplesPerPixel: 4,
             hasAlpha: true,
@@ -459,14 +460,16 @@ struct PacketTableMenuLogicTests {
             bitsPerPixel: 0
         ))
         let context = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
-        let frame = NSRect(origin: .zero, size: size)
 
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = context
-        cell.draw(withFrame: frame, in: NSView(frame: frame))
+        tableView.drawBackground(inClipRect: rowRect)
         NSGraphicsContext.restoreGraphicsState()
 
-        return try #require(bitmap.colorAt(x: 1, y: 1)?.usingColorSpace(.deviceRGB))
+        let trailingX = max(1, bitmap.pixelsWide - 2)
+        return try [1, trailingX].map { x in
+            try #require(bitmap.colorAt(x: x, y: 1)?.usingColorSpace(.deviceRGB))
+        }
     }
 
     @MainActor

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -325,14 +325,70 @@ struct PacketTableMenuLogicTests {
                 appearance: appearance
             )
 
-            #expect(selectedColor.alphaComponent > regularColor.alphaComponent)
-            #expect(selectedColor.alphaComponent < 0.5)
+            #expect(regularColor.alphaComponent == 1)
+            #expect(selectedColor.alphaComponent == 1)
+            #expect(selectedColor != regularColor)
         }
 
         let rowView = PacketHighlightRowView()
         rowView.highlightColor = .green
         rowView.isSelected = true
         #expect(rowView.interiorBackgroundStyle == .normal)
+    }
+
+    @MainActor
+    @Test func cellBasedPacketTablePaintsSelectedHighlightColor() throws {
+        let defaults = Self.makeUserDefaults()
+        let controller = PacketTableViewController(configuration: AppConfiguration(defaults: defaults))
+        controller.loadViewIfNeeded()
+        let tableView = try Self.tableView(in: controller)
+        let packet = makePacket(packetNumber: 1).applying(
+            textStyle: PacketTextStyle(highlightColor: .red)
+        )
+        controller.render(snapshot: makeSnapshot(packets: [packet]))
+        tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+
+        let column = try #require(tableView.tableColumns.first)
+        let cell = try #require(column.dataCell as? PacketTextCell)
+        controller.tableView(tableView, willDisplayCell: cell, for: column, row: 0)
+        let backgroundColor = try #require(cell.backgroundColor)
+        let color = try #require(backgroundColor.usingColorSpace(.deviceRGB))
+
+        #expect(cell.drawsBackground)
+        #expect(color.alphaComponent == 1)
+        #expect(color.redComponent > color.greenComponent)
+        #expect(color.redComponent > color.blueComponent)
+
+        let edgeColor = try Self.renderedEdgeColor(of: cell)
+        #expect(edgeColor.redComponent > edgeColor.greenComponent)
+        #expect(edgeColor.redComponent > edgeColor.blueComponent)
+    }
+
+    private func makeSnapshot(packets: [PacketSummary]) -> NetworkInspectorSnapshot {
+        var base = TCPViewerWindowSnapshot.foundation
+        base.packetIngestState.replace(with: packets, source: .live)
+        let rows = packets.map(PacketTableRow.init(packet:))
+        let visibleIndex = Dictionary(uniqueKeysWithValues: rows.enumerated().map { ($1.id, $0) })
+        let content = PacketTableContent(
+            displayFilter: PacketDisplayFilter(""),
+            displayFilterChips: [],
+            store: PacketTableRowStore(rows: rows, visiblePacketRowIndexByID: visibleIndex),
+            generation: 1,
+            updatePlan: .reload,
+            malformedPacketCount: 0
+        )
+        return NetworkInspectorSnapshot.make(
+            base: base,
+            selectedSidebar: .liveCapture,
+            selectedSourceListSelection: .allPackets,
+            sourceListSnapshot: .empty,
+            sourceListFilterText: "",
+            workspaceMode: .packets,
+            inspectorTab: .summary,
+            isInspectorVisible: true,
+            displayFilterText: "",
+            packetTableContent: content
+        )
     }
 
     private func makePacket(
@@ -385,6 +441,32 @@ struct PacketTableMenuLogicTests {
     private static func tableView(in controller: PacketTableViewController) throws -> NSTableView {
         let scrollView = try #require(controller.view as? NSScrollView)
         return try #require(scrollView.documentView as? NSTableView)
+    }
+
+    @MainActor
+    private static func renderedEdgeColor(of cell: NSCell) throws -> NSColor {
+        let size = NSSize(width: 80, height: 24)
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(size.width),
+            pixelsHigh: Int(size.height),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ))
+        let context = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+        let frame = NSRect(origin: .zero, size: size)
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        cell.draw(withFrame: frame, in: NSView(frame: frame))
+        NSGraphicsContext.restoreGraphicsState()
+
+        return try #require(bitmap.colorAt(x: 1, y: 1)?.usingColorSpace(.deviceRGB))
     }
 
     @MainActor

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -33,6 +33,7 @@ struct PacketTableMenuLogicTests {
         #expect(state.copyCellEnabled)
         #expect(state.pinEnabled)
         #expect(state.saveEnabled)
+        #expect(state.styleEnabled)
         #expect(state.exportEnabled)
         #expect(state.deleteEnabled)
     }
@@ -270,6 +271,7 @@ struct PacketTableMenuLogicTests {
             copyCellEnabled: true,
             pinEnabled: true,
             saveEnabled: true,
+            styleEnabled: true,
             exportEnabled: true,
             deleteEnabled: true
         ))
@@ -282,12 +284,23 @@ struct PacketTableMenuLogicTests {
         let items = menu.nonSeparatorItemsIncludingSubmenus()
         let copyRowsAsItem = try #require(menu.items.first { $0.title == "Copy Rows As" })
         let copyRowsAsSubmenu = try #require(copyRowsAsItem.submenu)
+        let highlightItem = try #require(menu.items.first { $0.title == "Highlight" })
+        let highlightSubmenu = try #require(highlightItem.submenu)
         let copyRowsAsTitles = copyRowsAsSubmenu.items.compactMap { item in
             item.isSeparatorItem ? nil : item.title
         }
 
         #expect(copyRowsAsTitles == ["Plain text", "JSON", "Markdown Table", "CSV", "CSV with Header"])
         #expect(copyRowsAsSubmenu.items.filter(\.isSeparatorItem).count == 2)
+        #expect(highlightSubmenu.items.compactMap { $0.isSeparatorItem ? nil : $0.title } == [
+            "Red", "Orange", "Yellow", "Green", "Teal", "Blue", "Indigo", "Purple", "Pink",
+            "Brown", "Gray", "Strikethrough", "Reset",
+        ])
+        #expect(Array(highlightSubmenu.items.prefix(9)).map(\.keyEquivalent) == (1...9).map(String.init))
+        #expect(highlightSubmenu.items.first { $0.title == "Brown" }?.keyEquivalent == "")
+        #expect(highlightSubmenu.items.first { $0.title == "Gray" }?.keyEquivalent == "")
+        #expect(highlightSubmenu.items.first { $0.title == "Strikethrough" }?.keyEquivalent == "/")
+        #expect(highlightSubmenu.items.first { $0.title == "Reset" }?.keyEquivalent == "0")
         #expect(menu.items.contains { $0.title == "Pin" && $0.submenu == nil })
         #expect(!items.isEmpty)
         #expect(items.allSatisfy { item in item.toolTip?.isEmpty == false })
@@ -377,6 +390,9 @@ private final class MenuActionHandler: NSObject, PacketTableContextMenuActionHan
     func copyCellFromMenu(_ sender: Any?) {}
     func pinRowsFromMenu(_ sender: Any?) {}
     func saveRowsFromMenu(_ sender: Any?) {}
+    func setPacketHighlightColorFromMenu(_ sender: Any?) {}
+    func togglePacketStrikethroughFromMenu(_ sender: Any?) {}
+    func resetPacketTextStyleFromMenu(_ sender: Any?) {}
     func exportRowsAsPcapFromMenu(_ sender: Any?) {}
     func exportRowsAsPcapngFromMenu(_ sender: Any?) {}
     func deleteRowsFromMenu(_ sender: Any?) {}

--- a/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
@@ -50,6 +50,28 @@ struct SavedPacketServiceTests {
         #expect(service.records().map { $0.packet.id } == [incomingPacket.id])
     }
 
+    @Test func textStyleMutationPersistsForSavedPacketRows() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Saved.json")
+        let service = SavedPacketService(storageURL: storageURL)
+        let first = makePacket(packetNumber: 1)
+        let second = makePacket(packetNumber: 2)
+        try service.save([first, second])
+
+        let didChange = try service.applyTextStyleMutation(
+            .setHighlightColor(.orange),
+            packetIDs: [first.id]
+        )
+        _ = try service.applyTextStyleMutation(.toggleStrikethrough, packetIDs: [first.id])
+        let reloaded = SavedPacketService(storageURL: storageURL)
+
+        #expect(didChange)
+        #expect(reloaded.records()[0].packet.resolvedTextStyle == PacketTextStyle(
+            highlightColor: .orange,
+            isStrikethrough: true
+        ))
+        #expect(reloaded.records()[1].packet.resolvedTextStyle == .plain)
+    }
+
     private func temporaryDirectory() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
@@ -72,6 +72,25 @@ struct SavedPacketServiceTests {
         #expect(reloaded.records()[1].packet.resolvedTextStyle == .plain)
     }
 
+    @Test func textStyleMutationRollsBackWhenPersistenceFails() throws {
+        let rootURL = temporaryDirectory()
+        let storageDirectoryURL = rootURL.appendingPathComponent("Saved", isDirectory: true)
+        try FileManager.default.createDirectory(at: storageDirectoryURL, withIntermediateDirectories: true)
+        let storageURL = storageDirectoryURL.appendingPathComponent("Saved.json")
+        let service = SavedPacketService(storageURL: storageURL)
+        let packet = makePacket(packetNumber: 1)
+        try service.save([packet])
+        let recordsBeforeMutation = service.records()
+
+        try FileManager.default.removeItem(at: storageDirectoryURL)
+        #expect(FileManager.default.createFile(atPath: storageDirectoryURL.path, contents: Data()))
+
+        #expect(throws: Error.self) {
+            try service.applyTextStyleMutation(.setHighlightColor(.red), packetIDs: [packet.id])
+        }
+        #expect(service.records() == recordsBeforeMutation)
+    }
+
     private func temporaryDirectory() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
@@ -104,13 +104,26 @@ struct TCPViewSessionFormatTests {
                 packetID: 9,
                 packetComment: "pcapng comment",
                 customComment: "custom comment",
-                colorHex: "#4A90E2"
+                colorHex: "#5E5CE6",
+                textStyle: PacketTextStyle(highlightColor: .indigo, isStrikethrough: true)
             ),
         ])
 
         let decoded = try Self.decode(TCPViewSessionAnnotations.self, from: Self.encode(annotations))
 
         #expect(decoded == annotations)
+    }
+
+    @Test func packetSummaryWithoutTextStyleFieldDecodesAsPlainForOlderSessions() throws {
+        let packet = Self.makePacket(id: 8, packetNumber: 8, client: nil)
+        var object = try #require(JSONSerialization.jsonObject(with: Self.encode(packet)) as? [String: Any])
+        object.removeValue(forKey: "textStyle")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try Self.decode(PacketSummary.self, from: legacyData)
+
+        #expect(decoded.resolvedTextStyle == .plain)
+        #expect(decoded.textStyle == nil)
     }
 
     @Test func clientStoreDeduplicatesTwentyThousandPacketsAndRestoresClients() {
@@ -144,8 +157,10 @@ struct TCPViewSessionFormatTests {
         let captureURL = directory.appendingPathComponent("capture-source.pcapng")
         try Data("pcapng-placeholder".utf8).write(to: captureURL)
         let destinationURL = directory.appendingPathComponent("sample.tcpviewsession")
+        let firstStyle = PacketTextStyle(highlightColor: .teal, isStrikethrough: true)
         let packets = [
-            Self.makePacket(id: 10, packetNumber: 1, client: Self.client, packetComment: "first comment"),
+            Self.makePacket(id: 10, packetNumber: 1, client: Self.client, packetComment: "first comment")
+                .applying(textStyle: firstStyle),
             Self.makePacket(id: 11, packetNumber: 2, client: Self.client),
         ]
         let snapshot = Self.makeSnapshot(
@@ -185,6 +200,9 @@ struct TCPViewSessionFormatTests {
         #expect(contents.clientStore.clients.count == 1)
         #expect(contents.packets.map(\.client) == [Self.client, Self.client])
         #expect(contents.annotations.annotations.first?.packetComment == "first comment")
+        #expect(contents.annotations.annotations.first?.colorHex == "#40C8E0")
+        #expect(contents.annotations.annotations.first?.textStyle == firstStyle)
+        #expect(contents.packets.map(\.resolvedTextStyle) == [firstStyle, .plain])
         #expect(contents.state.importedCaptureFiles.first?.displayName == "source.pcapng")
         #expect(jsonl.split(separator: "\n").count == packets.count)
         #expect(Self.zipPackageContainsRequiredFiles(contents.packageDirectoryURL))


### PR DESCRIPTION
## Summary

- Add configurable packet text color styling across dissection, models, and AppKit table views
- Support saving, exporting, and importing TCPView sessions with packet metadata preservation
- Improve packet context-menu actions, workspace state handling, and native capture integration
- Add unit coverage for session formats, saved packets, menu logic, workspace behavior, and metadata enrichment

## Testing

- Added and updated unit tests for core PcapNG fidelity and Network Inspector workflows