### PR TITLE
Preserve packet comments across capture workflows

### DIFF
--- a/PcapPlusPlusCore/Models/PacketComment.swift
+++ b/PcapPlusPlusCore/Models/PacketComment.swift
@@ -1,0 +1,22 @@
+//
+//  PacketComment.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 26/7/26.
+//
+
+import Foundation
+
+public enum PacketComment {
+    public static let maximumCharacterCount = 1_000
+
+    // Normalize line endings, trim outer whitespace, and enforce the UI storage limit.
+    public static func sanitized(_ value: String) -> String {
+        let normalized = value
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(normalized.prefix(maximumCharacterCount))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/PcapPlusPlusCore/Models/PacketModels.swift
+++ b/PcapPlusPlusCore/Models/PacketModels.swift
@@ -314,6 +314,7 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
     public let sniDomainName: String?
     public let client: PacketClient?
     public let textStyle: PacketTextStyle?
+    public let customComment: String?
 
     public init(
         id: UInt64? = nil,
@@ -336,7 +337,8 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
         captureMetadata: PacketCaptureMetadata,
         sniDomainName: String? = nil,
         client: PacketClient? = nil,
-        textStyle: PacketTextStyle? = nil
+        textStyle: PacketTextStyle? = nil,
+        customComment: String? = nil
     ) {
         self.id = id ?? packetNumber
         self.packetNumber = packetNumber
@@ -359,10 +361,16 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
         self.sniDomainName = sniDomainName
         self.client = client
         self.textStyle = textStyle?.isPlain == true ? nil : textStyle
+        let sanitizedComment = customComment.map(PacketComment.sanitized)
+        self.customComment = sanitizedComment?.isEmpty == false ? sanitizedComment : nil
     }
 
     public var resolvedTextStyle: PacketTextStyle {
         textStyle ?? .plain
+    }
+
+    public var resolvedComment: String? {
+        customComment ?? captureMetadata.packetComment
     }
 }
 

--- a/PcapPlusPlusCore/Models/PacketTextStyle.swift
+++ b/PcapPlusPlusCore/Models/PacketTextStyle.swift
@@ -68,11 +68,16 @@ public enum PacketTextStyleMutation: Sendable, Hashable {
 
 public struct PacketExportMetadata: Sendable {
     public let textStylesByPacketID: [PacketSummary.ID: PacketTextStyle]
+    public let commentsByPacketID: [PacketSummary.ID: String]
 
     public static let empty = PacketExportMetadata()
 
-    public init(textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:]) {
+    public init(
+        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
+        commentsByPacketID: [PacketSummary.ID: String] = [:]
+    ) {
         self.textStylesByPacketID = textStylesByPacketID
+        self.commentsByPacketID = commentsByPacketID
     }
 }
 
@@ -100,7 +105,36 @@ public extension PacketSummary {
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
             client: client,
-            textStyle: textStyle
+            textStyle: textStyle,
+            customComment: customComment
+        )
+    }
+
+    // Return a packet copy with a sanitized TCP Viewer comment override.
+    func applying(customComment: String) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: packetNumber,
+            timestamp: timestamp,
+            source: source,
+            interfaceID: interfaceID,
+            transportHint: transportHint,
+            protocolSummary: protocolSummary,
+            endpoints: endpoints,
+            originalLength: originalLength,
+            capturedLength: capturedLength,
+            streamID: streamID,
+            direction: direction,
+            tcpFlags: tcpFlags,
+            tcpPayloadLength: tcpPayloadLength,
+            infoSummary: infoSummary,
+            layers: layers,
+            decodeStatus: decodeStatus,
+            captureMetadata: captureMetadata,
+            sniDomainName: sniDomainName,
+            client: client,
+            textStyle: textStyle,
+            customComment: customComment
         )
     }
 }

--- a/PcapPlusPlusCore/Services/Core/NativeCaptureFile.swift
+++ b/PcapPlusPlusCore/Services/Core/NativeCaptureFile.swift
@@ -49,10 +49,14 @@ struct NativeCaptureFile {
         records: [NativePacketRecord],
         to url: URL,
         format: CaptureFileFormat,
-        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:]
+        textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
+        commentsByPacketID: [PacketSummary.ID: String] = [:]
     ) throws {
         let outputRecords = records.map { record in
-            record.withTextStyle(textStylesByPacketID[record.identifier] ?? record.textStyle)
+            record.withMetadata(
+                textStyle: textStylesByPacketID[record.identifier] ?? record.textStyle,
+                packetComment: commentsByPacketID[record.identifier] ?? record.packetComment
+            )
         }
         let temporaryURL = url.deletingLastPathComponent()
             .appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
@@ -87,6 +91,10 @@ struct NativeCaptureFile {
                 let hasStyles = outputRecords.contains { !$0.textStyle.isPlain }
                 if !hasStyles || !PcapTextStyleExtendedAttribute.write(stylesFrom: outputRecords, to: url) {
                     PcapTextStyleExtendedAttribute.remove(from: url)
+                }
+                let hasComments = outputRecords.contains { $0.packetComment?.isEmpty == false }
+                if !hasComments || !PcapCommentExtendedAttribute.write(commentsFrom: outputRecords, to: url) {
+                    PcapCommentExtendedAttribute.remove(from: url)
                 }
             }
         } catch let error as NSError where error.domain == TCPViewerNativeErrorDomain {
@@ -143,7 +151,7 @@ private struct PcapReader {
                 return NativeCaptureFile(
                     url: url,
                     format: .pcap,
-                    records: styledRecords(records),
+                    records: annotatedRecords(records),
                     metadata: metadata(),
                     skippedPacketCount: 1,
                     partialLoadReason: "Stopped at a truncated packet record."
@@ -171,7 +179,7 @@ private struct PcapReader {
         return NativeCaptureFile(
             url: url,
             format: .pcap,
-            records: styledRecords(records),
+            records: annotatedRecords(records),
             metadata: metadata(),
             skippedPacketCount: trailingByteCount > 0 ? 1 : 0,
             partialLoadReason: trailingByteCount > 0 ? "Stopped at an incomplete packet header." : nil
@@ -188,13 +196,17 @@ private struct PcapReader {
         )
     }
 
-    private func styledRecords(_ records: [NativePacketRecord]) -> [NativePacketRecord] {
+    private func annotatedRecords(_ records: [NativePacketRecord]) -> [NativePacketRecord] {
         let styles = PcapTextStyleExtendedAttribute.read(from: url, packetCount: records.count)
-        guard !styles.isEmpty else {
+        let comments = PcapCommentExtendedAttribute.read(from: url, packetCount: records.count)
+        guard !styles.isEmpty || !comments.isEmpty else {
             return records
         }
         return records.enumerated().map { index, record in
-            record.withTextStyle(styles[index] ?? .plain)
+            record.withMetadata(
+                textStyle: styles[index] ?? .plain,
+                packetComment: comments[index]
+            )
         }
     }
 
@@ -893,6 +905,72 @@ private enum PcapTextStyleExtendedAttribute {
 
 }
 
+private enum PcapCommentExtendedAttribute {
+    private static let name = "com.proxyman.TCPViewer.packet-comments"
+    private static let magic = Data("TCPVCMT1".utf8)
+    private static let headerLength = magic.count + 8
+
+    static func write(commentsFrom records: [NativePacketRecord], to url: URL) -> Bool {
+        var data = magic
+        data.appendLittleEndian(UInt64(records.count))
+        for (index, record) in records.enumerated() {
+            guard let comment = record.packetComment, !comment.isEmpty else {
+                continue
+            }
+            let commentData = Data(comment.utf8)
+            guard commentData.count <= Int(UInt32.max) else {
+                return false
+            }
+            data.appendLittleEndian(UInt64(index))
+            data.appendLittleEndian(UInt32(commentData.count))
+            data.append(commentData)
+        }
+
+        let result = data.withUnsafeBytes { bytes in
+            setxattr(url.path, name, bytes.baseAddress, bytes.count, 0, 0)
+        }
+        return result == 0
+    }
+
+    static func read(from url: URL, packetCount: Int) -> [Int: String] {
+        let length = getxattr(url.path, name, nil, 0, 0, 0)
+        guard length >= headerLength else {
+            return [:]
+        }
+        var data = Data(count: length)
+        let result = data.withUnsafeMutableBytes { bytes in
+            getxattr(url.path, name, bytes.baseAddress, bytes.count, 0, 0)
+        }
+        guard result == length, data.starts(with: magic),
+              data.readLittleEndianUInt64(at: magic.count) == UInt64(packetCount) else {
+            return [:]
+        }
+
+        var comments: [Int: String] = [:]
+        var offset = headerLength
+        while offset < data.count {
+            guard let ordinal = data.readLittleEndianUInt64(at: offset),
+                  let commentLength = data.readLittleEndianUInt32(at: offset + 8),
+                  ordinal < UInt64(packetCount) else {
+                return [:]
+            }
+            let commentStart = offset + 12
+            let commentEnd = commentStart + Int(commentLength)
+            guard commentEnd <= data.count,
+                  let comment = String(data: data[commentStart..<commentEnd], encoding: .utf8) else {
+                return [:]
+            }
+            comments[Int(ordinal)] = comment
+            offset = commentEnd
+        }
+        return comments
+    }
+
+    static func remove(from url: URL) {
+        _ = removexattr(url.path, name, 0)
+    }
+}
+
 enum PacketTextStyleBinaryCodec {
     static func encode(_ style: PacketTextStyle) -> UInt8 {
         colorCode(style.highlightColor) | (style.isStrikethrough ? 0x80 : 0)
@@ -948,7 +1026,7 @@ enum PacketTextStyleBinaryCodec {
 }
 
 private extension NativePacketRecord {
-    func withTextStyle(_ textStyle: PacketTextStyle) -> NativePacketRecord {
+    func withMetadata(textStyle: PacketTextStyle, packetComment: String?) -> NativePacketRecord {
         NativePacketRecord(
             identifier: identifier,
             packetNumber: packetNumber,
@@ -984,6 +1062,17 @@ private extension Data {
         var value: UInt64 = 0
         for index in 0..<8 {
             value |= UInt64(self[offset + index]) << UInt64(index * 8)
+        }
+        return value
+    }
+
+    func readLittleEndianUInt32(at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= count else {
+            return nil
+        }
+        var value: UInt32 = 0
+        for index in 0..<4 {
+            value |= UInt32(self[offset + index]) << UInt32(index * 8)
         }
         return value
     }

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -277,6 +277,7 @@ final class PCPPNativeOfflineDocument {
         to url: URL,
         format: String,
         textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
+        commentsByPacketID: [PacketSummary.ID: String] = [:],
         progressHandler: PCPPNativePacketExportProgressHandler?,
         cancellationCheck: PCPPNativeCancellationHandler?
     ) throws {
@@ -289,6 +290,7 @@ final class PCPPNativeOfflineDocument {
             to: url,
             format: CaptureFileFormat(exportRawValue: format),
             textStylesByPacketID: textStylesByPacketID,
+            commentsByPacketID: commentsByPacketID,
             progressHandler: progressHandler,
             cancellationCheck: cancellationCheck
         )
@@ -769,6 +771,7 @@ final class PCPPNativeLiveSession {
         to url: URL,
         format: String,
         textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
+        commentsByPacketID: [PacketSummary.ID: String] = [:],
         progressHandler: PCPPNativePacketExportProgressHandler?,
         cancellationCheck: PCPPNativeCancellationHandler?
     ) throws {
@@ -781,6 +784,7 @@ final class PCPPNativeLiveSession {
             to: url,
             format: CaptureFileFormat(exportRawValue: format),
             textStylesByPacketID: textStylesByPacketID,
+            commentsByPacketID: commentsByPacketID,
             progressHandler: progressHandler,
             cancellationCheck: cancellationCheck
         )
@@ -1130,6 +1134,7 @@ enum Exporter {
         to url: URL,
         format: CaptureFileFormat,
         textStylesByPacketID: [PacketSummary.ID: PacketTextStyle] = [:],
+        commentsByPacketID: [PacketSummary.ID: String] = [:],
         progressHandler: PCPPNativePacketExportProgressHandler?,
         cancellationCheck: PCPPNativeCancellationHandler?
     ) throws {
@@ -1146,7 +1151,8 @@ enum Exporter {
             records: records,
             to: url,
             format: format,
-            textStylesByPacketID: textStylesByPacketID
+            textStylesByPacketID: textStylesByPacketID,
+            commentsByPacketID: commentsByPacketID
         )
         progressHandler?(UInt(records.count), UInt(records.count))
     }

--- a/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
+++ b/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
@@ -417,6 +417,7 @@ private final class NativeLiveCaptureSessionState: @unchecked Sendable {
                         to: url,
                         format: format.rawValue,
                         textStylesByPacketID: metadata.textStylesByPacketID,
+                        commentsByPacketID: metadata.commentsByPacketID,
                         progressHandler: { exportedPacketCount, totalPacketCount in
                             progress?(PacketExportProgress(
                                 exportedPacketCount: Int(exportedPacketCount),

--- a/PcapPlusPlusCore/Services/OfflineCapture/NativeOfflineCaptureDocument.swift
+++ b/PcapPlusPlusCore/Services/OfflineCapture/NativeOfflineCaptureDocument.swift
@@ -284,6 +284,7 @@ private final class NativeOfflineCaptureDocumentState: @unchecked Sendable {
                         to: url,
                         format: format.rawValue,
                         textStylesByPacketID: metadata.textStylesByPacketID,
+                        commentsByPacketID: metadata.commentsByPacketID,
                         progressHandler: { exportedPacketCount, totalPacketCount in
                             progress?(PacketExportProgress(
                                 exportedPacketCount: Int(exportedPacketCount),

--- a/PcapPlusPlusCoreTests/Models/PacketCommentTests.swift
+++ b/PcapPlusPlusCoreTests/Models/PacketCommentTests.swift
@@ -1,0 +1,55 @@
+//
+//  PacketCommentTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 26/7/26.
+//
+
+import Foundation
+import Testing
+@testable import PcapPlusPlusCore
+
+struct PacketCommentTests {
+    @Test func sanitizesWhitespaceLineEndingsAndLength() {
+        let rawValue = "  \r\nFirst line\rSecond line\n" + String(repeating: "x", count: 1_100) + "  \n"
+        let comment = PacketComment.sanitized(rawValue)
+
+        #expect(comment.hasPrefix("First line\nSecond line\n"))
+        #expect(comment.count == PacketComment.maximumCharacterCount)
+        #expect(!comment.hasPrefix(" "))
+        #expect(!comment.hasSuffix(" "))
+    }
+
+    @Test func packetCommentOverrideIsSanitizedAndFallsBackToCaptureComment() {
+        let importedPacket = Self.makePacket(customComment: nil)
+        let editedPacket = importedPacket.applying(customComment: "\n Edited comment \n")
+
+        #expect(importedPacket.resolvedComment == "Imported comment")
+        #expect(editedPacket.customComment == "Edited comment")
+        #expect(editedPacket.resolvedComment == "Edited comment")
+    }
+
+    private static func makePacket(customComment: String?) -> PacketSummary {
+        PacketSummary(
+            packetNumber: 1,
+            timestamp: Date(timeIntervalSince1970: 1),
+            source: .offline,
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "127.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "127.0.0.1", port: 443)
+            ),
+            originalLength: 4,
+            capturedLength: 4,
+            infoSummary: "TCP",
+            layers: [],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(
+                linkType: .ethernet,
+                isTruncated: false,
+                packetComment: "Imported comment"
+            ),
+            customComment: customComment
+        )
+    }
+}

--- a/PcapPlusPlusCoreTests/Services/Core/PcapNGFidelityTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/PcapNGFidelityTests.swift
@@ -105,6 +105,25 @@ struct PcapNGFidelityTests {
         #expect(exportedBytes.range(of: Data("[TCPViewer:text-style:v2:indigo:1]".utf8)) != nil)
     }
 
+    @Test func pcapNGExportMetadataOverridesAndRoundTripsPacketComment() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapNGComment-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("commented.pcapng")
+        let record = makeRecord(identifier: 4, linkLayerType: Libpcap.dltEthernet)
+        let comment = "First line\nSecond line"
+
+        try NativeCaptureFile.write(
+            records: [record],
+            to: url,
+            format: .pcapng,
+            commentsByPacketID: [record.identifier: comment]
+        )
+
+        #expect(try NativeCaptureFile.load(from: url).records[0].packetComment == comment)
+    }
+
     @Test func pcapNGPreservesPlainCommentsThatLookLikeStyleMetadata() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("TCPViewer-PcapNGStyleComment-\(UUID().uuidString)", isDirectory: true)
@@ -173,6 +192,28 @@ struct PcapNGFidelityTests {
         #expect(styleMetadata.last == 0x89)
         #expect(capture.records.map(\.textStyle) == [style])
         #expect(capture.records[0].rawBytes == record.rawBytes)
+    }
+
+    @Test func pcapExportKeepsCanonicalBytesAndRoundTripsCommentInFileMetadata() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TCPViewer-PcapComment-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let plainURL = directory.appendingPathComponent("plain.pcap")
+        let commentedURL = directory.appendingPathComponent("commented.pcap")
+        let record = makeRecord(identifier: 1, linkLayerType: Libpcap.dltEthernet)
+        let comment = "Review this packet\nIt may be retried"
+
+        try NativeCaptureFile.write(records: [record], to: plainURL, format: .pcap)
+        try NativeCaptureFile.write(
+            records: [record],
+            to: commentedURL,
+            format: .pcap,
+            commentsByPacketID: [record.identifier: comment]
+        )
+
+        #expect(try Data(contentsOf: plainURL) == Data(contentsOf: commentedURL))
+        #expect(try NativeCaptureFile.load(from: commentedURL).records[0].packetComment == comment)
     }
 
     @Test func pcapTextStyleBinaryCodesRemainStable() {

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -326,6 +326,42 @@ struct PacketIngestState: Sendable, Equatable {
         return updatedIDs
     }
 
+    // Update indexed comments without scanning the full live-capture packet list.
+    @discardableResult
+    mutating func setCustomComment(
+        _ comment: String,
+        packetIDs: Set<PacketSummary.ID>
+    ) -> [PacketSummary.ID] {
+        let sanitizedComment = PacketComment.sanitized(comment)
+        guard !sanitizedComment.isEmpty else {
+            return []
+        }
+
+        var updatedIDs: [PacketSummary.ID] = []
+        updatedIDs.reserveCapacity(packetIDs.count)
+        for packetID in packetIDs {
+            guard let packetIndex = packetIndexByID[packetID] else {
+                continue
+            }
+            let packet = packets[packetIndex]
+            guard packet.customComment != sanitizedComment else {
+                continue
+            }
+            packets[packetIndex] = packet.applying(customComment: sanitizedComment)
+            updatedIDs.append(packetID)
+        }
+
+        guard !updatedIDs.isEmpty else {
+            lastMutation = .none
+            return []
+        }
+
+        updatedIDs.sort()
+        packetRevision &+= 1
+        lastMutation = .metadataUpdate(packetIDs: updatedIDs)
+        return updatedIDs
+    }
+
     // Append a batch and fold metadata updates that target older packets into a single mutation,
     // so consumers can take their cheap append paths without a redundant didSet fire.
     mutating func appendAndApplyMetadataUpdates(
@@ -960,6 +996,7 @@ final class TCPViewerWorkspaceController {
         let fileID: ImportedCaptureFileID
         var originalPacketIDs: [PacketSummary.ID]
         var textStylesByOriginalPacketID: [PacketSummary.ID: PacketTextStyle]
+        var commentsByOriginalPacketID: [PacketSummary.ID: String]
     }
 
     weak var delegate: TCPViewerWorkspaceControllerDelegate?
@@ -2105,6 +2142,11 @@ final class TCPViewerWorkspaceController {
                 metadata: PacketExportMetadata(
                     textStylesByPacketID: Dictionary(
                         uniqueKeysWithValues: exportSnapshot.packets.map { ($0.id, $0.resolvedTextStyle) }
+                    ),
+                    commentsByPacketID: Dictionary(
+                        uniqueKeysWithValues: exportSnapshot.packets.compactMap { packet in
+                            packet.resolvedComment.map { (packet.id, $0) }
+                        }
                     )
                 ),
                 progress: progress,
@@ -2138,6 +2180,11 @@ final class TCPViewerWorkspaceController {
             metadata: PacketExportMetadata(
                 textStylesByPacketID: Dictionary(
                     uniqueKeysWithValues: exportSnapshot.packets.map { ($0.id, $0.resolvedTextStyle) }
+                ),
+                commentsByPacketID: Dictionary(
+                    uniqueKeysWithValues: exportSnapshot.packets.compactMap { packet in
+                        packet.resolvedComment.map { (packet.id, $0) }
+                    }
                 )
             ),
             progress: progress,
@@ -2163,11 +2210,15 @@ final class TCPViewerWorkspaceController {
             if groups.last?.fileID == reference.fileID {
                 groups[groups.count - 1].originalPacketIDs.append(reference.originalPacketID)
                 groups[groups.count - 1].textStylesByOriginalPacketID[reference.originalPacketID] = packet.resolvedTextStyle
+                groups[groups.count - 1].commentsByOriginalPacketID[reference.originalPacketID] = packet.resolvedComment
             } else {
                 groups.append(ImportedSessionCaptureExportGroup(
                     fileID: reference.fileID,
                     originalPacketIDs: [reference.originalPacketID],
-                    textStylesByOriginalPacketID: [reference.originalPacketID: packet.resolvedTextStyle]
+                    textStylesByOriginalPacketID: [reference.originalPacketID: packet.resolvedTextStyle],
+                    commentsByOriginalPacketID: packet.resolvedComment.map {
+                        [reference.originalPacketID: $0]
+                    } ?? [:]
                 ))
             }
         }
@@ -2262,7 +2313,10 @@ final class TCPViewerWorkspaceController {
             withIDs: group.originalPacketIDs,
             to: partURL,
             format: .pcapng,
-            metadata: PacketExportMetadata(textStylesByPacketID: group.textStylesByOriginalPacketID),
+            metadata: PacketExportMetadata(
+                textStylesByPacketID: group.textStylesByOriginalPacketID,
+                commentsByPacketID: group.commentsByOriginalPacketID
+            ),
             progress: groupProgress,
             shouldCancel: shouldCancel
         ) { [weak self] result in
@@ -2417,16 +2471,23 @@ final class TCPViewerWorkspaceController {
                 snapshot.documentState.statusMessage = "Exporting \(url.lastPathComponent)..."
                 let originalPacketIDs = importedReferences.map(\.originalPacketID)
                 var remappedStyles: [PacketSummary.ID: PacketTextStyle] = [:]
+                var remappedComments: [PacketSummary.ID: String] = [:]
                 for (identifier, reference) in zip(identifiers, importedReferences) {
                     if let style = metadata.textStylesByPacketID[identifier] {
                         remappedStyles[reference.originalPacketID] = style
+                    }
+                    if let comment = metadata.commentsByPacketID[identifier] {
+                        remappedComments[reference.originalPacketID] = comment
                     }
                 }
                 importedDocument.exportPackets(
                     withIDs: originalPacketIDs,
                     to: url,
                     format: format,
-                    metadata: PacketExportMetadata(textStylesByPacketID: remappedStyles),
+                    metadata: PacketExportMetadata(
+                        textStylesByPacketID: remappedStyles,
+                        commentsByPacketID: remappedComments
+                    ),
                     progress: progress,
                     shouldCancel: cancellationCheck
                 ) { [weak self] result in
@@ -2742,6 +2803,14 @@ final class TCPViewerWorkspaceController {
         }
 
         _ = snapshot.packetIngestState.applyTextStyleMutation(mutation, packetIDs: packetIDs)
+    }
+
+    // Apply a packet comment mutation on main so render snapshots stay consistent.
+    func setCustomComment(_ comment: String, packetIDs: Set<PacketSummary.ID>) {
+        guard !packetIDs.isEmpty else {
+            return
+        }
+        _ = snapshot.packetIngestState.setCustomComment(comment, packetIDs: packetIDs)
     }
 
     #if DEBUG

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -180,6 +180,8 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
     let interfaceText: String
     let lengthText: String
     let summaryText: String
+    let comment: String?
+    let commentText: String
     let tags: [PacketTag]
     let severity: PacketSeverity
     let textStyle: PacketTextStyle
@@ -235,6 +237,11 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
         self.interfaceText = (packet.captureMetadata.interfaceName ?? packet.interfaceID ?? "-").tcpviewerNativeCopy
         self.lengthText = NetworkInspectorFormatters.byteCount(packet.capturedLength)
         self.summaryText = packet.infoSummary.tcpviewerNativeCopy
+        self.comment = packet.resolvedComment?.tcpviewerNativeCopy
+        self.commentText = (packet.resolvedComment ?? "")
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .tcpviewerNativeCopy
         self.tags = NetworkInspectorFormatters.tags(for: packet)
         self.severity = NetworkInspectorFormatters.severity(for: packet)
         self.textStyle = packet.resolvedTextStyle
@@ -309,6 +316,8 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
             summaryText
         case .tags:
             tagText
+        case .comment:
+            commentText
         case .unknown:
             ""
         }

--- a/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketTableMenuModels.swift
@@ -30,6 +30,7 @@ enum PacketTableColumnRole: String, Equatable, Sendable {
     case length
     case summary
     case tags
+    case comment
     case unknown
 
     static let visibleColumnIdentifiers = PacketTableColumnService.defaultDefinitions
@@ -57,6 +58,10 @@ struct PacketTableMenuState: Equatable {
     let styleEnabled: Bool
     let exportEnabled: Bool
     let deleteEnabled: Bool
+
+    var commentEnabled: Bool {
+        !targetRows.isEmpty
+    }
 
     static let empty = PacketTableMenuState(
         targetRows: [],

--- a/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
@@ -753,7 +753,8 @@ extension PacketSummary {
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
             client: client,
-            textStyle: textStyle
+            textStyle: textStyle,
+            customComment: customComment
         )
     }
 
@@ -783,7 +784,8 @@ extension PacketSummary {
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName ?? self.sniDomainName,
             client: client ?? self.client,
-            textStyle: textStyle
+            textStyle: textStyle,
+            customComment: customComment
         )
     }
 
@@ -809,7 +811,8 @@ extension PacketSummary {
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
             client: client,
-            textStyle: textStyle
+            textStyle: textStyle,
+            customComment: customComment
         )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/PacketTableColumnService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketTableColumnService.swift
@@ -207,6 +207,7 @@ final class PacketTableColumnService {
         .builtIn(.length, title: "Length", defaultWidth: 80, minimumWidth: 68),
         .builtIn(.summary, title: "Summary", defaultWidth: 320, minimumWidth: 120),
         .builtIn(.tags, title: "Tags", defaultWidth: 140, minimumWidth: 90),
+        .builtIn(.comment, title: "Comment", defaultWidth: 320, minimumWidth: 140),
     ]
 
     private(set) var definitions: [PacketTableColumnDefinition]
@@ -251,7 +252,9 @@ final class PacketTableColumnService {
                 minimumWidth: column.minimumWidth
             )
         }
-        let nextDefinitions = Self.uniqueDefinitions(baseDefinitions + customDefinitions)
+        let commentDefinitions = baseDefinitions.filter { $0.role == .comment }
+        let regularDefinitions = baseDefinitions.filter { $0.role != .comment }
+        let nextDefinitions = Self.uniqueDefinitions(regularDefinitions + customDefinitions + commentDefinitions)
         var nextVisibility = Dictionary(
             uniqueKeysWithValues: nextDefinitions.map { definition in
                 (

--- a/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
@@ -118,6 +118,36 @@ final class SavedPacketService {
         return didChange
     }
 
+    // Persist one sanitized comment across the matching saved packet copies.
+    @discardableResult
+    func setCustomComment(_ comment: String, packetIDs: Set<PacketSummary.ID>) throws -> Bool {
+        let sanitizedComment = PacketComment.sanitized(comment)
+        guard !sanitizedComment.isEmpty else {
+            return false
+        }
+
+        let previousRecords = cachedRecords
+        var didChange = false
+        for index in cachedRecords.indices where packetIDs.contains(cachedRecords[index].packet.id) {
+            let packet = cachedRecords[index].packet
+            guard packet.customComment != sanitizedComment else {
+                continue
+            }
+            cachedRecords[index].packet = packet.applying(customComment: sanitizedComment)
+            didChange = true
+        }
+
+        if didChange {
+            do {
+                try persist()
+            } catch {
+                cachedRecords = previousRecords
+                throw error
+            }
+        }
+        return didChange
+    }
+
     private func persist() throws {
         guard !isDocumentScoped else {
             return

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionExportService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionExportService.swift
@@ -153,13 +153,15 @@ final class TCPViewSessionExportService: TCPViewSessionExportWriting {
         TCPViewSessionAnnotations(
             annotations: packets.compactMap { packet in
                 let textStyle = packet.resolvedTextStyle
-                guard packet.captureMetadata.packetComment != nil || !textStyle.isPlain else {
+                guard packet.captureMetadata.packetComment != nil ||
+                        packet.customComment != nil ||
+                        !textStyle.isPlain else {
                     return nil
                 }
                 return TCPViewSessionPacketAnnotation(
                     packetID: packet.id,
                     packetComment: packet.captureMetadata.packetComment,
-                    customComment: nil,
+                    customComment: packet.customComment,
                     colorHex: textStyle.highlightColor?.sessionColorHex,
                     textStyle: textStyle.isPlain ? nil : textStyle
                 )

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
@@ -536,7 +536,8 @@ extension PacketSummary {
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
             client: client,
-            textStyle: textStyle
+            textStyle: textStyle,
+            customComment: customComment
         )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionImportService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionImportService.swift
@@ -92,15 +92,17 @@ final class TCPViewSessionImportService {
                 clients: sidecars.clientStore,
                 packageDirectoryURL: packageDirectoryURL
             )
-            let annotationStyles = Dictionary(
-                uniqueKeysWithValues: sidecars.annotations.annotations.compactMap { annotation in
-                    annotation.textStyle.map { (annotation.packetID, $0) }
-                }
+            let annotationsByPacketID = Dictionary(
+                uniqueKeysWithValues: sidecars.annotations.annotations.map { ($0.packetID, $0) }
             )
             let packets = TCPViewSessionClientStoreBuilder
                 .rehydratePackets(records: sidecars.packetRecords, clients: sidecars.clientStore)
                 .map { packet in
-                    annotationStyles[packet.id].map(packet.applying(textStyle:)) ?? packet
+                    guard let annotation = annotationsByPacketID[packet.id] else {
+                        return packet
+                    }
+                    let styledPacket = annotation.textStyle.map(packet.applying(textStyle:)) ?? packet
+                    return annotation.customComment.map(styledPacket.applying(customComment:)) ?? styledPacket
                 }
             return TCPViewSessionPackageContents(
                 sourceURL: url,
@@ -284,9 +286,21 @@ final class TCPViewSessionImportService {
         validPacketIDs: Set<PacketSummary.ID>
     ) -> TCPViewSessionAnnotations {
         var seenPacketIDs = Set<PacketSummary.ID>()
-        let sanitized = annotations.annotations.filter { annotation in
-            validPacketIDs.contains(annotation.packetID) &&
-                seenPacketIDs.insert(annotation.packetID).inserted
+        let sanitized = annotations.annotations.compactMap { annotation -> TCPViewSessionPacketAnnotation? in
+            guard validPacketIDs.contains(annotation.packetID),
+                  seenPacketIDs.insert(annotation.packetID).inserted else {
+                return nil
+            }
+            let customComment = annotation.customComment
+                .map(PacketComment.sanitized)
+                .flatMap { $0.isEmpty ? nil : $0 }
+            return TCPViewSessionPacketAnnotation(
+                packetID: annotation.packetID,
+                packetComment: annotation.packetComment,
+                customComment: customComment,
+                colorHex: annotation.colorHex,
+                textStyle: annotation.textStyle
+            )
         }
         return TCPViewSessionAnnotations(annotations: sanitized)
     }
@@ -667,16 +681,23 @@ final class TCPViewSessionOfflineDocument: OfflineCaptureDocumentProviding {
         }
 
         var remappedStyles: [PacketSummary.ID: PacketTextStyle] = [:]
+        var remappedComments: [PacketSummary.ID: String] = [:]
         for (sessionID, innerID) in zip(identifiers, innerIDs) {
             if let style = metadata.textStylesByPacketID[sessionID] {
                 remappedStyles[innerID] = style
+            }
+            if let comment = metadata.commentsByPacketID[sessionID] {
+                remappedComments[innerID] = comment
             }
         }
         innerDocument.exportPackets(
             withIDs: innerIDs,
             to: url,
             format: format,
-            metadata: PacketExportMetadata(textStylesByPacketID: remappedStyles),
+            metadata: PacketExportMetadata(
+                textStylesByPacketID: remappedStyles,
+                commentsByPacketID: remappedComments
+            ),
             progress: progress,
             shouldCancel: shouldCancel,
             completion: completion

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1410,9 +1410,45 @@ final class NetworkInspectorViewModel {
             return
         }
 
+        let targets = packetAnnotationMutationTargets(for: packetIDs)
+
+        do {
+            _ = try savedPacketService.applyTextStyleMutation(mutation, packetIDs: targets.savedPacketIDs)
+        } catch {
+            packetExportService.presentFailure(error, title: "Style Update Failed")
+            return
+        }
+        controller.applyTextStyleMutation(mutation, packetIDs: targets.activePacketIDs)
+        rebuildSnapshot()
+    }
+
+    // Store one sanitized comment in both active and matching saved packet copies.
+    func setPacketComment(_ comment: String, onPackets identifiers: [PacketSummary.ID]) {
+        let sanitizedComment = PacketComment.sanitized(comment)
+        let packetIDs = Set(identifiers)
+        guard !sanitizedComment.isEmpty, !packetIDs.isEmpty else {
+            return
+        }
+
+        let targets = packetAnnotationMutationTargets(for: packetIDs)
+        do {
+            _ = try savedPacketService.setCustomComment(
+                sanitizedComment,
+                packetIDs: targets.savedPacketIDs
+            )
+        } catch {
+            packetExportService.presentFailure(error, title: "Comment Update Failed")
+            return
+        }
+        controller.setCustomComment(sanitizedComment, packetIDs: targets.activePacketIDs)
+        rebuildSnapshot()
+    }
+
+    private func packetAnnotationMutationTargets(
+        for packetIDs: Set<PacketSummary.ID>
+    ) -> (savedPacketIDs: Set<PacketSummary.ID>, activePacketIDs: Set<PacketSummary.ID>) {
         let ingestState = controller.snapshot.packetIngestState
-        let savedRecords = savedPacketService.records()
-        let matchingCurrentSavedIDs = Set(savedRecords.compactMap { record -> PacketSummary.ID? in
+        let matchingCurrentSavedIDs = Set(savedPacketService.records().compactMap { record -> PacketSummary.ID? in
             guard packetIDs.contains(record.packet.id),
                   record.backingIdentity == ingestState.backingIdentity,
                   let activePacket = ingestState.packet(withID: record.packet.id),
@@ -1421,17 +1457,10 @@ final class NetworkInspectorViewModel {
             }
             return record.packet.id
         })
-        let savedPacketIDs = selectedSourceListSelection == .saved ? packetIDs : matchingCurrentSavedIDs
-        let activePacketIDs = selectedSourceListSelection == .saved ? matchingCurrentSavedIDs : packetIDs
-
-        do {
-            _ = try savedPacketService.applyTextStyleMutation(mutation, packetIDs: savedPacketIDs)
-        } catch {
-            packetExportService.presentFailure(error, title: "Style Update Failed")
-            return
+        if selectedSourceListSelection == .saved {
+            return (packetIDs, matchingCurrentSavedIDs)
         }
-        controller.applyTextStyleMutation(mutation, packetIDs: activePacketIDs)
-        rebuildSnapshot()
+        return (matchingCurrentSavedIDs, packetIDs)
     }
 
     func deletePackets(_ identifiers: [PacketSummary.ID]) {
@@ -1625,13 +1654,18 @@ final class NetworkInspectorViewModel {
             }
         }
         var styles: [PacketSummary.ID: PacketTextStyle] = [:]
+        var comments: [PacketSummary.ID: String] = [:]
         styles.reserveCapacity(identifiers.count)
+        comments.reserveCapacity(identifiers.count)
         for identifier in identifiers {
             if let packet = savedPacketsByID[identifier] ?? ingestState.packet(withID: identifier) {
                 styles[identifier] = packet.resolvedTextStyle
+                if let comment = packet.resolvedComment {
+                    comments[identifier] = comment
+                }
             }
         }
-        return PacketExportMetadata(textStylesByPacketID: styles)
+        return PacketExportMetadata(textStylesByPacketID: styles, commentsByPacketID: comments)
     }
 
     private func validatedExportPacketIDs(

--- a/TCPViewer/Features/NetworkInspector/Views/PacketCommentSheetViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketCommentSheetViewController.swift
@@ -1,0 +1,198 @@
+//
+//  PacketCommentSheetViewController.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 26/7/26.
+//
+
+import AppKit
+import PcapPlusPlusCore
+
+final class PacketCommentSheetViewController: NSViewController, NSTextViewDelegate {
+    private enum Layout {
+        static let width: CGFloat = 520
+        static let horizontalPadding: CGFloat = 24
+        static let verticalPadding: CGFloat = 20
+        static let editorHeight: CGFloat = 170
+    }
+
+    private let initialComment: String
+    private let packetCount: Int
+    private let saveHandler: (String) -> Void
+    private let textView = NSTextView()
+    private let countLabel = NSTextField(labelWithString: "")
+    private let saveButton = NSButton(title: "Save", target: nil, action: nil)
+    private var sheetWindow: NSWindow?
+
+    init(
+        initialComment: String?,
+        packetCount: Int = 1,
+        saveHandler: @escaping (String) -> Void
+    ) {
+        self.initialComment = initialComment.map(PacketComment.sanitized) ?? ""
+        self.packetCount = max(1, packetCount)
+        self.saveHandler = saveHandler
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Build a compact AppKit sheet with a multiline editor and explicit actions.
+    override func loadView() {
+        let titleLabel = NSTextField(labelWithString: titleText)
+        titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize + 2, weight: .semibold)
+
+        let detailLabel = NSTextField(labelWithString: detailText)
+        detailLabel.textColor = .secondaryLabelColor
+
+        textView.delegate = self
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.allowsUndo = true
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.string = initialComment
+
+        let scrollView = NSScrollView()
+        scrollView.borderType = .bezelBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.documentView = textView
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        countLabel.alignment = .right
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+
+        let cancelButton = NSButton(title: "Cancel", target: self, action: #selector(cancel(_:)))
+        cancelButton.bezelStyle = .rounded
+        cancelButton.keyEquivalent = "\u{1b}"
+
+        saveButton.target = self
+        saveButton.action = #selector(save(_:))
+        saveButton.bezelStyle = .rounded
+        saveButton.bezelColor = .controlAccentColor
+        saveButton.contentTintColor = .alternateSelectedControlTextColor
+        saveButton.keyEquivalent = "\r"
+        saveButton.keyEquivalentModifierMask = .command
+
+        let buttons = NSStackView(views: [cancelButton, saveButton])
+        buttons.orientation = .horizontal
+        buttons.alignment = .centerY
+        buttons.spacing = 8
+
+        let footer = NSStackView(views: [countLabel, buttons])
+        footer.orientation = .horizontal
+        footer.alignment = .centerY
+        footer.distribution = .fill
+
+        let stackView = NSStackView(views: [titleLabel, detailLabel, scrollView, footer])
+        stackView.orientation = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = 8
+        stackView.setCustomSpacing(14, after: detailLabel)
+        stackView.setCustomSpacing(14, after: scrollView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let rootView = NSView()
+        rootView.addSubview(stackView)
+        view = rootView
+
+        NSLayoutConstraint.activate([
+            rootView.widthAnchor.constraint(equalToConstant: Layout.width),
+            stackView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor, constant: Layout.horizontalPadding),
+            stackView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor, constant: -Layout.horizontalPadding),
+            stackView.topAnchor.constraint(equalTo: rootView.topAnchor, constant: Layout.verticalPadding),
+            stackView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor, constant: -Layout.verticalPadding),
+            scrollView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: Layout.editorHeight),
+            footer.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+        ])
+
+        updateState()
+    }
+
+    // Attach the editor to the packet window and focus its multiline text view.
+    func show(attachedTo parentWindow: NSWindow?) {
+        loadViewIfNeeded()
+        let window = NSWindow(contentViewController: self)
+        window.styleMask = [.titled]
+        window.title = titleText
+        window.isReleasedWhenClosed = false
+        sheetWindow = window
+
+        if let parentWindow {
+            parentWindow.beginSheet(window)
+        } else {
+            window.makeKeyAndOrderFront(nil)
+        }
+        window.makeFirstResponder(textView)
+        textView.setSelectedRange(NSRange(location: textView.string.utf16.count, length: 0))
+    }
+
+    private var titleText: String {
+        if packetCount > 1 {
+            return "Add Comment to \(packetCount) Packets"
+        }
+        return initialComment.isEmpty ? "Add Comment" : "Edit Comment"
+    }
+
+    private var detailText: String {
+        packetCount > 1
+            ? "This comment will be applied to \(packetCount) selected packets."
+            : "Add a note for this packet."
+    }
+
+    func textView(
+        _ textView: NSTextView,
+        shouldChangeTextIn affectedCharRange: NSRange,
+        replacementString: String?
+    ) -> Bool {
+        // Enforce the same character limit before AppKit commits an edit.
+        let current = textView.string as NSString
+        let proposed = current.replacingCharacters(in: affectedCharRange, with: replacementString ?? "")
+        return proposed.count <= PacketComment.maximumCharacterCount
+    }
+
+    // Refresh the counter and Save availability after each text edit.
+    func textDidChange(_ notification: Notification) {
+        updateState()
+    }
+
+    // Keep the footer state in sync with the sanitized editor value.
+    private func updateState() {
+        countLabel.stringValue = "\(textView.string.count) / \(PacketComment.maximumCharacterCount)"
+        saveButton.isEnabled = !PacketComment.sanitized(textView.string).isEmpty
+    }
+
+    @objc private func cancel(_ sender: Any?) {
+        dismiss()
+    }
+
+    // Sanitize once more before forwarding the final comment.
+    @objc private func save(_ sender: Any?) {
+        let comment = PacketComment.sanitized(textView.string)
+        guard !comment.isEmpty else {
+            return
+        }
+        dismiss()
+        saveHandler(comment)
+    }
+
+    // Close either the attached sheet or a standalone fallback window.
+    private func dismiss() {
+        guard let sheetWindow else {
+            return
+        }
+        if let parentWindow = sheetWindow.sheetParent {
+            parentWindow.endSheet(sheetWindow)
+        } else {
+            sheetWindow.close()
+        }
+        self.sheetWindow = nil
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableCells.swift
@@ -354,24 +354,21 @@ final class PacketClientCell: NSTextFieldCell {
 private extension NSTextFieldCell {
     // Rebuild attributed text after fonts and colors are configured for a reused cell.
     func applyStrikethrough(_ isEnabled: Bool) {
-        guard isEnabled else {
-            attributedStringValue = NSAttributedString(
-                string: stringValue,
-                attributes: [
-                    .font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
-                    .foregroundColor: textColor ?? NSColor.labelColor,
-                ]
-            )
-            return
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = lineBreakMode
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
+            .foregroundColor: textColor ?? NSColor.labelColor,
+            // Keep AppKit on the same baseline layout path when text is truncated.
+            .paragraphStyle: paragraphStyle,
+        ]
+        if isEnabled {
+            attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
         }
 
         attributedStringValue = NSAttributedString(
             string: stringValue,
-            attributes: [
-                .font: font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize),
-                .foregroundColor: textColor ?? NSColor.labelColor,
-                .strikethroughStyle: NSUnderlineStyle.single.rawValue,
-            ]
+            attributes: attributes
         )
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
@@ -9,10 +9,10 @@ import AppKit
 import PcapPlusPlusCore
 
 enum PacketCommentShortcut {
-    static let keyEquivalent = "m"
-    static let modifierMask: NSEvent.ModifierFlags = [.command, .option]
+    static let keyEquivalent = "l"
+    static let modifierMask: NSEvent.ModifierFlags = [.command]
 
-    // Match only Option-Command-M while ignoring device-specific modifier flags.
+    // Match only Command-L while ignoring device-specific modifier flags.
     static func matches(_ event: NSEvent) -> Bool {
         let relevantFlags = event.modifierFlags.intersection([.command, .option, .shift, .control])
         return relevantFlags == modifierMask &&

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableContextMenuController.swift
@@ -8,6 +8,18 @@
 import AppKit
 import PcapPlusPlusCore
 
+enum PacketCommentShortcut {
+    static let keyEquivalent = "m"
+    static let modifierMask: NSEvent.ModifierFlags = [.command, .option]
+
+    // Match only Option-Command-M while ignoring device-specific modifier flags.
+    static func matches(_ event: NSEvent) -> Bool {
+        let relevantFlags = event.modifierFlags.intersection([.command, .option, .shift, .control])
+        return relevantFlags == modifierMask &&
+            event.charactersIgnoringModifiers?.lowercased() == keyEquivalent
+    }
+}
+
 @objc protocol PacketTableContextMenuActionHandling: AnyObject {
     func copyRowsFromMenu(_ sender: Any?)
     func copyRowsAsPlainTextFromMenu(_ sender: Any?)
@@ -18,6 +30,7 @@ import PcapPlusPlusCore
     func copyCellFromMenu(_ sender: Any?)
     func pinRowsFromMenu(_ sender: Any?)
     func saveRowsFromMenu(_ sender: Any?)
+    func addPacketCommentFromMenu(_ sender: Any?)
     func setPacketHighlightColorFromMenu(_ sender: Any?)
     func togglePacketStrikethroughFromMenu(_ sender: Any?)
     func resetPacketTextStyleFromMenu(_ sender: Any?)
@@ -78,6 +91,16 @@ final class PacketTableContextMenuController: NSObject {
         ))
 
         menu.addItem(.separator())
+        let commentItem = item(
+            title: "Add Comment…",
+            action: #selector(PacketTableContextMenuActionHandling.addPacketCommentFromMenu(_:)),
+            keyEquivalent: PacketCommentShortcut.keyEquivalent,
+            isEnabled: state.commentEnabled,
+            toolTip: "Add or edit comments for the targeted packets.",
+            systemSymbolName: "text.bubble"
+        )
+        commentItem.keyEquivalentModifierMask = PacketCommentShortcut.modifierMask
+        menu.addItem(commentItem)
         menu.addItem(highlightMenuItem(state: state))
 
         menu.addItem(.separator())

--- a/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketTableViewController.swift
@@ -18,6 +18,11 @@ protocol PacketTableViewControllerDelegate: AnyObject {
     func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
     func packetTableViewController(
         _ controller: PacketTableViewController,
+        didRequestSetComment comment: String,
+        onPackets identifiers: [PacketSummary.ID]
+    )
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
         didRequestApplyTextStyle mutation: PacketTextStyleMutation,
         toPackets identifiers: [PacketSummary.ID]
     )
@@ -60,6 +65,7 @@ enum PacketTableSelectionSyncPlanner {
 fileprivate protocol PacketTableKeyboardActionHandling: AnyObject {
     func packetTableViewDidRequestCopyRowsFromKeyboard(_ tableView: PacketTableView)
     func packetTableViewDidRequestDeleteFromKeyboard(_ tableView: PacketTableView)
+    func packetTableViewDidRequestAddCommentFromKeyboard(_ tableView: PacketTableView)
     func packetTableView(_ tableView: PacketTableView, didRequestTextStyle mutation: PacketTextStyleMutation)
 }
 
@@ -77,6 +83,10 @@ fileprivate final class PacketTableView: NSTableView {
 
     override func keyDown(with event: NSEvent) {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if PacketCommentShortcut.matches(event) {
+            keyboardActionHandler?.packetTableViewDidRequestAddCommentFromKeyboard(self)
+            return
+        }
         if flags.contains(.command), event.charactersIgnoringModifiers?.lowercased() == "c" {
             copy(nil)
             return
@@ -249,6 +259,7 @@ final class PacketTableViewController: NSViewController {
     private var pendingUserSelection: PendingUserSelection?
     private var clickedRowIndex: Int?
     private var clickedColumnIdentifier: String?
+    private var commentSheetController: PacketCommentSheetViewController?
     private var customColumnWorkQueue: [CustomColumnWorkItem] = []
     private var customColumnWorkQueueHeadIndex = 0
     private var queuedCustomColumnWorkKeys = Set<String>()
@@ -409,6 +420,7 @@ final class PacketTableViewController: NSViewController {
         tableView.autosaveName = Self.columnAutosaveName
         tableView.autosaveTableColumns = false
         restoreColumnLayout(restoredLayout)
+        moveCommentColumnToEnd()
         syncColumnVisibilityFromTable()
 
         scrollView.documentView = tableView
@@ -431,7 +443,9 @@ final class PacketTableViewController: NSViewController {
         column.title = definition.tableTitle
         column.width = CGFloat(definition.defaultWidth)
         column.minWidth = CGFloat(definition.minimumWidth)
-        column.resizingMask = .userResizingMask
+        column.resizingMask = definition.role == .comment
+            ? [.userResizingMask, .autoresizingMask]
+            : .userResizingMask
         column.dataCell = cell(for: definition.cellKind)
         column.isHidden = !columnService.isColumnVisible(identifier: definition.identifier)
         tableView.addTableColumn(column)
@@ -444,6 +458,17 @@ final class PacketTableViewController: NSViewController {
         }
 
         addColumn(definition)
+        moveCommentColumnToEnd()
+    }
+
+    // Keep Comment as the flexible trailing column after built-in and custom columns.
+    private func moveCommentColumnToEnd() {
+        guard let commentIndex = tableView.tableColumns.firstIndex(where: {
+            $0.identifier.rawValue == PacketTableColumnRole.comment.rawValue
+        }), commentIndex != tableView.tableColumns.count - 1 else {
+            return
+        }
+        tableView.moveColumn(commentIndex, toColumn: tableView.tableColumns.count - 1)
     }
 
     private func cell(for kind: PacketTableColumnCellKind) -> NSCell {
@@ -1024,6 +1049,31 @@ final class PacketTableViewController: NSViewController {
         delegate?.packetTableViewController(self, didRequestSavePackets: identifiers)
     }
 
+    @objc func addPacketCommentFromMenu(_ sender: Any?) {
+        let targetRows = targetRows()
+        guard !targetRows.isEmpty else {
+            return
+        }
+        let identifiers = targetRows.map(\.id)
+        let initialComment = targetRows.count == 1 ? targetRows[0].comment : nil
+
+        let sheet = PacketCommentSheetViewController(
+            initialComment: initialComment,
+            packetCount: targetRows.count
+        ) { [weak self] comment in
+            guard let self else {
+                return
+            }
+            self.delegate?.packetTableViewController(
+                self,
+                didRequestSetComment: comment,
+                onPackets: identifiers
+            )
+        }
+        commentSheetController = sheet
+        sheet.show(attachedTo: view.window)
+    }
+
     @objc func setPacketHighlightColorFromMenu(_ sender: Any?) {
         guard let menuItem = sender as? NSMenuItem,
               let rawValue = menuItem.representedObject as? String,
@@ -1147,6 +1197,15 @@ extension PacketTableViewController: NSTableViewDataSource, NSTableViewDelegate 
         saveColumnLayout()
     }
 
+    func tableView(_ tableView: NSTableView, shouldReorderColumn columnIndex: Int, toColumn newColumnIndex: Int) -> Bool {
+        guard let commentIndex = tableView.tableColumns.firstIndex(where: {
+            $0.identifier.rawValue == PacketTableColumnRole.comment.rawValue
+        }) else {
+            return true
+        }
+        return columnIndex != commentIndex && newColumnIndex < commentIndex
+    }
+
     func tableViewColumnDidResize(_ notification: Notification) {
         saveColumnLayout()
     }
@@ -1184,6 +1243,12 @@ extension PacketTableViewController: PacketTableKeyboardActionHandling {
         clickedRowIndex = nil
         clickedColumnIdentifier = nil
         deleteTargetRows()
+    }
+
+    fileprivate func packetTableViewDidRequestAddCommentFromKeyboard(_ tableView: PacketTableView) {
+        clickedRowIndex = nil
+        clickedColumnIdentifier = nil
+        addPacketCommentFromMenu(nil)
     }
 
     fileprivate func packetTableView(_ tableView: PacketTableView, didRequestTextStyle mutation: PacketTextStyleMutation) {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -17,6 +17,11 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewController(_ controller: PacketWorkspaceViewController, didRequestSavePackets identifiers: [PacketSummary.ID])
     func packetWorkspaceViewController(
         _ controller: PacketWorkspaceViewController,
+        didRequestSetComment comment: String,
+        onPackets identifiers: [PacketSummary.ID]
+    )
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
         didRequestApplyTextStyle mutation: PacketTextStyleMutation,
         toPackets identifiers: [PacketSummary.ID]
     )
@@ -385,6 +390,18 @@ extension PacketWorkspaceViewController: PacketTableViewControllerDelegate {
 
     func packetTableViewController(_ controller: PacketTableViewController, didRequestSavePackets identifiers: [PacketSummary.ID]) {
         delegate?.packetWorkspaceViewController(self, didRequestSavePackets: identifiers)
+    }
+
+    func packetTableViewController(
+        _ controller: PacketTableViewController,
+        didRequestSetComment comment: String,
+        onPackets identifiers: [PacketSummary.ID]
+    ) {
+        delegate?.packetWorkspaceViewController(
+            self,
+            didRequestSetComment: comment,
+            onPackets: identifiers
+        )
     }
 
     func packetTableViewController(

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -1295,6 +1295,14 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 
     func packetWorkspaceViewController(
         _ controller: PacketWorkspaceViewController,
+        didRequestSetComment comment: String,
+        onPackets identifiers: [PacketSummary.ID]
+    ) {
+        viewModel.setPacketComment(comment, onPackets: identifiers)
+    }
+
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
         didRequestApplyTextStyle mutation: PacketTextStyleMutation,
         toPackets identifiers: [PacketSummary.ID]
     ) {

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -1894,6 +1894,20 @@ struct PacketIngestStateMutationTests {
         #expect(state.packets[2].textStyle == nil)
     }
 
+    @Test func commentMutationUpdatesOnlyIndexedPackets() {
+        var state = PacketIngestState.empty
+        let packets = (1...3).map { makePacket(packetNumber: UInt64($0)) }
+        state.append(packets, source: .live)
+
+        let updatedIDs = state.setCustomComment("\n Review this packet \n", packetIDs: [1, 3, 99])
+
+        #expect(updatedIDs == [1, 3])
+        #expect(state.packets[0].customComment == "Review this packet")
+        #expect(state.packets[1].customComment == nil)
+        #expect(state.packets[2].customComment == "Review this packet")
+        #expect(state.lastMutation == .metadataUpdate(packetIDs: [1, 3]))
+    }
+
     private func makePacket(packetNumber: UInt64) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -2134,11 +2134,12 @@ struct NetworkInspectorViewModelTests {
         #expect(document.exportRequests.first?.2 == .pcapng)
     }
 
-    @Test func packetExportSnapshotsComposedTextStyles() async {
+    @Test func packetExportSnapshotsComposedTextStylesAndComment() async {
         let packet = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let secondPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .tcp)
         let document = InspectorFakeDocument(
             url: URL(fileURLWithPath: "/tmp/style-export-source.pcapng"),
-            packets: [packet]
+            packets: [packet, secondPacket]
         )
         let viewModel = NetworkInspectorViewModel(
             services: TCPViewerServiceRegistry(core: InspectorFakeCore(
@@ -2149,17 +2150,22 @@ struct NetworkInspectorViewModelTests {
         )
 
         await viewModel.openDocument(at: document.currentURL())
-        await waitUntil { viewModel.snapshot.packetRows.count == 1 }
+        await waitUntil { viewModel.snapshot.packetRows.count == 2 }
         viewModel.applyTextStyleMutation(.setHighlightColor(.purple), toPackets: [packet.id])
         viewModel.applyTextStyleMutation(.toggleStrikethrough, toPackets: [packet.id])
+        viewModel.setPacketComment(
+            "\n Review these packets \n",
+            onPackets: [packet.id, secondPacket.id]
+        )
 
         #expect(viewModel.snapshot.packetRows.first?.textStyle == PacketTextStyle(
             highlightColor: .purple,
             isStrikethrough: true
         ))
+        #expect(viewModel.snapshot.packetRows.map(\.comment) == ["Review these packets", "Review these packets"])
 
         let result = await viewModel.exportPackets(
-            [packet.id],
+            [packet.id, secondPacket.id],
             to: URL(fileURLWithPath: "/tmp/style-export.pcapng"),
             format: .pcapng
         )
@@ -2172,6 +2178,8 @@ struct NetworkInspectorViewModelTests {
             highlightColor: .purple,
             isStrikethrough: true
         ))
+        #expect(document.exportMetadataRequests.first?.commentsByPacketID[packet.id] == "Review these packets")
+        #expect(document.exportMetadataRequests.first?.commentsByPacketID[secondPacket.id] == "Review these packets")
     }
 
     @Test func clearTablePacketsRemovesOnlyVisibleRows() async {

--- a/TCPViewerTests/Features/NetworkInspector/PacketCommentSheetViewControllerTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCommentSheetViewControllerTests.swift
@@ -1,0 +1,72 @@
+//
+//  PacketCommentSheetViewControllerTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 26/7/26.
+//
+
+import AppKit
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct PacketCommentSheetViewControllerTests {
+    @MainActor
+    @Test func providesMultilineEditorAndProminentCommandReturnSave() throws {
+        var savedComment: String?
+        let controller = PacketCommentSheetViewController(initialComment: "Existing") {
+            savedComment = $0
+        }
+        controller.loadViewIfNeeded()
+
+        let textView = try #require(Self.descendants(of: controller.view).compactMap { $0 as? NSTextView }.first)
+        let buttons = Self.descendants(of: controller.view).compactMap { $0 as? NSButton }
+        let cancelButton = try #require(buttons.first { $0.title == "Cancel" })
+        let saveButton = try #require(buttons.first { $0.title == "Save" })
+
+        #expect(!textView.isRichText)
+        #expect(cancelButton.keyEquivalent == "\u{1b}")
+        #expect(saveButton.bezelColor == .controlAccentColor)
+        #expect(saveButton.keyEquivalent == "\r")
+        #expect(saveButton.keyEquivalentModifierMask == .command)
+
+        textView.string = "  First line\nSecond line  \n"
+        controller.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        saveButton.performClick(nil)
+        #expect(savedComment == "First line\nSecond line")
+    }
+
+    @MainActor
+    @Test func rejectsInputBeyondOneThousandCharacters() throws {
+        let controller = PacketCommentSheetViewController(initialComment: nil) { _ in }
+        controller.loadViewIfNeeded()
+        let textView = try #require(Self.descendants(of: controller.view).compactMap { $0 as? NSTextView }.first)
+
+        #expect(controller.textView(
+            textView,
+            shouldChangeTextIn: NSRange(location: 0, length: 0),
+            replacementString: "First line\nSecond line"
+        ))
+        #expect(!controller.textView(
+            textView,
+            shouldChangeTextIn: NSRange(location: 0, length: 0),
+            replacementString: String(repeating: "x", count: 1_001)
+        ))
+    }
+
+    @MainActor
+    @Test func multiplePacketModeExplainsThatEverySelectionWillChange() {
+        let controller = PacketCommentSheetViewController(initialComment: nil, packetCount: 3) { _ in }
+        controller.loadViewIfNeeded()
+        let labels = Self.descendants(of: controller.view)
+            .compactMap { ($0 as? NSTextField)?.stringValue }
+
+        #expect(labels.contains("Add Comment to 3 Packets"))
+        #expect(labels.contains("This comment will be applied to 3 selected packets."))
+    }
+
+    @MainActor
+    private static func descendants(of view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap(descendants(of:))
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableColumnServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableColumnServiceTests.swift
@@ -37,6 +37,7 @@ struct PacketTableColumnServiceTests {
             "length",
             "summary",
             "tags",
+            "comment",
         ])
         #expect(service.visibleColumnIdentifiers == PacketTableColumnRole.visibleColumnIdentifiers)
         #expect(service.menuEntries.filter { $0.isVisible }.map(\.identifier) == PacketTableColumnRole.visibleColumnIdentifiers)
@@ -87,9 +88,10 @@ struct PacketTableColumnServiceTests {
 
         service.setCustomColumns(customColumns)
 
-        #expect(service.definitions.suffix(2).map(\.identifier) == [
+        #expect(service.definitions.suffix(3).map(\.identifier) == [
             "custom.field.ip.src",
             "custom.field.tcp.srcport",
+            "comment",
         ])
         #expect(!service.isColumnVisible(identifier: "custom.field.ip.src"))
         #expect(service.setColumnVisibility(identifier: "custom.field.ip.src", isVisible: true))

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -34,6 +34,7 @@ struct PacketTableMenuLogicTests {
         #expect(state.pinEnabled)
         #expect(state.saveEnabled)
         #expect(state.styleEnabled)
+        #expect(state.commentEnabled)
         #expect(state.exportEnabled)
         #expect(state.deleteEnabled)
     }
@@ -54,6 +55,7 @@ struct PacketTableMenuLogicTests {
         #expect(state.targetRows == [1])
         #expect(state.clickedColumn == .source)
         #expect(state.pinEnabled)
+        #expect(state.commentEnabled)
         #expect(state.exportEnabled)
     }
 
@@ -93,6 +95,16 @@ struct PacketTableMenuLogicTests {
         10.0.0.1
         "Hello, world"
         """)
+    }
+
+    @Test func commentColumnFlattensMultilineTextForOneLineRendering() {
+        let row = PacketTableRow(packet: makePacket(
+            packetNumber: 1,
+            customComment: "First line\nSecond line"
+        ))
+
+        #expect(row.comment == "First line\nSecond line")
+        #expect(row.text(for: .comment) == "First line Second line")
     }
 
     @Test func copyFormatterSupportsRowsAsFormatsForMultipleSelections() throws {
@@ -238,7 +250,7 @@ struct PacketTableMenuLogicTests {
 
         #expect(customColumns.count == 1)
         #expect(!customColumn.isHidden)
-        #expect(tableView.tableColumns.last?.identifier.rawValue == "custom.field.ip.src")
+        #expect(tableView.tableColumns.suffix(2).map { $0.identifier.rawValue } == ["custom.field.ip.src", "comment"])
 
         let restoredController = PacketTableViewController(configuration: AppConfiguration(defaults: defaults))
         restoredController.loadViewIfNeeded()
@@ -247,7 +259,7 @@ struct PacketTableMenuLogicTests {
             withIdentifier: NSUserInterfaceItemIdentifier("custom.field.ip.src")
         ))
 
-        #expect(restoredTableView.tableColumns.last?.identifier.rawValue == "custom.field.ip.src")
+        #expect(restoredTableView.tableColumns.suffix(2).map { $0.identifier.rawValue } == ["custom.field.ip.src", "comment"])
         #expect(!restoredCustomColumn.isHidden)
 
         restoredController.resetPacketTableColumnsFromMenu(nil)
@@ -285,6 +297,7 @@ struct PacketTableMenuLogicTests {
         let copyRowsAsItem = try #require(menu.items.first { $0.title == "Copy Rows As" })
         let copyRowsAsSubmenu = try #require(copyRowsAsItem.submenu)
         let highlightItem = try #require(menu.items.first { $0.title == "Highlight" })
+        let commentItem = try #require(menu.items.first { $0.title == "Add Comment…" })
         let highlightSubmenu = try #require(highlightItem.submenu)
         let copyRowsAsTitles = copyRowsAsSubmenu.items.compactMap { item in
             item.isSeparatorItem ? nil : item.title
@@ -302,10 +315,43 @@ struct PacketTableMenuLogicTests {
         #expect(highlightSubmenu.items.first { $0.title == "Strikethrough" }?.keyEquivalent == "/")
         #expect(highlightSubmenu.items.first { $0.title == "Reset" }?.keyEquivalent == "0")
         #expect(menu.items.contains { $0.title == "Pin" && $0.submenu == nil })
+        #expect(commentItem.isEnabled)
+        #expect(commentItem.keyEquivalent == PacketCommentShortcut.keyEquivalent)
+        #expect(commentItem.keyEquivalentModifierMask == PacketCommentShortcut.modifierMask)
         let highlightIndex = try #require(menu.items.firstIndex(where: { $0.title == "Highlight" }))
-        #expect(highlightIndex > 0 && menu.items[highlightIndex - 1].isSeparatorItem)
+        #expect(highlightIndex > 0 && menu.items[highlightIndex - 1].title == "Add Comment…")
         #expect(!items.isEmpty)
         #expect(items.allSatisfy { item in item.toolTip?.isEmpty == false })
+    }
+
+    @Test func commentShortcutMatchesOnlyOptionCommandM() throws {
+        let matchingEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "m",
+            charactersIgnoringModifiers: "m",
+            isARepeat: false,
+            keyCode: 46
+        ))
+        let conflictingEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "M",
+            charactersIgnoringModifiers: "m",
+            isARepeat: false,
+            keyCode: 46
+        ))
+
+        #expect(PacketCommentShortcut.matches(matchingEvent))
+        #expect(!PacketCommentShortcut.matches(conflictingEvent))
     }
 
     @MainActor
@@ -396,7 +442,8 @@ struct PacketTableMenuLogicTests {
         packetNumber: UInt64,
         infoSummary: String? = nil,
         sniDomainName: String? = nil,
-        client: PacketClient? = nil
+        client: PacketClient? = nil,
+        customComment: String? = nil
     ) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,
@@ -416,7 +463,8 @@ struct PacketTableMenuLogicTests {
             decodeStatus: PacketDecodeStatus(kind: .complete),
             captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
             sniDomainName: sniDomainName,
-            client: client
+            client: client,
+            customComment: customComment
         )
     }
 
@@ -504,6 +552,7 @@ private final class MenuActionHandler: NSObject, PacketTableContextMenuActionHan
     func copyCellFromMenu(_ sender: Any?) {}
     func pinRowsFromMenu(_ sender: Any?) {}
     func saveRowsFromMenu(_ sender: Any?) {}
+    func addPacketCommentFromMenu(_ sender: Any?) {}
     func setPacketHighlightColorFromMenu(_ sender: Any?) {}
     func togglePacketStrikethroughFromMenu(_ sender: Any?) {}
     func resetPacketTextStyleFromMenu(_ sender: Any?) {}

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -324,11 +324,23 @@ struct PacketTableMenuLogicTests {
         #expect(items.allSatisfy { item in item.toolTip?.isEmpty == false })
     }
 
-    @Test func commentShortcutMatchesOnlyOptionCommandM() throws {
+    @Test func commentShortcutMatchesCommandLWithoutConflictingWithMinimize() throws {
         let matchingEvent = try #require(NSEvent.keyEvent(
             with: .keyDown,
             location: .zero,
-            modifierFlags: [.command, .option],
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "l",
+            charactersIgnoringModifiers: "l",
+            isARepeat: false,
+            keyCode: 37
+        ))
+        let minimizeEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
             timestamp: 0,
             windowNumber: 0,
             context: nil,
@@ -337,21 +349,9 @@ struct PacketTableMenuLogicTests {
             isARepeat: false,
             keyCode: 46
         ))
-        let conflictingEvent = try #require(NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: [.command, .shift],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            characters: "M",
-            charactersIgnoringModifiers: "m",
-            isARepeat: false,
-            keyCode: 46
-        ))
 
         #expect(PacketCommentShortcut.matches(matchingEvent))
-        #expect(!PacketCommentShortcut.matches(conflictingEvent))
+        #expect(!PacketCommentShortcut.matches(minimizeEvent))
     }
 
     @MainActor
@@ -366,6 +366,28 @@ struct PacketTableMenuLogicTests {
             )
             #expect(color.alphaComponent == 1)
         }
+    }
+
+    @MainActor
+    @Test func truncatedAttributedCellKeepsTheSameVerticalTextPosition() throws {
+        let configuration = AppConfiguration(defaults: Self.makeUserDefaults())
+        let cell = PacketTextCell()
+        cell.stringValue = "com.tinyspeck.slackmacgap.helper"
+        cell.configure(style: .secondary, textStyle: .plain, configuration: configuration)
+
+        let truncatedRows = try Self.occupiedTextRows(
+            in: cell,
+            width: 160,
+            height: Int(configuration.packetRowHeight)
+        )
+        let fullRows = try Self.occupiedTextRows(
+            in: cell,
+            width: 360,
+            height: Int(configuration.packetRowHeight)
+        )
+
+        #expect(!truncatedRows.isEmpty)
+        #expect(truncatedRows == fullRows)
     }
 
     @MainActor
@@ -490,6 +512,39 @@ struct PacketTableMenuLogicTests {
     private static func tableView(in controller: PacketTableViewController) throws -> NSTableView {
         let scrollView = try #require(controller.view as? NSScrollView)
         return try #require(scrollView.documentView as? NSTableView)
+    }
+
+    @MainActor
+    private static func occupiedTextRows(in cell: NSCell, width: Int, height: Int) throws -> IndexSet {
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ))
+        let context = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+        let frame = NSRect(x: 0, y: 0, width: width, height: height)
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        NSColor.clear.setFill()
+        frame.fill()
+        cell.draw(withFrame: frame, in: NSView(frame: frame))
+        context.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+
+        let prefixWidth = min(width, 80)
+        return IndexSet((0..<height).filter { y in
+            (0..<prefixWidth).contains { x in
+                (bitmap.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.1
+            }
+        })
     }
 
     @MainActor

--- a/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
@@ -91,6 +91,21 @@ struct SavedPacketServiceTests {
         #expect(service.records() == recordsBeforeMutation)
     }
 
+    @Test func commentMutationSanitizesAndPersistsForSavedPacketRows() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("Saved.json")
+        let service = SavedPacketService(storageURL: storageURL)
+        let first = makePacket(packetNumber: 1)
+        let second = makePacket(packetNumber: 2)
+        try service.save([first, second])
+
+        let didChange = try service.setCustomComment("\n First line\nSecond line \n", packetIDs: [first.id])
+        let reloaded = SavedPacketService(storageURL: storageURL)
+
+        #expect(didChange)
+        #expect(reloaded.records()[0].packet.customComment == "First line\nSecond line")
+        #expect(reloaded.records()[1].packet.customComment == nil)
+    }
+
     private func temporaryDirectory() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
@@ -160,7 +160,8 @@ struct TCPViewSessionFormatTests {
         let firstStyle = PacketTextStyle(highlightColor: .teal, isStrikethrough: true)
         let packets = [
             Self.makePacket(id: 10, packetNumber: 1, client: Self.client, packetComment: "first comment")
-                .applying(textStyle: firstStyle),
+                .applying(textStyle: firstStyle)
+                .applying(customComment: "TCP Viewer note\nSecond line"),
             Self.makePacket(id: 11, packetNumber: 2, client: Self.client),
         ]
         let snapshot = Self.makeSnapshot(
@@ -200,9 +201,11 @@ struct TCPViewSessionFormatTests {
         #expect(contents.clientStore.clients.count == 1)
         #expect(contents.packets.map(\.client) == [Self.client, Self.client])
         #expect(contents.annotations.annotations.first?.packetComment == "first comment")
+        #expect(contents.annotations.annotations.first?.customComment == "TCP Viewer note\nSecond line")
         #expect(contents.annotations.annotations.first?.colorHex == "#40C8E0")
         #expect(contents.annotations.annotations.first?.textStyle == firstStyle)
         #expect(contents.packets.map(\.resolvedTextStyle) == [firstStyle, .plain])
+        #expect(contents.packets.first?.customComment == "TCP Viewer note\nSecond line")
         #expect(contents.state.importedCaptureFiles.first?.displayName == "source.pcapng")
         #expect(jsonl.split(separator: "\n").count == packets.count)
         #expect(Self.zipPackageContainsRequiredFiles(contents.packageDirectoryURL))


### PR DESCRIPTION
## Summary
- Add sanitized custom comments to packet summaries and table metadata.
- Persist comments through session files and PCAP/PCAPNG extended attributes.
- Support comment editing, display, saved packets, imports, exports, and packet remapping.
- Add round-trip and byte-fidelity coverage for exported comments.

## Testing
- Added PcapPlusPlusCore tests for PCAP and PCAPNG comment round trips and canonical byte preservation.
- Not run (not requested).