### PR TITLE
Add passive DNS domain attribution

### DIFF
--- a/PcapPlusPlusCore/Dissection/DNSMessageParser.swift
+++ b/PcapPlusPlusCore/Dissection/DNSMessageParser.swift
@@ -1,0 +1,343 @@
+//
+//  DNSMessageParser.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Darwin
+import Foundation
+
+struct DNSMessageParser {
+    private static let maximumRecordCount = 64
+    private static let maximumResolutionCount = 32
+    private static let maximumNameJumps = 8
+    private static let maximumCNAMEHops = 8
+
+    private struct Question {
+        let name: String
+        let type: UInt16
+        let recordClass: UInt16
+    }
+
+    private struct AddressRecord {
+        let ownerName: String
+        let address: String
+        let timeToLive: UInt32
+    }
+
+    private struct CNAMERecord {
+        let targetName: String
+        let timeToLive: UInt32
+    }
+
+    private enum RecordData {
+        case address(String)
+        case cname(String)
+        case unsupported
+    }
+
+    private struct ResourceRecord {
+        let ownerName: String
+        let type: UInt16
+        let recordClass: UInt16
+        let timeToLive: UInt32
+        let data: RecordData
+    }
+
+    private struct ResolvedAddress {
+        let ownerName: String
+        let address: String
+        let timeToLive: UInt32
+    }
+
+    private let bytes: [UInt8]
+
+    init(data: Data) {
+        self.bytes = Array(data)
+    }
+
+    // Parse one complete DNS response into bounded hostname-to-address observations.
+    func resolutions() -> [DNSResolutionObservation] {
+        guard bytes.count >= 12,
+              let flags = readUInt16(at: 2),
+              flags & 0x8000 != 0,
+              flags & 0x0200 == 0,
+              flags & 0x000f == 0,
+              let questionCount = readUInt16(at: 4),
+              let answerCount = readUInt16(at: 6),
+              let authorityCount = readUInt16(at: 8),
+              let additionalCount = readUInt16(at: 10) else {
+            return []
+        }
+
+        let totalRecordCount = Int(answerCount) + Int(authorityCount) + Int(additionalCount)
+        guard Int(questionCount) <= Self.maximumRecordCount,
+              totalRecordCount <= Self.maximumRecordCount else {
+            return []
+        }
+
+        var cursor = 12
+        var questions: [Question] = []
+        questions.reserveCapacity(Int(questionCount))
+        for _ in 0..<questionCount {
+            guard let name = readName(cursor: &cursor),
+                  let type = readUInt16(at: cursor),
+                  let recordClass = readUInt16(at: cursor + 2) else {
+                return []
+            }
+            cursor += 4
+            questions.append(Question(name: name, type: type, recordClass: recordClass & 0x7fff))
+        }
+
+        var records: [ResourceRecord] = []
+        records.reserveCapacity(totalRecordCount)
+        for _ in 0..<totalRecordCount {
+            guard let record = readResourceRecord(cursor: &cursor) else {
+                return []
+            }
+            records.append(record)
+        }
+
+        return buildResolutions(questions: questions, records: records)
+    }
+
+    private func readResourceRecord(cursor: inout Int) -> ResourceRecord? {
+        guard let ownerName = readName(cursor: &cursor),
+              let type = readUInt16(at: cursor),
+              let recordClass = readUInt16(at: cursor + 2),
+              let timeToLive = readUInt32(at: cursor + 4),
+              let dataLength = readUInt16(at: cursor + 8) else {
+            return nil
+        }
+        cursor += 10
+        let dataStart = cursor
+        let dataEnd = dataStart + Int(dataLength)
+        guard dataEnd >= dataStart, dataEnd <= bytes.count else {
+            return nil
+        }
+
+        let data: RecordData
+        switch type {
+        case 1 where dataLength == 4:
+            data = .address(ipv4Address(at: dataStart) ?? "")
+        case 28 where dataLength == 16:
+            data = .address(ipv6Address(at: dataStart) ?? "")
+        case 5:
+            var nameCursor = dataStart
+            if let name = readName(cursor: &nameCursor), nameCursor <= dataEnd {
+                data = .cname(name)
+            } else {
+                return nil
+            }
+        default:
+            data = .unsupported
+        }
+        cursor = dataEnd
+
+        if case .address(let address) = data, address.isEmpty {
+            return nil
+        }
+        return ResourceRecord(
+            ownerName: ownerName,
+            type: type,
+            recordClass: recordClass & 0x7fff,
+            timeToLive: timeToLive,
+            data: data
+        )
+    }
+
+    private func buildResolutions(questions: [Question], records: [ResourceRecord]) -> [DNSResolutionObservation] {
+        var addressesByOwner: [String: [AddressRecord]] = [:]
+        var cnameByOwner: [String: CNAMERecord] = [:]
+
+        for record in records where record.recordClass == 1 {
+            switch record.data {
+            case .address(let address) where record.type == 1 || record.type == 28:
+                addressesByOwner[record.ownerName, default: []].append(AddressRecord(
+                    ownerName: record.ownerName,
+                    address: address,
+                    timeToLive: record.timeToLive
+                ))
+            case .cname(let targetName):
+                cnameByOwner[record.ownerName] = CNAMERecord(
+                    targetName: targetName,
+                    timeToLive: record.timeToLive
+                )
+            default:
+                continue
+            }
+        }
+
+        var output: [DNSResolutionObservation] = []
+        var emittedKeys: Set<String> = []
+        var usedAddressKeys: Set<String> = []
+
+        for question in questions where question.recordClass == 1 && (question.type == 1 || question.type == 28) {
+            let resolved = resolve(
+                name: question.name,
+                inheritedTTL: UInt32.max,
+                addressesByOwner: addressesByOwner,
+                cnameByOwner: cnameByOwner,
+                visited: []
+            )
+            for address in resolved {
+                let emittedKey = "\(question.name)|\(address.address)"
+                guard emittedKeys.insert(emittedKey).inserted else { continue }
+                output.append(DNSResolutionObservation(
+                    domainName: question.name,
+                    ipAddress: address.address,
+                    timeToLive: address.timeToLive
+                ))
+                usedAddressKeys.insert("\(address.ownerName)|\(address.address)")
+                if output.count == Self.maximumResolutionCount {
+                    return output
+                }
+            }
+        }
+
+        // Responses normally repeat the question. Retain useful owner names when they do not.
+        for record in records where record.recordClass == 1 {
+            guard case .address(let address) = record.data else { continue }
+            let addressKey = "\(record.ownerName)|\(address)"
+            guard !usedAddressKeys.contains(addressKey),
+                  emittedKeys.insert(addressKey).inserted else { continue }
+            output.append(DNSResolutionObservation(
+                domainName: record.ownerName,
+                ipAddress: address,
+                timeToLive: record.timeToLive
+            ))
+            if output.count == Self.maximumResolutionCount {
+                return output
+            }
+        }
+        return output
+    }
+
+    private func resolve(
+        name: String,
+        inheritedTTL: UInt32,
+        addressesByOwner: [String: [AddressRecord]],
+        cnameByOwner: [String: CNAMERecord],
+        visited: Set<String>
+    ) -> [ResolvedAddress] {
+        guard visited.count < Self.maximumCNAMEHops, !visited.contains(name) else {
+            return []
+        }
+
+        if let addresses = addressesByOwner[name], !addresses.isEmpty {
+            return addresses.map {
+                ResolvedAddress(
+                    ownerName: $0.ownerName,
+                    address: $0.address,
+                    timeToLive: min(inheritedTTL, $0.timeToLive)
+                )
+            }
+        }
+
+        guard let cname = cnameByOwner[name] else {
+            return []
+        }
+        var nextVisited = visited
+        nextVisited.insert(name)
+        return resolve(
+            name: cname.targetName,
+            inheritedTTL: min(inheritedTTL, cname.timeToLive),
+            addressesByOwner: addressesByOwner,
+            cnameByOwner: cnameByOwner,
+            visited: nextVisited
+        )
+    }
+
+    private func readName(cursor: inout Int) -> String? {
+        let originalCursor = cursor
+        var readCursor = cursor
+        var nextCursor: Int?
+        var labels: [String] = []
+        var visitedPointers: Set<Int> = []
+        var jumpCount = 0
+        var renderedLength = 0
+
+        // Pointer and length limits prevent malformed captures from looping or expanding forever.
+        while readCursor < bytes.count {
+            let length = bytes[readCursor]
+            if length == 0 {
+                cursor = nextCursor ?? (readCursor + 1)
+                return normalizedName(labels.joined(separator: "."))
+            }
+
+            if length & 0xc0 == 0xc0 {
+                guard readCursor + 1 < bytes.count, jumpCount < Self.maximumNameJumps else {
+                    return nil
+                }
+                let pointer = Int(length & 0x3f) << 8 | Int(bytes[readCursor + 1])
+                guard pointer < bytes.count, visitedPointers.insert(pointer).inserted else {
+                    return nil
+                }
+                nextCursor = nextCursor ?? (readCursor + 2)
+                readCursor = pointer
+                jumpCount += 1
+                continue
+            }
+
+            guard length & 0xc0 == 0, length <= 63 else {
+                return nil
+            }
+            readCursor += 1
+            let labelEnd = readCursor + Int(length)
+            guard labelEnd <= bytes.count,
+                  let label = String(bytes: bytes[readCursor..<labelEnd], encoding: .utf8),
+                  !label.isEmpty,
+                  label.unicodeScalars.allSatisfy({
+                      $0.value > 0x20 && $0.value < 0x7f && $0.value != 0x2e
+                  }) else {
+                return nil
+            }
+            renderedLength += label.utf8.count + (labels.isEmpty ? 0 : 1)
+            guard renderedLength <= 253 else {
+                return nil
+            }
+            labels.append(label)
+            readCursor = labelEnd
+        }
+
+        cursor = originalCursor
+        return nil
+    }
+
+    private func normalizedName(_ value: String) -> String? {
+        let normalized = value.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+        return normalized.isEmpty || normalized.utf8.count > 253 ? nil : normalized
+    }
+
+    private func readUInt16(at offset: Int) -> UInt16? {
+        guard offset >= 0, offset + 2 <= bytes.count else { return nil }
+        return UInt16(bytes[offset]) << 8 | UInt16(bytes[offset + 1])
+    }
+
+    private func readUInt32(at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= bytes.count else { return nil }
+        return UInt32(bytes[offset]) << 24 |
+            UInt32(bytes[offset + 1]) << 16 |
+            UInt32(bytes[offset + 2]) << 8 |
+            UInt32(bytes[offset + 3])
+    }
+
+    private func ipv4Address(at offset: Int) -> String? {
+        guard offset >= 0, offset + 4 <= bytes.count else { return nil }
+        return "\(bytes[offset]).\(bytes[offset + 1]).\(bytes[offset + 2]).\(bytes[offset + 3])"
+    }
+
+    private func ipv6Address(at offset: Int) -> String? {
+        guard offset >= 0, offset + 16 <= bytes.count else { return nil }
+        var address = in6_addr()
+        withUnsafeMutableBytes(of: &address) { destination in
+            destination.copyBytes(from: bytes[offset..<(offset + 16)])
+        }
+        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET6, &address, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+            return nil
+        }
+        return String(cString: buffer)
+    }
+}

--- a/PcapPlusPlusCore/Dissection/DNSTCPStreamParser.swift
+++ b/PcapPlusPlusCore/Dissection/DNSTCPStreamParser.swift
@@ -1,0 +1,175 @@
+//
+//  DNSTCPStreamParser.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Foundation
+
+struct DNSTCPStreamSegment {
+    let payloadSequenceNumber: UInt32
+    let payload: [UInt8]
+    let resetsStream: Bool
+    let endsStream: Bool
+}
+
+struct DNSTCPStreamParser {
+    private static let maximumMessageLength = Int(UInt16.max)
+    private static let maximumMessagesPerPacket = 32
+    private static let maximumObservationsPerPacket = 64
+
+    private struct StreamKey: Hashable {
+        let sourceAddress: String
+        let sourcePort: UInt16
+        let destinationAddress: String
+        let destinationPort: UInt16
+    }
+
+    private struct StreamState {
+        var nextSequenceNumber: UInt32
+        var bufferedBytes: [UInt8]
+        var lastObservedAt: Date
+    }
+
+    private let maximumStreamCount: Int
+    private let idleTimeout: TimeInterval
+    private var streams: [StreamKey: StreamState] = [:]
+
+    // Configure small per-session bounds because DNS/TCP is uncommon but capture input is untrusted.
+    init(maximumStreamCount: Int = 256, idleTimeout: TimeInterval = 120) {
+        self.maximumStreamCount = max(maximumStreamCount, 1)
+        self.idleTimeout = max(idleTimeout, 0)
+    }
+
+    // Parse every complete length-prefixed DNS message in one TCP payload.
+    static func resolutions(inCompletePayload payload: [UInt8]) -> [DNSResolutionObservation] {
+        var bufferedBytes = payload
+        return drainCompleteMessages(from: &bufferedBytes)
+    }
+
+    // Reassemble sequential DNS/TCP payload bytes and return observations on the completing packet.
+    mutating func resolutions(for packet: AnalyzedPacket, at timestamp: Date) -> [DNSResolutionObservation] {
+        guard let segment = packet.dnsTCPStreamSegment,
+              let sourceAddress = packet.sourceAddress,
+              let sourcePort = packet.sourcePort,
+              let destinationAddress = packet.destinationAddress,
+              let destinationPort = packet.destinationPort else {
+            return []
+        }
+
+        let key = StreamKey(
+            sourceAddress: sourceAddress,
+            sourcePort: sourcePort,
+            destinationAddress: destinationAddress,
+            destinationPort: destinationPort
+        )
+        if segment.resetsStream {
+            streams.removeValue(forKey: key)
+            return []
+        }
+
+        guard !segment.payload.isEmpty else {
+            if segment.endsStream {
+                streams.removeValue(forKey: key)
+            }
+            return []
+        }
+
+        var state = streams.removeValue(forKey: key)
+        if let lastObservedAt = state?.lastObservedAt {
+            let age = timestamp.timeIntervalSince(lastObservedAt)
+            if age > idleTimeout {
+                state = nil
+            }
+        }
+        if state == nil {
+            evictStreamIfNeeded()
+            state = StreamState(
+                nextSequenceNumber: segment.payloadSequenceNumber,
+                bufferedBytes: [],
+                lastObservedAt: timestamp
+            )
+        }
+
+        guard var current = state else {
+            return []
+        }
+        let relativeSequence = Int64(Int32(bitPattern: segment.payloadSequenceNumber &- current.nextSequenceNumber))
+        if relativeSequence > 0 {
+            // A capture gap loses the framing boundary, so restart from the newest segment instead of mixing bytes.
+            current.bufferedBytes.removeAll(keepingCapacity: true)
+            current.nextSequenceNumber = segment.payloadSequenceNumber
+        }
+
+        let repeatedByteCount = relativeSequence < 0 ? Int(min(-relativeSequence, Int64(segment.payload.count))) : 0
+        let newBytes = segment.payload.dropFirst(repeatedByteCount)
+        guard newBytes.count <= Self.maximumMessageLength + 2 else {
+            return []
+        }
+        current.bufferedBytes.append(contentsOf: newBytes)
+        current.nextSequenceNumber = current.nextSequenceNumber &+ UInt32(newBytes.count)
+        current.lastObservedAt = timestamp
+
+        let observations = Self.drainCompleteMessages(from: &current.bufferedBytes)
+        if current.bufferedBytes.count > Self.maximumMessageLength + 2 {
+            current.bufferedBytes.removeAll(keepingCapacity: false)
+        }
+        if segment.endsStream {
+            streams.removeValue(forKey: key)
+        } else {
+            streams[key] = current
+        }
+        return observations
+    }
+
+    // Drop all partial streams when a capture lineage is cleared.
+    mutating func reset() {
+        streams.removeAll(keepingCapacity: false)
+    }
+
+    // Consume complete frames once so repeated Data removals cannot amplify work on hostile payloads.
+    private static func drainCompleteMessages(from bufferedBytes: inout [UInt8]) -> [DNSResolutionObservation] {
+        var observations: [DNSResolutionObservation] = []
+        var seen: Set<DNSResolutionObservation> = []
+        var cursor = 0
+        var messageCount = 0
+
+        while cursor + 2 <= bufferedBytes.count, messageCount < maximumMessagesPerPacket {
+            let messageLength = Int(UInt16(bufferedBytes[cursor]) << 8 | UInt16(bufferedBytes[cursor + 1]))
+            if messageLength == 0 {
+                cursor += 2
+                messageCount += 1
+                continue
+            }
+            let messageEnd = cursor + 2 + messageLength
+            guard messageEnd <= bufferedBytes.count else {
+                break
+            }
+
+            let message = Data(bufferedBytes[(cursor + 2)..<messageEnd])
+            for observation in DNSMessageParser(data: message).resolutions()
+            where observations.count < maximumObservationsPerPacket && seen.insert(observation).inserted {
+                observations.append(observation)
+            }
+            cursor = messageEnd
+            messageCount += 1
+        }
+
+        if cursor > 0 {
+            bufferedBytes.removeFirst(cursor)
+        }
+        if messageCount == maximumMessagesPerPacket || observations.count == maximumObservationsPerPacket {
+            bufferedBytes.removeAll(keepingCapacity: false)
+        }
+        return observations
+    }
+
+    // Evict one bounded slot in average O(1); idle validation separately protects tuple reuse.
+    private mutating func evictStreamIfNeeded() {
+        guard streams.count >= maximumStreamCount, let streamToEvict = streams.keys.first else {
+            return
+        }
+        streams.removeValue(forKey: streamToEvict)
+    }
+}

--- a/PcapPlusPlusCore/Dissection/SwiftPacketDissector.swift
+++ b/PcapPlusPlusCore/Dissection/SwiftPacketDissector.swift
@@ -105,10 +105,15 @@ enum SwiftPacketDissector {
     private static let wiresharkWarningLogLock = NSLock()
     private static var loggedWiresharkWarningKeys: Set<String> = []
 
-    static func dissect(record: NativePacketRecord, disablesWireshark: Bool) -> SwiftPacketDissection {
+    static func dissect(
+        record: NativePacketRecord,
+        disablesWireshark: Bool,
+        analyzedPacket: AnalyzedPacket? = nil
+    ) -> SwiftPacketDissection {
         dissect(
             record: record,
             disablesWireshark: disablesWireshark,
+            analyzedPacket: analyzedPacket,
             wiresharkRuntimeStatus: SwiftWiresharkRuntimeStatus(
                 isAvailable: false,
                 unavailableReason: "Wireshark libwireshark backend is unavailable."
@@ -120,11 +125,11 @@ enum SwiftPacketDissector {
     static func dissect(
         record: NativePacketRecord,
         disablesWireshark: Bool,
+        analyzedPacket: AnalyzedPacket? = nil,
         wiresharkRuntimeStatus: SwiftWiresharkRuntimeStatus,
         logger: SwiftWiresharkConsoleLogger = SwiftWiresharkConsoleLogger()
     ) -> SwiftPacketDissection {
-        let analyzer = PacketAnalyzer(record: record)
-        let packet = analyzer.analyze()
+        let packet = analyzedPacket ?? PacketAnalyzer(record: record).analyze()
         var nodes = packet.detailNodes
         if disablesWireshark {
             let reason = "Wireshark libwireshark backend is disabled for this capture."
@@ -250,6 +255,7 @@ struct AnalyzedPacket {
     var streamID: UInt32?
     var tcpFlags: String?
     var tcpPayloadLength: Int?
+    var dnsTCPStreamSegment: DNSTCPStreamSegment?
     var sniDomainName: String?
     var dnsResolutions: [DNSResolutionObservation] = []
     var layers: [PacketLayer] = []
@@ -569,13 +575,32 @@ final class PacketAnalyzer {
         packet.layers = inheritedLayers + [PacketLayer(name: "TCP", detailSummary: packet.infoSummary)]
         packet.detailNodes = inheritedNodes + [tcpNode]
 
+        let isPlaintextDNS = sourcePort == 53 || destinationPort == 53
+        if isPlaintextDNS {
+            let sequenceNumber = readUInt32BE(at: offset + 4) ?? 0
+            packet.dnsTCPStreamSegment = DNSTCPStreamSegment(
+                payloadSequenceNumber: sequenceNumber &+ (flagsValue & 0x0002 != 0 ? 1 : 0),
+                payload: [],
+                resetsStream: flagsValue & 0x0006 != 0,
+                endsStream: flagsValue & 0x0001 != 0
+            )
+        }
+
         guard payloadLength > 0, payloadOffset <= bytes.count else {
             return packet
         }
 
         let payload = Array(bytes[payloadOffset..<min(bytes.count, payloadOffset + payloadLength)])
+        if let segment = packet.dnsTCPStreamSegment {
+            packet.dnsTCPStreamSegment = DNSTCPStreamSegment(
+                payloadSequenceNumber: segment.payloadSequenceNumber,
+                payload: payload,
+                resetsStream: segment.resetsStream,
+                endsStream: segment.endsStream
+            )
+        }
         // Only port 53 is plaintext DNS; DoT/DoH payloads must remain opaque without decryption.
-        if sourcePort == 53 || destinationPort == 53,
+        if isPlaintextDNS,
            payload.count >= 2 {
             let messageLength = Int(UInt16(payload[0]) << 8 | UInt16(payload[1]))
             if messageLength > 0,
@@ -584,9 +609,7 @@ final class PacketAnalyzer {
                 packet.transportHint = .dns
                 packet.protocolSummary = "DNS"
                 packet.infoSummary = dns.summary
-                packet.dnsResolutions = DNSMessageParser(
-                    data: Data(payload[2..<(messageLength + 2)])
-                ).resolutions()
+                packet.dnsResolutions = DNSTCPStreamParser.resolutions(inCompletePayload: payload)
                 packet.layers.append(PacketLayer(name: "DNS", detailSummary: dns.summary))
                 packet.detailNodes.append(dns.node)
                 return packet

--- a/PcapPlusPlusCore/Dissection/SwiftPacketDissector.swift
+++ b/PcapPlusPlusCore/Dissection/SwiftPacketDissector.swift
@@ -166,6 +166,7 @@ enum SwiftPacketDissector {
             decodeStatus: decodeDescriptor,
             captureMetadata: captureMetadata,
             sniDomainName: packet.sniDomainName,
+            dnsResolutions: packet.dnsResolutions,
             textStyle: record.textStyle
         )
         let inspection = PCPPNativePacketInspectionDescriptor(
@@ -250,6 +251,7 @@ struct AnalyzedPacket {
     var tcpFlags: String?
     var tcpPayloadLength: Int?
     var sniDomainName: String?
+    var dnsResolutions: [DNSResolutionObservation] = []
     var layers: [PacketLayer] = []
     var detailNodes: [PacketDetailNode] = []
     var decodeStatus = PacketDecodeStatus(kind: .complete)
@@ -572,6 +574,25 @@ final class PacketAnalyzer {
         }
 
         let payload = Array(bytes[payloadOffset..<min(bytes.count, payloadOffset + payloadLength)])
+        // Only port 53 is plaintext DNS; DoT/DoH payloads must remain opaque without decryption.
+        if sourcePort == 53 || destinationPort == 53,
+           payload.count >= 2 {
+            let messageLength = Int(UInt16(payload[0]) << 8 | UInt16(payload[1]))
+            if messageLength > 0,
+               payload.count >= messageLength + 2,
+               let dns = dnsNode(offset: payloadOffset + 2, length: messageLength) {
+                packet.transportHint = .dns
+                packet.protocolSummary = "DNS"
+                packet.infoSummary = dns.summary
+                packet.dnsResolutions = DNSMessageParser(
+                    data: Data(payload[2..<(messageLength + 2)])
+                ).resolutions()
+                packet.layers.append(PacketLayer(name: "DNS", detailSummary: dns.summary))
+                packet.detailNodes.append(dns.node)
+                return packet
+            }
+        }
+
         if let tls = tlsNode(payload: payload, offset: payloadOffset) {
             let versionName = tls.layerName
             packet.transportHint = .tls
@@ -646,10 +667,15 @@ final class PacketAnalyzer {
         packet.layers = inheritedLayers + [PacketLayer(name: "UDP", detailSummary: packet.infoSummary)]
         packet.detailNodes = inheritedNodes + [udpNode]
 
+        // Only port 53 is plaintext DNS; encrypted DNS bytes must never become false cache evidence.
         if sourcePort == 53 || destinationPort == 53, let dns = dnsNode(offset: payloadOffset, length: payloadLength) {
             packet.transportHint = .dns
             packet.protocolSummary = "DNS"
             packet.infoSummary = dns.summary
+            let dnsEnd = min(bytes.count, payloadOffset + payloadLength)
+            packet.dnsResolutions = DNSMessageParser(
+                data: Data(bytes[payloadOffset..<dnsEnd])
+            ).resolutions()
             packet.layers.append(PacketLayer(name: "DNS", detailSummary: dns.summary))
             packet.detailNodes.append(dns.node)
         } else if payloadLength > 0 {
@@ -1144,12 +1170,19 @@ final class PacketAnalyzer {
                 break
             }
             let type = readUInt16BE(at: cursor) ?? 0
+            let timeToLive = readUInt32BE(at: cursor + 4) ?? 0
             let dataLength = Int(readUInt16BE(at: cursor + 8) ?? 0)
             let dataOffset = cursor + 10
             children.append(field(id: "dns.answer.\(answerIndex).name", name: "Name", fieldName: "dns.resp.name", value: parsedName.name, offset: parsedName.rangeOffset, length: parsedName.rangeLength))
             children.append(field(id: "dns.answer.\(answerIndex).type", name: "Type", fieldName: "dns.resp.type", value: dnsTypeName(type), offset: cursor, length: 2))
+            children.append(field(id: "dns.answer.\(answerIndex).ttl", name: "Time to live", fieldName: "dns.resp.ttl", value: "\(timeToLive)", offset: cursor + 4, length: 4))
             if type == 1, dataLength == 4, bytes.count >= dataOffset + 4 {
                 children.append(field(id: "dns.answer.\(answerIndex).data", name: "Address", fieldName: "dns.a", value: ipv4Address(at: dataOffset), offset: dataOffset, length: 4))
+            } else if type == 28, dataLength == 16, bytes.count >= dataOffset + 16 {
+                children.append(field(id: "dns.answer.\(answerIndex).data", name: "AAAA Address", fieldName: "dns.aaaa", value: ipv6Address(at: dataOffset), offset: dataOffset, length: 16))
+            } else if type == 5,
+                      let cname = dnsName(at: dataOffset, packetStart: offset) {
+                children.append(field(id: "dns.answer.\(answerIndex).data", name: "Canonical name", fieldName: "dns.cname", value: cname.name, offset: cname.rangeOffset, length: cname.rangeLength))
             } else {
                 children.append(field(id: "dns.answer.\(answerIndex).data", name: "RDATA", fieldName: "dns.resp.data", value: hexBytes(offset: dataOffset, length: min(dataLength, bytes.count - dataOffset)), offset: dataOffset, length: min(dataLength, bytes.count - dataOffset)))
             }

--- a/PcapPlusPlusCore/Models/PacketModels.swift
+++ b/PcapPlusPlusCore/Models/PacketModels.swift
@@ -292,6 +292,23 @@ public struct PacketClient: Sendable, Codable, Hashable {
     }
 }
 
+public struct DNSResolutionObservation: Sendable, Codable, Hashable {
+    public let domainName: String
+    public let ipAddress: String
+    public let timeToLive: UInt32
+
+    public init(domainName: String, ipAddress: String, timeToLive: UInt32) {
+        self.domainName = domainName
+        self.ipAddress = ipAddress
+        self.timeToLive = timeToLive
+    }
+}
+
+public enum PacketDomainSource: String, Sendable, Codable, Hashable {
+    case sni
+    case dns
+}
+
 public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
     public let id: UInt64
     public let packetNumber: UInt64
@@ -312,6 +329,8 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
     public let decodeStatus: PacketDecodeStatus
     public let captureMetadata: PacketCaptureMetadata
     public let sniDomainName: String?
+    public let dnsDomainName: String?
+    public let dnsResolutions: [DNSResolutionObservation]?
     public let client: PacketClient?
     public let textStyle: PacketTextStyle?
     public let customComment: String?
@@ -336,6 +355,8 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
         decodeStatus: PacketDecodeStatus,
         captureMetadata: PacketCaptureMetadata,
         sniDomainName: String? = nil,
+        dnsDomainName: String? = nil,
+        dnsResolutions: [DNSResolutionObservation]? = nil,
         client: PacketClient? = nil,
         textStyle: PacketTextStyle? = nil,
         customComment: String? = nil
@@ -359,6 +380,8 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
         self.decodeStatus = decodeStatus
         self.captureMetadata = captureMetadata
         self.sniDomainName = sniDomainName
+        self.dnsDomainName = dnsDomainName
+        self.dnsResolutions = dnsResolutions?.isEmpty == true ? nil : dnsResolutions
         self.client = client
         self.textStyle = textStyle?.isPlain == true ? nil : textStyle
         let sanitizedComment = customComment.map(PacketComment.sanitized)
@@ -371,6 +394,27 @@ public struct PacketSummary: Identifiable, Sendable, Codable, Hashable {
 
     public var resolvedComment: String? {
         customComment ?? captureMetadata.packetComment
+    }
+
+    public var domainName: String? {
+        Self.normalizedDomain(sniDomainName) ?? Self.normalizedDomain(dnsDomainName)
+    }
+
+    public var domainSource: PacketDomainSource? {
+        if Self.normalizedDomain(sniDomainName) != nil {
+            return .sni
+        }
+        if Self.normalizedDomain(dnsDomainName) != nil {
+            return .dns
+        }
+        return nil
+    }
+
+    private static func normalizedDomain(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
     }
 }
 

--- a/PcapPlusPlusCore/Models/PacketTextStyle.swift
+++ b/PcapPlusPlusCore/Models/PacketTextStyle.swift
@@ -104,6 +104,8 @@ public extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
+            dnsDomainName: dnsDomainName,
+            dnsResolutions: dnsResolutions,
             client: client,
             textStyle: textStyle,
             customComment: customComment
@@ -132,6 +134,8 @@ public extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
+            dnsDomainName: dnsDomainName,
+            dnsResolutions: dnsResolutions,
             client: client,
             textStyle: textStyle,
             customComment: customComment

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeSupport.swift
@@ -394,6 +394,7 @@ enum NativeBridgeMapper {
             decodeStatus: decodeStatus(descriptor.decodeStatus),
             captureMetadata: packetCaptureMetadata(descriptor.captureMetadata),
             sniDomainName: descriptor.sniDomainName,
+            dnsResolutions: descriptor.dnsResolutions,
             textStyle: descriptor.textStyle
         )
     }

--- a/PcapPlusPlusCore/NativeBridge/NativeBridgeTypes.swift
+++ b/PcapPlusPlusCore/NativeBridge/NativeBridgeTypes.swift
@@ -220,6 +220,7 @@ final class PCPPNativePacketSummaryDescriptor {
     let decodeStatus: PCPPNativeDecodeStatusDescriptor
     let captureMetadata: PCPPNativePacketCaptureMetadataDescriptor
     let sniDomainName: String?
+    let dnsResolutions: [DNSResolutionObservation]?
     let textStyle: PacketTextStyle
 
     init(
@@ -241,6 +242,7 @@ final class PCPPNativePacketSummaryDescriptor {
         decodeStatus: PCPPNativeDecodeStatusDescriptor,
         captureMetadata: PCPPNativePacketCaptureMetadataDescriptor,
         sniDomainName: String?,
+        dnsResolutions: [DNSResolutionObservation]? = nil,
         textStyle: PacketTextStyle = .plain
     ) {
         self.identifier = identifier
@@ -261,6 +263,7 @@ final class PCPPNativePacketSummaryDescriptor {
         self.decodeStatus = decodeStatus
         self.captureMetadata = captureMetadata
         self.sniDomainName = sniDomainName
+        self.dnsResolutions = dnsResolutions?.isEmpty == true ? nil : dnsResolutions
         self.textStyle = textStyle
     }
 }

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -957,6 +957,7 @@ private func makePacketSummaryDescriptor(
         decodeStatus: decodeStatusDescriptor(analyzed.decodeStatus),
         captureMetadata: captureMetadataDescriptor(record),
         sniDomainName: wireshark.sniDomainName,
+        dnsResolutions: analyzed.dnsResolutions,
         textStyle: record.textStyle
     )
 }

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -321,6 +321,7 @@ final class PCPPNativeOfflineDocument {
             let totalBytes = UInt64((try? FileManager.default.attributesOfItem(atPath: sourceURL.path)[.size] as? NSNumber)?.uint64Value ?? 0)
             var summaries: [PCPPNativePacketSummaryDescriptor] = []
             var pendingBatch: [PCPPNativePacketSummaryDescriptor] = []
+            var dnsTCPStreamParser = DNSTCPStreamParser()
 
             for (index, record) in records.enumerated() {
                 if cancellationCheck?() == true {
@@ -341,7 +342,11 @@ final class PCPPNativeOfflineDocument {
 
                 let summary = try autoreleasepool {
                     try state.write {
-                        try self.makePacketSummaryDescriptorSafely(record: record, state: &$0)
+                        try self.makePacketSummaryDescriptorSafely(
+                            record: record,
+                            state: &$0,
+                            dnsTCPStreamParser: &dnsTCPStreamParser
+                        )
                     }
                 }
                 summaries.append(summary)
@@ -409,21 +414,30 @@ final class PCPPNativeOfflineDocument {
 
     private func makePacketSummaryDescriptorSafely(
         record: NativePacketRecord,
-        state: inout PCPPNativeOfflineDocumentState
+        state: inout PCPPNativeOfflineDocumentState,
+        dnsTCPStreamParser: inout DNSTCPStreamParser
     ) throws -> PCPPNativePacketSummaryDescriptor {
+        var analyzed = PacketAnalyzer(record: record).analyze()
+        mergeDNSResolutions(
+            dnsTCPStreamParser.resolutions(for: analyzed, at: record.timestamp),
+            into: &analyzed
+        )
         do {
             let session = try requireDissectionSession(in: state)
             try session.observe(record)
             let wiresharkSummary = try session.summarize(record)
-            let analyzer = PacketAnalyzer(record: record).analyze()
-            return makePacketSummaryDescriptor(record: record, analyzed: analyzer, wireshark: wiresharkSummary)
+            return makePacketSummaryDescriptor(record: record, analyzed: analyzed, wireshark: wiresharkSummary)
         } catch {
             if NativeErrorIsCriticalWiresharkException(error) {
                 throw error
             }
             // A single packet can be malformed enough for epan to reject it; keep the file open.
             state.partiallyLoaded = true
-            return SwiftPacketDissector.dissect(record: record, disablesWireshark: true).summary
+            return SwiftPacketDissector.dissect(
+                record: record,
+                disablesWireshark: true,
+                analyzedPacket: analyzed
+            ).summary
         }
     }
 
@@ -500,6 +514,7 @@ private struct PCPPNativeLiveSessionState {
     var packetsDroppedByInterface: UInt64 = 0
     var liveLinkLayerType = Libpcap.dltEthernet
     var dissectionSession: WiresharkEpanSession?
+    var dnsTCPStreamParser = DNSTCPStreamParser()
     var statusMessage: String?
 }
 
@@ -607,6 +622,7 @@ final class PCPPNativeLiveSession {
             $0.packetNumber = 1
             $0.liveLinkLayerType = captureBackend.dataLink(for: openedHandle)
             $0.packetStore.reset()
+            $0.dnsTCPStreamParser.reset()
             $0.packetsReceived = 0
             $0.packetsDropped = 0
             $0.packetsDroppedByInterface = 0
@@ -694,6 +710,7 @@ final class PCPPNativeLiveSession {
             $0.packetsDropped = 0
             $0.packetsDroppedByInterface = 0
             $0.dissectionSession = nextDissectionSession
+            $0.dnsTCPStreamParser.reset()
             if nextDissectionSession != nil {
                 $0.statusMessage = nil
             }
@@ -843,18 +860,30 @@ final class PCPPNativeLiveSession {
 
             let result: (summary: PCPPNativePacketSummaryDescriptor, degraded: Bool) = autoreleasepool {
                 state.write {
+                    var analyzed = PacketAnalyzer(record: record).analyze()
+                    mergeDNSResolutions(
+                        $0.dnsTCPStreamParser.resolutions(for: analyzed, at: record.timestamp),
+                        into: &analyzed
+                    )
                     guard let session = $0.dissectionSession else {
-                        return (SwiftPacketDissector.dissect(record: record, disablesWireshark: true).summary, false)
+                        return (SwiftPacketDissector.dissect(
+                            record: record,
+                            disablesWireshark: true,
+                            analyzedPacket: analyzed
+                        ).summary, false)
                     }
 
                     do {
                         try session.observe(record)
                         let wiresharkSummary = try session.summarize(record)
-                        let analyzer = PacketAnalyzer(record: record).analyze()
-                        return (makePacketSummaryDescriptor(record: record, analyzed: analyzer, wireshark: wiresharkSummary), false)
+                        return (makePacketSummaryDescriptor(record: record, analyzed: analyzed, wireshark: wiresharkSummary), false)
                     } catch {
                         disableWiresharkAfterFailure(error, state: &$0)
-                        return (SwiftPacketDissector.dissect(record: record, disablesWireshark: true).summary, true)
+                        return (SwiftPacketDissector.dissect(
+                            record: record,
+                            disablesWireshark: true,
+                            analyzedPacket: analyzed
+                        ).summary, true)
                     }
                 }
             }
@@ -925,6 +954,15 @@ final class PCPPNativeLiveSession {
             statusMessage: status ?? state.statusMessage
         )
     }
+}
+
+// Merge stream observations with packet-local parsing while preserving stable order.
+private func mergeDNSResolutions(_ resolutions: [DNSResolutionObservation], into packet: inout AnalyzedPacket) {
+    guard !resolutions.isEmpty else {
+        return
+    }
+    var seen = Set(packet.dnsResolutions)
+    packet.dnsResolutions.append(contentsOf: resolutions.filter { seen.insert($0).inserted })
 }
 
 private func makePacketSummaryDescriptor(

--- a/PcapPlusPlusCoreTests/Dissection/DNSMessageParserTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/DNSMessageParserTests.swift
@@ -1,0 +1,325 @@
+//
+//  DNSMessageParserTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Darwin
+import Foundation
+import Testing
+@testable import PcapPlusPlusCore
+
+struct DNSMessageParserTests {
+
+    // MARK: - A records
+
+    @Test func parsesSingleAResponse() throws {
+        let observations = parse(response(
+            questions: [("spotify.com", 1)],
+            answers: [record(owner: .pointer(12), type: 1, ttl: 60, data: [35, 186, 224, 34])]
+        ))
+
+        #expect(observations == [DNSResolutionObservation(domainName: "spotify.com", ipAddress: "35.186.224.34", timeToLive: 60)])
+    }
+
+    @Test func lowercasesARecordDomain() throws {
+        let observations = parse(response(
+            questions: [("API.Example.COM", 1)],
+            answers: [record(owner: .pointer(12), type: 1, ttl: 120, data: [192, 0, 2, 10])]
+        ))
+
+        #expect(observations.first?.domainName == "api.example.com")
+    }
+
+    @Test func parsesMultipleARecords() throws {
+        let observations = parse(response(
+            questions: [("pool.example", 1)],
+            answers: [
+                record(owner: .pointer(12), type: 1, ttl: 30, data: [192, 0, 2, 1]),
+                record(owner: .pointer(12), type: 1, ttl: 45, data: [192, 0, 2, 2]),
+            ]
+        ))
+
+        #expect(observations.map(\.ipAddress) == ["192.0.2.1", "192.0.2.2"])
+        #expect(observations.map(\.timeToLive) == [30, 45])
+    }
+
+    @Test func deduplicatesRepeatedARecords() throws {
+        let duplicate = record(owner: .pointer(12), type: 1, ttl: 30, data: [198, 51, 100, 7])
+        let observations = parse(response(
+            questions: [("duplicate.example", 1)],
+            answers: [duplicate, duplicate]
+        ))
+
+        #expect(observations.count == 1)
+    }
+
+    @Test func ignoresARecordWithNonInternetClass() throws {
+        let observations = parse(response(
+            questions: [("class.example", 1)],
+            answers: [record(owner: .pointer(12), type: 1, recordClass: 3, ttl: 30, data: [192, 0, 2, 3])]
+        ))
+
+        #expect(observations.isEmpty)
+    }
+
+    // MARK: - AAAA records
+
+    @Test func parsesSingleAAAAResponse() throws {
+        let observations = parse(response(
+            questions: [("ipv6.example", 28)],
+            answers: [record(owner: .pointer(12), type: 28, ttl: 60, data: ipv6("2001:db8::1"))]
+        ))
+
+        #expect(observations == [DNSResolutionObservation(domainName: "ipv6.example", ipAddress: "2001:db8::1", timeToLive: 60)])
+    }
+
+    @Test func parsesCompressedAAAAOwner() throws {
+        let observations = parse(response(
+            questions: [("compressed.example", 28)],
+            answers: [record(owner: .pointer(12), type: 28, ttl: 90, data: ipv6("2001:db8::20"))]
+        ))
+
+        #expect(observations.first?.ipAddress == "2001:db8::20")
+    }
+
+    @Test func parsesMultipleAAAARecords() throws {
+        let observations = parse(response(
+            questions: [("pool6.example", 28)],
+            answers: [
+                record(owner: .name("pool6.example"), type: 28, ttl: 20, data: ipv6("2001:db8::1")),
+                record(owner: .name("pool6.example"), type: 28, ttl: 25, data: ipv6("2001:db8::2")),
+            ]
+        ))
+
+        #expect(observations.map(\.ipAddress) == ["2001:db8::1", "2001:db8::2"])
+    }
+
+    @Test func canonicalizesExpandedAAAAAddress() throws {
+        let observations = parse(response(
+            questions: [("canonical.example", 28)],
+            answers: [record(owner: .pointer(12), type: 28, ttl: 60, data: ipv6("2001:0db8:0000:0000:0000:0000:0000:0001"))]
+        ))
+
+        #expect(observations.first?.ipAddress == "2001:db8::1")
+    }
+
+    @Test func rejectsAAAARecordWithInvalidLength() throws {
+        let observations = parse(response(
+            questions: [("broken6.example", 28)],
+            answers: [record(owner: .pointer(12), type: 28, ttl: 60, data: [UInt8](repeating: 0, count: 15))]
+        ))
+
+        #expect(observations.isEmpty)
+    }
+
+    // MARK: - CNAME records
+
+    @Test func resolvesCNAMEToARecord() throws {
+        let observations = parse(response(
+            questions: [("music.example", 1)],
+            answers: [
+                record(owner: .pointer(12), type: 5, ttl: 120, data: encodedName("edge.example")),
+                record(owner: .name("edge.example"), type: 1, ttl: 60, data: [203, 0, 113, 8]),
+            ]
+        ))
+
+        #expect(observations == [DNSResolutionObservation(domainName: "music.example", ipAddress: "203.0.113.8", timeToLive: 60)])
+    }
+
+    @Test func resolvesCNAMEToAAAARecord() throws {
+        let observations = parse(response(
+            questions: [("music6.example", 28)],
+            answers: [
+                record(owner: .pointer(12), type: 5, ttl: 120, data: encodedName("edge6.example")),
+                record(owner: .name("edge6.example"), type: 28, ttl: 60, data: ipv6("2001:db8::8")),
+            ]
+        ))
+
+        #expect(observations.first?.domainName == "music6.example")
+        #expect(observations.first?.ipAddress == "2001:db8::8")
+    }
+
+    @Test func followsTwoCNAMEHops() throws {
+        let observations = parse(response(
+            questions: [("one.example", 1)],
+            answers: [
+                record(owner: .pointer(12), type: 5, ttl: 300, data: encodedName("two.example")),
+                record(owner: .name("two.example"), type: 5, ttl: 200, data: encodedName("three.example")),
+                record(owner: .name("three.example"), type: 1, ttl: 100, data: [203, 0, 113, 3]),
+            ]
+        ))
+
+        #expect(observations.first?.ipAddress == "203.0.113.3")
+    }
+
+    @Test func usesMinimumTTLAlongCNAMEChain() throws {
+        let observations = parse(response(
+            questions: [("short.example", 1)],
+            answers: [
+                record(owner: .pointer(12), type: 5, ttl: 15, data: encodedName("target.example")),
+                record(owner: .name("target.example"), type: 1, ttl: 300, data: [203, 0, 113, 15]),
+            ]
+        ))
+
+        #expect(observations.first?.timeToLive == 15)
+    }
+
+    @Test func stopsCNAMECycles() throws {
+        let observations = parse(response(
+            questions: [("cycle-a.example", 1)],
+            answers: [
+                record(owner: .pointer(12), type: 5, ttl: 60, data: encodedName("cycle-b.example")),
+                record(owner: .name("cycle-b.example"), type: 5, ttl: 60, data: encodedName("cycle-a.example")),
+            ]
+        ))
+
+        #expect(observations.isEmpty)
+    }
+
+    // MARK: - Invalid and unsupported messages
+
+    @Test func ignoresDNSQueries() throws {
+        let message = response(
+            flags: 0x0100,
+            questions: [("query.example", 1)],
+            answers: [record(owner: .pointer(12), type: 1, ttl: 60, data: [192, 0, 2, 1])]
+        )
+
+        #expect(parse(message).isEmpty)
+    }
+
+    @Test func ignoresTruncatedResponses() throws {
+        let message = response(
+            flags: 0x8380,
+            questions: [("truncated.example", 1)],
+            answers: [record(owner: .pointer(12), type: 1, ttl: 60, data: [192, 0, 2, 1])]
+        )
+
+        #expect(parse(message).isEmpty)
+    }
+
+    @Test func ignoresErrorResponses() throws {
+        let message = response(flags: 0x8183, questions: [("missing.example", 1)], answers: [])
+
+        #expect(parse(message).isEmpty)
+    }
+
+    @Test func rejectsOutOfBoundsRecordData() throws {
+        var message = response(
+            questions: [("short.example", 1)],
+            answers: [record(owner: .pointer(12), type: 1, ttl: 60, data: [192, 0, 2, 1])]
+        )
+        message.removeLast()
+
+        #expect(parse(message).isEmpty)
+    }
+
+    @Test func rejectsCompressionPointerCycles() throws {
+        var message = Data([UInt8](repeating: 0, count: 12))
+        message.replaceSubrange(0..<12, with: header(flags: 0x8180, questionCount: 1, answerCount: 0))
+        message.append(contentsOf: [0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01])
+
+        #expect(parse(message).isEmpty)
+    }
+
+    private func parse(_ data: Data) -> [DNSResolutionObservation] {
+        DNSMessageParser(data: data).resolutions()
+    }
+}
+
+private enum EncodedDNSName {
+    case name(String)
+    case pointer(UInt16)
+}
+
+private struct EncodedDNSRecord {
+    let owner: EncodedDNSName
+    let type: UInt16
+    let recordClass: UInt16
+    let ttl: UInt32
+    let data: [UInt8]
+}
+
+private func record(
+    owner: EncodedDNSName,
+    type: UInt16,
+    recordClass: UInt16 = 1,
+    ttl: UInt32,
+    data: [UInt8]
+) -> EncodedDNSRecord {
+    EncodedDNSRecord(owner: owner, type: type, recordClass: recordClass, ttl: ttl, data: data)
+}
+
+private func response(
+    flags: UInt16 = 0x8180,
+    questions: [(String, UInt16)],
+    answers: [EncodedDNSRecord]
+) -> Data {
+    var data = header(
+        flags: flags,
+        questionCount: UInt16(questions.count),
+        answerCount: UInt16(answers.count)
+    )
+    for (name, type) in questions {
+        data.append(contentsOf: encodedName(name))
+        data.appendBigEndian(type)
+        data.appendBigEndian(UInt16(1))
+    }
+    for answer in answers {
+        switch answer.owner {
+        case .name(let value):
+            data.append(contentsOf: encodedName(value))
+        case .pointer(let offset):
+            data.appendBigEndian(UInt16(0xc000) | offset)
+        }
+        data.appendBigEndian(answer.type)
+        data.appendBigEndian(answer.recordClass)
+        data.appendBigEndian(answer.ttl)
+        data.appendBigEndian(UInt16(answer.data.count))
+        data.append(contentsOf: answer.data)
+    }
+    return data
+}
+
+private func header(flags: UInt16, questionCount: UInt16, answerCount: UInt16) -> Data {
+    var data = Data()
+    data.appendBigEndian(UInt16(0x1234))
+    data.appendBigEndian(flags)
+    data.appendBigEndian(questionCount)
+    data.appendBigEndian(answerCount)
+    data.appendBigEndian(UInt16(0))
+    data.appendBigEndian(UInt16(0))
+    return data
+}
+
+private func encodedName(_ name: String) -> [UInt8] {
+    var bytes: [UInt8] = []
+    for label in name.split(separator: ".") {
+        bytes.append(UInt8(label.utf8.count))
+        bytes.append(contentsOf: label.utf8)
+    }
+    bytes.append(0)
+    return bytes
+}
+
+private func ipv6(_ address: String) -> [UInt8] {
+    var value = in6_addr()
+    precondition(inet_pton(AF_INET6, address, &value) == 1)
+    return withUnsafeBytes(of: value) { Array($0) }
+}
+
+private extension Data {
+    mutating func appendBigEndian(_ value: UInt16) {
+        append(UInt8((value >> 8) & 0xff))
+        append(UInt8(value & 0xff))
+    }
+
+    mutating func appendBigEndian(_ value: UInt32) {
+        append(UInt8((value >> 24) & 0xff))
+        append(UInt8((value >> 16) & 0xff))
+        append(UInt8((value >> 8) & 0xff))
+        append(UInt8(value & 0xff))
+    }
+}

--- a/PcapPlusPlusCoreTests/Dissection/DNSTCPStreamParserTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/DNSTCPStreamParserTests.swift
@@ -1,0 +1,134 @@
+//
+//  DNSTCPStreamParserTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Foundation
+import Testing
+@testable import PcapPlusPlusCore
+
+struct DNSTCPStreamParserTests {
+    private let expectedResolution = DNSResolutionObservation(
+        domainName: "www.example.com",
+        ipAddress: "93.184.216.34",
+        timeToLive: 60
+    )
+
+    @Test func reassemblesSplitLengthPrefix() {
+        var parser = DNSTCPStreamParser()
+        let message = framedResponse()
+
+        #expect(parse(&parser, sequence: 10, payload: Array(message.prefix(1))).isEmpty)
+        #expect(parse(&parser, sequence: 11, payload: Array(message.dropFirst())) == [expectedResolution])
+    }
+
+    @Test func reassemblesMessageBodyAcrossSegments() {
+        var parser = DNSTCPStreamParser()
+        let message = framedResponse()
+        let splitIndex = message.count / 2
+
+        #expect(parse(&parser, sequence: 100, payload: Array(message[..<splitIndex])).isEmpty)
+        #expect(parse(
+            &parser,
+            sequence: UInt32(100 + splitIndex),
+            payload: Array(message[splitIndex...])
+        ) == [expectedResolution])
+    }
+
+    @Test func parsesMultipleMessagesFromOneSegment() {
+        var parser = DNSTCPStreamParser()
+        let secondResolution = DNSResolutionObservation(
+            domainName: "www.example.com",
+            ipAddress: "203.0.113.9",
+            timeToLive: 60
+        )
+        let payload = framedResponse() + framedResponse(address: [203, 0, 113, 9])
+
+        #expect(parse(&parser, sequence: 1, payload: payload) == [expectedResolution, secondResolution])
+    }
+
+    @Test func ignoresFullyRetransmittedBytes() {
+        var parser = DNSTCPStreamParser()
+        let message = framedResponse()
+        let splitIndex = message.count / 2
+        let firstSegment = Array(message[..<splitIndex])
+
+        #expect(parse(&parser, sequence: 500, payload: firstSegment).isEmpty)
+        #expect(parse(&parser, sequence: 500, payload: firstSegment).isEmpty)
+        #expect(parse(
+            &parser,
+            sequence: UInt32(500 + splitIndex),
+            payload: Array(message[splitIndex...])
+        ) == [expectedResolution])
+    }
+
+    @Test func keepsConcurrentClientStreamsIsolated() {
+        var parser = DNSTCPStreamParser()
+        let message = framedResponse()
+        let splitIndex = message.count / 2
+
+        #expect(parse(&parser, sequence: 1, payload: Array(message[..<splitIndex]), destinationPort: 50_001).isEmpty)
+        #expect(parse(&parser, sequence: 80, payload: Array(message[..<splitIndex]), destinationPort: 50_002).isEmpty)
+        #expect(parse(
+            &parser,
+            sequence: UInt32(1 + splitIndex),
+            payload: Array(message[splitIndex...]),
+            destinationPort: 50_001
+        ) == [expectedResolution])
+        #expect(parse(
+            &parser,
+            sequence: UInt32(80 + splitIndex),
+            payload: Array(message[splitIndex...]),
+            destinationPort: 50_002
+        ) == [expectedResolution])
+    }
+
+    @Test func resetDiscardsPartialMessages() {
+        var parser = DNSTCPStreamParser()
+        let message = framedResponse()
+
+        #expect(parse(&parser, sequence: 1, payload: Array(message.prefix(10))).isEmpty)
+        parser.reset()
+        #expect(parse(&parser, sequence: 100, payload: message) == [expectedResolution])
+    }
+
+    private func parse(
+        _ parser: inout DNSTCPStreamParser,
+        sequence: UInt32,
+        payload: [UInt8],
+        destinationPort: UInt16 = 50_000
+    ) -> [DNSResolutionObservation] {
+        var packet = AnalyzedPacket()
+        packet.sourceAddress = "192.0.2.53"
+        packet.sourcePort = 53
+        packet.destinationAddress = "192.0.2.10"
+        packet.destinationPort = destinationPort
+        packet.dnsTCPStreamSegment = DNSTCPStreamSegment(
+            payloadSequenceNumber: sequence,
+            payload: payload,
+            resetsStream: false,
+            endsStream: false
+        )
+        return parser.resolutions(for: packet, at: Date(timeIntervalSince1970: TimeInterval(sequence)))
+    }
+
+    private func framedResponse(address: [UInt8] = [93, 184, 216, 34]) -> [UInt8] {
+        let response = dnsResponse(address: address)
+        return [UInt8(response.count >> 8), UInt8(response.count & 0xff)] + response
+    }
+
+    private func dnsResponse(address: [UInt8]) -> [UInt8] {
+        [
+            0x12, 0x34, 0x81, 0x80,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x03, 0x77, 0x77, 0x77,
+            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+            0x03, 0x63, 0x6f, 0x6d, 0x00,
+            0x00, 0x01, 0x00, 0x01,
+            0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x3c, 0x00, 0x04,
+        ] + address
+    }
+}

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -585,6 +585,47 @@ struct InspectorPipelineTests {
         #expect(packet.dnsResolutions?.first?.ipAddress == "93.184.216.34")
     }
 
+    @Test func splitLengthPrefixedDNSOverTCPProducesResolutionOnCompletingPacket() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dnsPayload = makeDNSResponsePayload()
+        var framedPayload: [UInt8] = []
+        framedPayload.appendBigEndian(UInt16(dnsPayload.count))
+        framedPayload.append(contentsOf: dnsPayload)
+        let splitIndex = framedPayload.count / 2
+        let firstPayload = Array(framedPayload[..<splitIndex])
+        let secondPayload = Array(framedPayload[splitIndex...])
+        let captureURL = directory.appendingPathComponent("split-dns-over-tcp.pcap")
+        try writePCAP(to: captureURL, packets: [
+            makeIPv4TCPPacket(
+                sourcePort: 53,
+                destinationPort: 54_321,
+                identification: 0x1243,
+                sequenceNumber: 10,
+                payload: firstPayload
+            ),
+            makeIPv4TCPPacket(
+                sourcePort: 53,
+                destinationPort: 54_321,
+                identification: 0x1244,
+                sequenceNumber: UInt32(10 + firstPayload.count),
+                payload: secondPayload
+            ),
+        ])
+
+        let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: captureURL)
+        let packets = try await document.open()
+
+        #expect(packets.count == 2)
+        #expect(packets[0].dnsResolutions == nil)
+        #expect(packets[1].dnsResolutions == [DNSResolutionObservation(
+            domainName: "www.example.com",
+            ipAddress: "93.184.216.34",
+            timeToLive: 60
+        )])
+    }
+
     @Test func encryptedDNSPortsDoNotParseLengthPrefixedBytesAsPlainDNS() {
         let dnsPayload = makeDNSResponsePayload()
         var encryptedCarrierPayload: [UInt8] = []

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -543,6 +543,11 @@ struct InspectorPipelineTests {
 
         #expect(packet.transportHint == .dns)
         #expect(packet.protocolSummary?.localizedCaseInsensitiveContains("DNS") == true)
+        #expect(packet.dnsResolutions == [DNSResolutionObservation(
+            domainName: "www.example.com",
+            ipAddress: "93.184.216.34",
+            timeToLive: 60
+        )])
         let dnsNode = try #require(findNode(in: inspection.detailNodes, fieldName: "dns"))
         #expect(findNode(in: dnsNode.children, fieldName: "dns.id")?.value == "0x1234")
         #expect(findNode(in: dnsNode.children, fieldName: "dns.flags.response")?.value?.localizedCaseInsensitiveContains("response") == true)
@@ -553,6 +558,58 @@ struct InspectorPipelineTests {
         #expect(findNode(in: dnsNode.children, fieldName: "dns.resp.name")?.value == "www.example.com")
         #expect(findNode(in: dnsNode.children, fieldName: "dns.a")?.value == "93.184.216.34")
         #expect(findNode(in: dnsNode.children, fieldName: "dns.a")?.byteRange == PacketByteRange(offset: 87, length: 4))
+    }
+
+    @Test func completeLengthPrefixedDNSOverTCPProducesResolutionObservation() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dnsPayload = makeDNSResponsePayload()
+        var tcpPayload: [UInt8] = []
+        tcpPayload.appendBigEndian(UInt16(dnsPayload.count))
+        tcpPayload.append(contentsOf: dnsPayload)
+        let captureURL = directory.appendingPathComponent("dns-over-tcp.pcap")
+        try writePCAP(to: captureURL, packets: [makeIPv4TCPPacket(
+            sourcePort: 53,
+            destinationPort: 54_321,
+            identification: 0x1239,
+            payload: tcpPayload
+        )])
+
+        let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: captureURL)
+        let packets = try await document.open()
+        let packet = try #require(packets.first)
+
+        #expect(packet.transportHint == .dns)
+        #expect(packet.dnsResolutions?.first?.domainName == "www.example.com")
+        #expect(packet.dnsResolutions?.first?.ipAddress == "93.184.216.34")
+    }
+
+    @Test func encryptedDNSPortsDoNotParseLengthPrefixedBytesAsPlainDNS() {
+        let dnsPayload = makeDNSResponsePayload()
+        var encryptedCarrierPayload: [UInt8] = []
+        encryptedCarrierPayload.appendBigEndian(UInt16(dnsPayload.count))
+        encryptedCarrierPayload.append(contentsOf: dnsPayload)
+        let rawBytes = makeIPv4TCPPacket(
+            sourcePort: 853,
+            destinationPort: 54_321,
+            identification: 0x1242,
+            payload: encryptedCarrierPayload
+        )
+        let packet = PacketAnalyzer(record: NativePacketRecord(
+            identifier: 1,
+            packetNumber: 1,
+            timestamp: Date(timeIntervalSince1970: 0),
+            rawBytes: rawBytes,
+            originalLength: rawBytes.count,
+            linkLayerType: Libpcap.dltEthernet,
+            interfaceIdentifier: nil,
+            interfaceName: nil,
+            packetComment: nil
+        )).analyze()
+
+        #expect(packet.transportHint != .dns)
+        #expect(packet.dnsResolutions.isEmpty)
     }
 
     @Test func phaseTwoInspectionUsesWiresharkPayloadDetailsForUnestablishedStreams() async throws {
@@ -1384,26 +1441,7 @@ private func makeIPv4UDPPayloadPacket() -> Data {
 }
 
 private func makeIPv4DNSResponsePacket() -> Data {
-    let dnsPayload: [UInt8] = [
-        0x12, 0x34,
-        0x81, 0x80,
-        0x00, 0x01,
-        0x00, 0x01,
-        0x00, 0x00,
-        0x00, 0x00,
-        0x03, 0x77, 0x77, 0x77,
-        0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
-        0x03, 0x63, 0x6f, 0x6d,
-        0x00,
-        0x00, 0x01,
-        0x00, 0x01,
-        0xc0, 0x0c,
-        0x00, 0x01,
-        0x00, 0x01,
-        0x00, 0x00, 0x00, 0x3c,
-        0x00, 0x04,
-        0x5d, 0xb8, 0xd8, 0x22,
-    ]
+    let dnsPayload = makeDNSResponsePayload()
     let udpLength = UInt16(8 + dnsPayload.count)
     let ipv4TotalLength = UInt16(20 + Int(udpLength))
     var packet = Data([
@@ -1424,6 +1462,29 @@ private func makeIPv4DNSResponsePacket() -> Data {
     packet.appendBigEndian(UInt16(0))
     packet.append(contentsOf: dnsPayload)
     return packet
+}
+
+private func makeDNSResponsePayload() -> [UInt8] {
+    [
+        0x12, 0x34,
+        0x81, 0x80,
+        0x00, 0x01,
+        0x00, 0x01,
+        0x00, 0x00,
+        0x00, 0x00,
+        0x03, 0x77, 0x77, 0x77,
+        0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+        0x03, 0x63, 0x6f, 0x6d,
+        0x00,
+        0x00, 0x01,
+        0x00, 0x01,
+        0xc0, 0x0c,
+        0x00, 0x01,
+        0x00, 0x01,
+        0x00, 0x00, 0x00, 0x3c,
+        0x00, 0x04,
+        0x5d, 0xb8, 0xd8, 0x22,
+    ]
 }
 
 private func makeIPv4HTTPRequestPacket() -> Data {

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -431,6 +431,7 @@ struct PacketIngestState: Sendable, Equatable {
                 let currentPacket = packets[packetIndex]
                 let updatedPacket = currentPacket.tcpviewerApplying(
                     sniDomainName: update.sniDomainName,
+                    dnsDomainName: update.dnsDomainName,
                     client: update.client,
                     direction: update.direction
                 )

--- a/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
+++ b/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
@@ -698,7 +698,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
             capturedBytes += packet.capturedLength
             let protocolName = packet.protocolSummary ?? packet.transportHint.rawValue
             protocolCounts[protocolName, default: 0] += 1
-            if let domain = packet.sniDomainName {
+            if let domain = packet.domainName {
                 let value = redactsSensitiveData ? redactor.redact(domain) : domain
                 domainCounts[value, default: 0] += 1
             }

--- a/TCPViewer/Features/MCP/TCPViewerMCPPacketQueryService.swift
+++ b/TCPViewer/Features/MCP/TCPViewerMCPPacketQueryService.swift
@@ -320,7 +320,7 @@ enum TCPViewerMCPPacketQueryService {
             }
         }
         if !query.domains.isEmpty {
-            guard let domain = packet.sniDomainName?.lowercased(),
+            guard let domain = packet.domainName?.lowercased(),
                   query.domains.contains(where: { domain.contains($0) }) else {
                 return false
             }
@@ -374,7 +374,7 @@ enum TCPViewerMCPPacketQueryService {
         case .protocolName:
             return protocolValues(packet)
         case .domain:
-            return packet.sniDomainName.map { [$0] } ?? []
+            return packet.domainName.map { [$0] } ?? []
         case .sourceAddress:
             return packet.endpoints.source.address.map { [$0] } ?? []
         case .destinationAddress:
@@ -409,7 +409,7 @@ enum TCPViewerMCPPacketQueryService {
             return [String(packet.captureMetadata.isTruncated)]
         case .text:
             return protocolValues(packet) + [
-                packet.sniDomainName,
+                packet.domainName,
                 packet.endpoints.source.address,
                 packet.endpoints.destination.address,
                 packet.client?.displayName,

--- a/TCPViewer/Features/MCP/TCPViewerMCPPacketSerializer.swift
+++ b/TCPViewer/Features/MCP/TCPViewerMCPPacketSerializer.swift
@@ -41,8 +41,11 @@ struct TCPViewerMCPPacketSerializer {
         if let interfaceID = packet.interfaceID {
             object["interface_id"] = protectedText(interfaceID)
         }
-        if let domain = packet.sniDomainName {
+        if let domain = packet.domainName {
             object["domain"] = protectedText(domain)
+        }
+        if let domainSource = packet.domainSource {
+            object["domain_source"] = .string(domainSource.rawValue)
         }
         if let streamID = packet.streamID {
             object["stream_id"] = .int(Int(streamID))

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -80,7 +80,7 @@ private extension String {
     // Re-encode through UTF-8 to force a Swift-owned (native) string buffer.
     //
     // Strings handed to us by the native packet layer (`PacketSummary.protocolSummary`,
-    // `infoSummary`, `sniDomainName`, endpoint addresses, …) and by Foundation/AppKit lookups
+    // `infoSummary`, domain names, endpoint addresses, …) and by Foundation/AppKit lookups
     // (`PacketClient` bundle identifiers/paths, interface names) are lazily Cocoa-backed: the Swift
     // `String` only wraps an `NSString` whose lifetime is owned elsewhere. A `PacketTableRow` built
     // from those strings is long-lived and is copied by AppKit on the main thread while live capture
@@ -154,7 +154,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
     let id: PacketSummary.ID
     let sourceAddress: String?
     let destinationAddress: String?
-    let sniDomainName: String?
+    let domainName: String?
     let clientIconFilePath: String?
     let hasClient: Bool
     let timestamp: Date
@@ -205,7 +205,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
         self.id = packet.id
         self.sourceAddress = packet.endpoints.source.address?.tcpviewerNativeCopy
         self.destinationAddress = packet.endpoints.destination.address?.tcpviewerNativeCopy
-        self.sniDomainName = packet.sniDomainName?.tcpviewerNativeCopy
+        self.domainName = packet.domainName?.tcpviewerNativeCopy
         self.clientIconFilePath = (clientIconFilePath ?? PacketClientIconPathResolver.iconFilePath(for: packet.client))?.tcpviewerNativeCopy
         self.hasClient = packet.client != nil
         self.timestamp = packet.timestamp
@@ -216,7 +216,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
         self.destinationText = NetworkInspectorFormatters.endpointLabel(packet.endpoints.destination)
         self.sourcePortText = NetworkInspectorFormatters.portLabel(packet.endpoints.source.port)
         self.destinationPortText = NetworkInspectorFormatters.portLabel(packet.endpoints.destination.port)
-        self.domainText = (packet.sniDomainName ?? "-").tcpviewerNativeCopy
+        self.domainText = (packet.domainName ?? "-").tcpviewerNativeCopy
         self.clientText = (packet.client?.displayName ?? "-").tcpviewerNativeCopy
         self.protocolText = NetworkInspectorFormatters.protocolLabel(for: packet).tcpviewerNativeCopy
         self.streamIDText = packet.streamID.map(String.init) ?? "-"
@@ -252,7 +252,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
     }
 
     var canPinDomain: Bool {
-        sniDomainName?.tcpviewerTrimmedNonEmpty != nil
+        domainName?.tcpviewerTrimmedNonEmpty != nil
     }
 
     var canPinClient: Bool {
@@ -463,7 +463,7 @@ struct PacketDisplayFilter: Sendable, Hashable {
             "\(packet.packetNumber)",
             NetworkInspectorFormatters.protocolLabel(for: packet),
             endpointText(for: packet),
-            packet.sniDomainName ?? "",
+            packet.domainName ?? "",
             clientText(for: packet),
             "\(packet.capturedLength)",
             packet.infoSummary,

--- a/TCPViewer/Features/NetworkInspector/Models/PacketStructuredFilterModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketStructuredFilterModels.swift
@@ -486,7 +486,7 @@ final class PacketStructuredFilterService {
             return [searchableText(for: packet)]
         case .urlDomain:
             return compact([
-                packet.sniDomainName,
+                packet.domainName,
                 packet.infoSummary,
                 packet.layers.compactMap(\.detailSummary).joined(separator: " "),
             ])
@@ -566,7 +566,7 @@ final class PacketStructuredFilterService {
             packet.transportHint.rawValue,
             endpointValues(packet.endpoints.source).joined(separator: " "),
             endpointValues(packet.endpoints.destination).joined(separator: " "),
-            packet.sniDomainName,
+            packet.domainName,
             packet.client?.displayName,
             packet.client?.name,
             packet.client?.bundleIdentifier,

--- a/TCPViewer/Features/NetworkInspector/Services/DNSResolutionCache.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/DNSResolutionCache.swift
@@ -55,6 +55,9 @@ struct DNSResolutionCache {
                 expiresAt: timestamp.addingTimeInterval(lifetime)
             )
             var entries = entriesByIPAddress[ipAddress, default: []]
+            #if DEBUG
+            let isRefresh = entries.contains { $0.domainName == domainName }
+            #endif
             entries.removeAll { $0.expiresAt <= timestamp || $0.domainName == domainName }
             entries.append(entry)
             if entries.count > maximumDomainsPerIPAddress {
@@ -65,6 +68,12 @@ struct DNSResolutionCache {
                 insertionOrder.append(ipAddress)
             }
             entriesByIPAddress[ipAddress] = entries
+            #if DEBUG
+            Self.debugLog(
+                "\(isRefresh ? "refreshed" : "stored") domain=\(domainName) ip=\(ipAddress) "
+                    + "ttl=\(observation.timeToLive)s retained=\(Int(lifetime))s"
+            )
+            #endif
         }
 
         evictIfNeeded()
@@ -72,8 +81,16 @@ struct DNSResolutionCache {
 
     // Return the newest unexpired observation for an IP in average O(1) time.
     mutating func domain(forIPAddress address: String, at timestamp: Date) -> String? {
-        guard let ipAddress = Self.normalizedIPAddress(address),
-              var entries = entriesByIPAddress[ipAddress] else {
+        guard let ipAddress = Self.normalizedIPAddress(address) else {
+            #if DEBUG
+            Self.debugLog("lookup ip=\(address) result=miss reason=invalid-address")
+            #endif
+            return nil
+        }
+        guard var entries = entriesByIPAddress[ipAddress] else {
+            #if DEBUG
+            Self.debugLog("lookup ip=\(ipAddress) result=miss reason=not-cached")
+            #endif
             return nil
         }
 
@@ -81,10 +98,17 @@ struct DNSResolutionCache {
         guard !entries.isEmpty else {
             // Keep the bounded key slot so reinsertion cannot create duplicate FIFO entries.
             entriesByIPAddress[ipAddress] = []
+            #if DEBUG
+            Self.debugLog("lookup ip=\(ipAddress) result=miss reason=expired")
+            #endif
             return nil
         }
         entriesByIPAddress[ipAddress] = entries
-        return entries.max { $0.observedAt < $1.observedAt }?.domainName
+        let domainName = entries.max { $0.observedAt < $1.observedAt }?.domainName
+        #if DEBUG
+        Self.debugLog("lookup ip=\(ipAddress) result=hit domain=\(domainName ?? "-")")
+        #endif
+        return domainName
     }
 
     mutating func reset() {
@@ -145,4 +169,11 @@ struct DNSResolutionCache {
         }
         return nil
     }
+
+    #if DEBUG
+    // Keep captured domain and address diagnostics out of release builds.
+    private static func debugLog(_ message: String) {
+        print("[TCPViewer][DNS Cache] \(message)")
+    }
+    #endif
 }

--- a/TCPViewer/Features/NetworkInspector/Services/DNSResolutionCache.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/DNSResolutionCache.swift
@@ -1,0 +1,148 @@
+//
+//  DNSResolutionCache.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Darwin
+import Foundation
+import PcapPlusPlusCore
+
+struct DNSResolutionCache {
+    struct DebugSnapshot: Equatable {
+        let ipAddressCount: Int
+        let candidateCount: Int
+    }
+
+    private struct Entry {
+        let domainName: String
+        let observedAt: Date
+        let expiresAt: Date
+    }
+
+    private let maximumIPAddressCount: Int
+    private let maximumDomainsPerIPAddress: Int
+    private let maximumRetention: TimeInterval
+    private var entriesByIPAddress: [String: [Entry]] = [:]
+    private var insertionOrder: [String] = []
+    private var evictionIndex = 0
+
+    init(
+        maximumIPAddressCount: Int = 50_000,
+        maximumDomainsPerIPAddress: Int = 4,
+        maximumRetention: TimeInterval = 86_400
+    ) {
+        self.maximumIPAddressCount = max(maximumIPAddressCount, 1)
+        self.maximumDomainsPerIPAddress = max(maximumDomainsPerIPAddress, 1)
+        self.maximumRetention = max(maximumRetention, 0)
+    }
+
+    // Store bounded DNS evidence and honor the shorter of the record TTL and retention limit.
+    mutating func observe(_ observations: [DNSResolutionObservation], at timestamp: Date) {
+        for observation in observations {
+            guard observation.timeToLive > 0,
+                  maximumRetention > 0,
+                  let ipAddress = Self.normalizedIPAddress(observation.ipAddress),
+                  let domainName = Self.normalizedDomain(observation.domainName) else {
+                continue
+            }
+
+            let lifetime = min(TimeInterval(observation.timeToLive), maximumRetention)
+            let entry = Entry(
+                domainName: domainName,
+                observedAt: timestamp,
+                expiresAt: timestamp.addingTimeInterval(lifetime)
+            )
+            var entries = entriesByIPAddress[ipAddress, default: []]
+            entries.removeAll { $0.expiresAt <= timestamp || $0.domainName == domainName }
+            entries.append(entry)
+            if entries.count > maximumDomainsPerIPAddress {
+                entries.removeFirst(entries.count - maximumDomainsPerIPAddress)
+            }
+
+            if entriesByIPAddress[ipAddress] == nil {
+                insertionOrder.append(ipAddress)
+            }
+            entriesByIPAddress[ipAddress] = entries
+        }
+
+        evictIfNeeded()
+    }
+
+    // Return the newest unexpired observation for an IP in average O(1) time.
+    mutating func domain(forIPAddress address: String, at timestamp: Date) -> String? {
+        guard let ipAddress = Self.normalizedIPAddress(address),
+              var entries = entriesByIPAddress[ipAddress] else {
+            return nil
+        }
+
+        entries.removeAll { $0.expiresAt <= timestamp }
+        guard !entries.isEmpty else {
+            // Keep the bounded key slot so reinsertion cannot create duplicate FIFO entries.
+            entriesByIPAddress[ipAddress] = []
+            return nil
+        }
+        entriesByIPAddress[ipAddress] = entries
+        return entries.max { $0.observedAt < $1.observedAt }?.domainName
+    }
+
+    mutating func reset() {
+        entriesByIPAddress.removeAll(keepingCapacity: false)
+        insertionOrder.removeAll(keepingCapacity: false)
+        evictionIndex = 0
+    }
+
+    func debugSnapshot() -> DebugSnapshot {
+        DebugSnapshot(
+            ipAddressCount: entriesByIPAddress.count,
+            candidateCount: entriesByIPAddress.values.reduce(0) { $0 + $1.count }
+        )
+    }
+
+    private mutating func evictIfNeeded() {
+        while entriesByIPAddress.count > maximumIPAddressCount, evictionIndex < insertionOrder.count {
+            let ipAddress = insertionOrder[evictionIndex]
+            evictionIndex += 1
+            entriesByIPAddress.removeValue(forKey: ipAddress)
+        }
+
+        if evictionIndex > 4_096, evictionIndex * 2 > insertionOrder.count {
+            insertionOrder.removeFirst(evictionIndex)
+            evictionIndex = 0
+        }
+    }
+
+    private static func normalizedDomain(_ value: String) -> String? {
+        let normalized = value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        guard !normalized.isEmpty, normalized.utf8.count <= 253 else {
+            return nil
+        }
+        return normalized
+    }
+
+    private static func normalizedIPAddress(_ value: String) -> String? {
+        let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        var ipv4 = in_addr()
+        if inet_pton(AF_INET, value, &ipv4) == 1 {
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &ipv4, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return String(cString: buffer)
+        }
+
+        var ipv6 = in6_addr()
+        if inet_pton(AF_INET6, value, &ipv6) == 1 {
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            guard inet_ntop(AF_INET6, &ipv6, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return String(cString: buffer)
+        }
+        return nil
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketMetadataEnrichmentService.swift
@@ -18,8 +18,23 @@ struct PacketMetadataEnrichmentResult {
 struct PacketMetadataUpdate {
     let packetIDs: [PacketSummary.ID]
     let sniDomainName: String?
+    let dnsDomainName: String?
     let client: PacketClient?
     let direction: PacketDirection?
+
+    init(
+        packetIDs: [PacketSummary.ID],
+        sniDomainName: String?,
+        dnsDomainName: String? = nil,
+        client: PacketClient?,
+        direction: PacketDirection?
+    ) {
+        self.packetIDs = packetIDs
+        self.sniDomainName = sniDomainName
+        self.dnsDomainName = dnsDomainName
+        self.client = client
+        self.direction = direction
+    }
 }
 
 #if DEBUG
@@ -97,6 +112,7 @@ extension PacketClientResolving {
 final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
     private struct FlowMetadata {
         var sniDomainName: String?
+        var dnsDomainName: String?
         var client: PacketClient?
         var direction: PacketDirection?
         var pendingPacketIDs: [PacketSummary.ID] = []
@@ -107,6 +123,7 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
     private let flowIdleTimeout: TimeInterval
     private let maxPendingPacketIDsPerFlow: Int
     private let clientResolver: any PacketClientResolving
+    private var dnsResolutionCache: DNSResolutionCache
     private var flowMetadataByStreamID: [UInt32: FlowMetadata] = [:]
     private var flowOrder: [UInt32] = []
 
@@ -114,11 +131,13 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
         maxCachedFlows: Int = 100_000,
         flowIdleTimeout: TimeInterval = 600,
         maxPendingPacketIDsPerFlow: Int = 128,
+        dnsResolutionCache: DNSResolutionCache = DNSResolutionCache(),
         clientResolver: any PacketClientResolving = MacOSPacketClientResolver()
     ) {
         self.maxCachedFlows = max(maxCachedFlows, 1)
         self.flowIdleTimeout = max(flowIdleTimeout, 0)
         self.maxPendingPacketIDsPerFlow = max(maxPendingPacketIDsPerFlow, 1)
+        self.dnsResolutionCache = dnsResolutionCache
         self.clientResolver = clientResolver
     }
 
@@ -126,6 +145,7 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
     func reset() {
         flowMetadataByStreamID.removeAll(keepingCapacity: false)
         flowOrder.removeAll(keepingCapacity: false)
+        dnsResolutionCache.reset()
         clientResolver.reset()
     }
 
@@ -147,12 +167,17 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
         enrichedPackets.reserveCapacity(packets.count)
 
         for packet in packets {
+            dnsResolutionCache.observe(packet.dnsResolutions ?? [], at: packet.timestamp)
+
             guard let streamID = packet.streamID else {
                 let resolution = source == .live ? clientResolver.resolution(for: packet) : nil
+                let direction = resolution?.direction ?? packet.direction
+                let dnsDomainName = resolvedDNSDomain(for: packet, direction: direction)
                 enrichedPackets.append(packet.tcpviewerApplying(
                     sniDomainName: packet.sniDomainName,
+                    dnsDomainName: dnsDomainName,
                     client: resolution?.client,
-                    direction: resolution?.direction
+                    direction: direction
                 ))
                 continue
             }
@@ -160,7 +185,13 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
             var metadata = metadataForFlow(streamID, packet: packet)
             var shouldBackfill = false
 
-            if let sniDomainName = packet.sniDomainName, !sniDomainName.isEmpty, metadata.sniDomainName != sniDomainName {
+            if metadata.direction == nil {
+                metadata.direction = packet.direction
+            }
+
+            if let sniDomainName = packet.sniDomainName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !sniDomainName.isEmpty,
+               metadata.sniDomainName != sniDomainName {
                 metadata.sniDomainName = sniDomainName
                 shouldBackfill = true
             }
@@ -171,10 +202,25 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
                 shouldBackfill = true
             }
 
+            if metadata.dnsDomainName == nil,
+               let dnsDomainName = packet.dnsDomainName?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !dnsDomainName.isEmpty {
+                metadata.dnsDomainName = dnsDomainName
+                shouldBackfill = true
+            }
+
+            if metadata.sniDomainName == nil,
+               metadata.dnsDomainName == nil,
+               let dnsDomainName = resolvedDNSDomain(for: packet, direction: metadata.direction) {
+                metadata.dnsDomainName = dnsDomainName
+                shouldBackfill = true
+            }
+
             if shouldBackfill, !metadata.pendingPacketIDs.isEmpty {
                 updates.append(PacketMetadataUpdate(
                     packetIDs: metadata.pendingPacketIDs,
                     sniDomainName: metadata.sniDomainName,
+                    dnsDomainName: metadata.dnsDomainName,
                     client: metadata.client,
                     direction: metadata.direction
                 ))
@@ -182,6 +228,7 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
 
             let enrichedPacket = packet.tcpviewerApplying(
                 sniDomainName: metadata.sniDomainName ?? packet.sniDomainName,
+                dnsDomainName: metadata.dnsDomainName ?? packet.dnsDomainName,
                 client: metadata.client,
                 direction: metadata.direction
             )
@@ -194,6 +241,41 @@ final class PacketMetadataEnrichmentService: PacketMetadataEnriching {
         }
 
         return PacketMetadataEnrichmentResult(packets: enrichedPackets, updates: updates)
+    }
+
+    private func resolvedDNSDomain(for packet: PacketSummary, direction: PacketDirection?) -> String? {
+        guard packet.transportHint != .dns else {
+            return nil
+        }
+
+        // Direction selects the remote endpoint; ambiguous traffic is attributed only with one clear match.
+        switch direction {
+        case .outbound:
+            return packet.endpoints.destination.address.flatMap {
+                dnsResolutionCache.domain(forIPAddress: $0, at: packet.timestamp)
+            }
+        case .inbound:
+            return packet.endpoints.source.address.flatMap {
+                dnsResolutionCache.domain(forIPAddress: $0, at: packet.timestamp)
+            }
+        case .local, .unknown, nil:
+            let sourceDomain = packet.endpoints.source.address.flatMap {
+                dnsResolutionCache.domain(forIPAddress: $0, at: packet.timestamp)
+            }
+            let destinationDomain = packet.endpoints.destination.address.flatMap {
+                dnsResolutionCache.domain(forIPAddress: $0, at: packet.timestamp)
+            }
+            if let sourceDomain, destinationDomain == nil {
+                return sourceDomain
+            }
+            if let destinationDomain, sourceDomain == nil {
+                return destinationDomain
+            }
+            if sourceDomain == destinationDomain {
+                return sourceDomain
+            }
+            return nil
+        }
     }
 
     private func metadataForFlow(_ streamID: UInt32, packet: PacketSummary) -> FlowMetadata {
@@ -752,6 +834,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
+            dnsDomainName: dnsDomainName,
+            dnsResolutions: dnsResolutions,
             client: client,
             textStyle: textStyle,
             customComment: customComment
@@ -760,6 +844,7 @@ extension PacketSummary {
 
     func tcpviewerApplying(
         sniDomainName: String? = nil,
+        dnsDomainName: String? = nil,
         client: PacketClient? = nil,
         direction: PacketDirection? = nil
     ) -> PacketSummary {
@@ -783,6 +868,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName ?? self.sniDomainName,
+            dnsDomainName: dnsDomainName ?? self.dnsDomainName,
+            dnsResolutions: dnsResolutions,
             client: client ?? self.client,
             textStyle: textStyle,
             customComment: customComment
@@ -810,6 +897,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
+            dnsDomainName: dnsDomainName,
+            dnsResolutions: dnsResolutions,
             client: client,
             textStyle: textStyle,
             customComment: customComment

--- a/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketPinService.swift
@@ -50,7 +50,7 @@ enum PacketPinMatcher {
     static func matches(_ packet: PacketSummary, pin: PacketPin) -> Bool {
         switch pin.kind {
         case .domain:
-            return normalizedDomain(packet.sniDomainName) == pin.domain
+            return normalizedDomain(packet.domainName) == pin.domain
         case .ip:
             return packet.endpoints.source.address == pin.ipAddress ||
                 packet.endpoints.destination.address == pin.ipAddress
@@ -195,14 +195,14 @@ final class PacketPinService {
     ) throws -> PacketPin {
         switch kind {
         case .domain:
-            guard let domain = PacketPinMatcher.normalizedDomain(packet.sniDomainName) else {
+            guard let domain = PacketPinMatcher.normalizedDomain(packet.domainName) else {
                 throw PacketPinCreationError.missingDomain
             }
 
             return PacketPin(
                 id: PacketPinID(rawValue: "domain:\(domain)"),
                 kind: .domain,
-                title: packet.sniDomainName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? domain,
+                title: packet.domainName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? domain,
                 createdAt: now,
                 domain: domain,
                 ipAddress: nil,

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -405,7 +405,7 @@ enum PacketSourceListClassifier {
     }
 
     static func domainIdentity(for packet: PacketSummary) -> PacketSourceDomainIdentity {
-        guard let domainName = trimmed(packet.sniDomainName) else {
+        guard let domainName = trimmed(packet.domainName) else {
             return PacketSourceDomainIdentity(key: .ipAddresses, displayName: "IP Addresses")
         }
 

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
@@ -535,6 +535,8 @@ extension PacketSummary {
             decodeStatus: decodeStatus,
             captureMetadata: captureMetadata,
             sniDomainName: sniDomainName,
+            dnsDomainName: dnsDomainName,
+            dnsResolutions: dnsResolutions,
             client: client,
             textStyle: textStyle,
             customComment: customComment

--- a/TCPViewerTests/Features/NetworkInspector/DNSResolutionCacheTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/DNSResolutionCacheTests.swift
@@ -1,0 +1,121 @@
+//
+//  DNSResolutionCacheTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+struct DNSResolutionCacheTests {
+
+    @Test func storesAndLooksUpIPv4Address() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation("spotify.com", "35.186.224.34", ttl: 60)], at: time(0))
+
+        #expect(cache.domain(forIPAddress: "35.186.224.34", at: time(1)) == "spotify.com")
+    }
+
+    @Test func canonicalizesIPv6LookupAddress() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation("ipv6.example", "2001:0db8:0:0:0:0:0:1", ttl: 60)], at: time(0))
+
+        #expect(cache.domain(forIPAddress: "2001:db8::1", at: time(1)) == "ipv6.example")
+    }
+
+    @Test func normalizesDomainCaseAndTrailingDot() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation(" Spotify.COM. ", "192.0.2.1", ttl: 60)], at: time(0))
+
+        #expect(cache.domain(forIPAddress: "192.0.2.1", at: time(1)) == "spotify.com")
+    }
+
+    @Test func returnsNilForUnknownAddress() {
+        var cache = DNSResolutionCache()
+
+        #expect(cache.domain(forIPAddress: "192.0.2.99", at: time(0)) == nil)
+    }
+
+    @Test func expiresEntryAtDNSRecordTTL() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation("short.example", "192.0.2.2", ttl: 5)], at: time(10))
+
+        #expect(cache.domain(forIPAddress: "192.0.2.2", at: time(14)) == "short.example")
+        #expect(cache.domain(forIPAddress: "192.0.2.2", at: time(15)) == nil)
+    }
+
+    @Test func capsEntryLifetimeAtConfiguredRetention() {
+        var cache = DNSResolutionCache(maximumRetention: 10)
+        cache.observe([observation("long.example", "192.0.2.3", ttl: 3_600)], at: time(0))
+
+        #expect(cache.domain(forIPAddress: "192.0.2.3", at: time(9)) == "long.example")
+        #expect(cache.domain(forIPAddress: "192.0.2.3", at: time(10)) == nil)
+    }
+
+    @Test func ignoresZeroTTLObservations() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation("zero.example", "192.0.2.4", ttl: 0)], at: time(0))
+
+        #expect(cache.domain(forIPAddress: "192.0.2.4", at: time(0)) == nil)
+    }
+
+    @Test func newestDomainWinsForSharedIPAddress() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation("old.example", "192.0.2.5", ttl: 60)], at: time(0))
+        cache.observe([observation("new.example", "192.0.2.5", ttl: 60)], at: time(1))
+
+        #expect(cache.domain(forIPAddress: "192.0.2.5", at: time(2)) == "new.example")
+    }
+
+    @Test func capsCandidatesPerIPAddress() {
+        var cache = DNSResolutionCache(maximumDomainsPerIPAddress: 2)
+        cache.observe([observation("one.example", "192.0.2.6", ttl: 60)], at: time(0))
+        cache.observe([observation("two.example", "192.0.2.6", ttl: 60)], at: time(1))
+        cache.observe([observation("three.example", "192.0.2.6", ttl: 60)], at: time(2))
+
+        #expect(cache.debugSnapshot().candidateCount == 2)
+        #expect(cache.domain(forIPAddress: "192.0.2.6", at: time(3)) == "three.example")
+    }
+
+    @Test func evictsOldestIPAddressAtGlobalLimit() {
+        var cache = DNSResolutionCache(maximumIPAddressCount: 2)
+        cache.observe([observation("one.example", "192.0.2.1", ttl: 60)], at: time(0))
+        cache.observe([observation("two.example", "192.0.2.2", ttl: 60)], at: time(1))
+        cache.observe([observation("three.example", "192.0.2.3", ttl: 60)], at: time(2))
+
+        #expect(cache.domain(forIPAddress: "192.0.2.1", at: time(3)) == nil)
+        #expect(cache.domain(forIPAddress: "192.0.2.2", at: time(3)) == "two.example")
+        #expect(cache.domain(forIPAddress: "192.0.2.3", at: time(3)) == "three.example")
+    }
+
+    @Test func rejectsInvalidAddressesAndDomains() {
+        var cache = DNSResolutionCache()
+        cache.observe([
+            observation("", "192.0.2.1", ttl: 60),
+            observation("invalid.example", "not-an-ip", ttl: 60),
+        ], at: time(0))
+
+        #expect(cache.debugSnapshot() == .init(ipAddressCount: 0, candidateCount: 0))
+    }
+
+    @Test func resetRemovesAllObservations() {
+        var cache = DNSResolutionCache()
+        cache.observe([observation("reset.example", "192.0.2.7", ttl: 60)], at: time(0))
+
+        cache.reset()
+
+        #expect(cache.domain(forIPAddress: "192.0.2.7", at: time(1)) == nil)
+        #expect(cache.debugSnapshot() == .init(ipAddressCount: 0, candidateCount: 0))
+    }
+
+    private func observation(_ domain: String, _ address: String, ttl: UInt32) -> DNSResolutionObservation {
+        DNSResolutionObservation(domainName: domain, ipAddress: address, timeToLive: ttl)
+    }
+
+    private func time(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: seconds)
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/PacketMetadataDNSAttributionTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketMetadataDNSAttributionTests.swift
@@ -1,0 +1,239 @@
+//
+//  PacketMetadataDNSAttributionTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/8/26.
+//
+
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+struct PacketMetadataDNSAttributionTests {
+
+    @Test func attributesLaterOutboundPacketFromDNSResponse() throws {
+        let service = makeService()
+        let result = service.enrich([
+            dnsPacket(domain: "spotify.com", address: "35.186.224.34", ttl: 60),
+            flowPacket(number: 2, destination: "35.186.224.34", direction: .outbound),
+        ], source: .offline)
+
+        #expect(result.packets[1].dnsDomainName == "spotify.com")
+        #expect(result.packets[1].domainName == "spotify.com")
+        #expect(result.packets[1].domainSource == .dns)
+    }
+
+    @Test func attributesLaterInboundPacketFromDNSResponse() throws {
+        let service = makeService()
+        let result = service.enrich([
+            dnsPacket(domain: "edge.example", address: "203.0.113.9", ttl: 60),
+            flowPacket(
+                number: 2,
+                source: "203.0.113.9",
+                destination: "192.168.1.5",
+                direction: .inbound
+            ),
+        ], source: .offline)
+
+        #expect(result.packets[1].dnsDomainName == "edge.example")
+    }
+
+    @Test func attributesCanonicalIPv6Endpoint() throws {
+        let service = makeService()
+        let result = service.enrich([
+            dnsPacket(domain: "ipv6.example", address: "2001:db8::8", ttl: 60),
+            flowPacket(number: 2, destination: "2001:0db8:0:0:0:0:0:8", direction: .outbound),
+        ], source: .offline)
+
+        #expect(result.packets[1].dnsDomainName == "ipv6.example")
+    }
+
+    @Test func keepsSNIAsHigherPriorityThanDNS() throws {
+        let service = makeService()
+        let result = service.enrich([
+            dnsPacket(domain: "dns.example", address: "192.0.2.10", ttl: 60),
+            flowPacket(
+                number: 2,
+                destination: "192.0.2.10",
+                direction: .outbound,
+                sniDomainName: "sni.example"
+            ),
+        ], source: .offline)
+
+        #expect(result.packets[1].sniDomainName == "sni.example")
+        #expect(result.packets[1].domainName == "sni.example")
+        #expect(result.packets[1].domainSource == .sni)
+    }
+
+    @Test func laterSNIBackfillsDNSAttributedFlow() throws {
+        let service = makeService()
+        let dns = dnsPacket(domain: "dns.example", address: "192.0.2.11", ttl: 60)
+        let first = flowPacket(
+            number: 2,
+            destination: "192.0.2.11",
+            streamID: 77,
+            direction: .outbound
+        )
+        let clientHello = flowPacket(
+            number: 3,
+            destination: "192.0.2.11",
+            streamID: 77,
+            direction: .outbound,
+            sniDomainName: "sni.example"
+        )
+
+        _ = service.enrich([dns, first], source: .offline)
+        let result = service.enrich([clientHello], source: .offline)
+
+        #expect(result.packets.first?.domainName == "sni.example")
+        #expect(result.updates.first?.packetIDs == [first.id])
+        #expect(result.updates.first?.sniDomainName == "sni.example")
+    }
+
+    @Test func doesNotAttributeExpiredDNSObservation() throws {
+        let service = makeService()
+        let result = service.enrich([
+            dnsPacket(domain: "expired.example", address: "192.0.2.12", ttl: 1, timestamp: 10),
+            flowPacket(number: 2, destination: "192.0.2.12", direction: .outbound, timestamp: 11),
+        ], source: .offline)
+
+        #expect(result.packets[1].domainName == nil)
+    }
+
+    @Test func resetClearsDNSObservations() throws {
+        let service = makeService()
+        _ = service.enrich([
+            dnsPacket(domain: "reset.example", address: "192.0.2.13", ttl: 60),
+        ], source: .offline)
+
+        service.reset()
+        let result = service.enrich([
+            flowPacket(number: 2, destination: "192.0.2.13", direction: .outbound),
+        ], source: .offline)
+
+        #expect(result.packets.first?.domainName == nil)
+    }
+
+    @Test func leavesPacketUnattributedWhenBothUnknownEndpointsMatch() throws {
+        let service = makeService()
+        let result = service.enrich([
+            dnsPacket(domain: "source.example", address: "192.0.2.20", ttl: 60),
+            dnsPacket(number: 2, domain: "destination.example", address: "192.0.2.21", ttl: 60),
+            flowPacket(number: 3, source: "192.0.2.20", destination: "192.0.2.21", direction: nil),
+        ], source: .offline)
+
+        #expect(result.packets[2].domainName == nil)
+    }
+
+    @Test func skipsAttributionOnDNSPacketItself() throws {
+        let service = makeService()
+        let first = dnsPacket(domain: "resolver.example", address: "8.8.8.8", ttl: 60)
+        let second = dnsPacket(number: 2, domain: "other.example", address: "192.0.2.30", ttl: 60)
+
+        let result = service.enrich([first, second], source: .offline)
+
+        #expect(result.packets.allSatisfy { $0.dnsDomainName == nil })
+    }
+
+    @Test func leavesDoTAndDoHTrafficUnattributedWithoutPlaintextEvidence() throws {
+        let service = makeService()
+        let dot = flowPacket(number: 1, destination: "1.1.1.1", destinationPort: 853, direction: .outbound)
+        let doh = flowPacket(number: 2, destination: "1.1.1.1", destinationPort: 443, direction: .outbound)
+
+        let result = service.enrich([dot, doh], source: .offline)
+
+        #expect(result.packets.allSatisfy { $0.domainName == nil })
+    }
+
+    private func makeService() -> PacketMetadataEnrichmentService {
+        PacketMetadataEnrichmentService(
+            dnsResolutionCache: DNSResolutionCache(maximumRetention: 3_600),
+            clientResolver: DNSAttributionClientResolver()
+        )
+    }
+
+    private func dnsPacket(
+        number: UInt64 = 1,
+        domain: String,
+        address: String,
+        ttl: UInt32,
+        timestamp: TimeInterval = 0
+    ) -> PacketSummary {
+        packet(
+            number: number,
+            timestamp: timestamp,
+            transportHint: .dns,
+            source: "8.8.8.8",
+            sourcePort: 53,
+            destination: "192.168.1.5",
+            destinationPort: 53_000,
+            dnsResolutions: [DNSResolutionObservation(domainName: domain, ipAddress: address, timeToLive: ttl)]
+        )
+    }
+
+    private func flowPacket(
+        number: UInt64,
+        source: String = "192.168.1.5",
+        destination: String,
+        destinationPort: UInt16 = 443,
+        streamID: UInt32? = nil,
+        direction: PacketDirection?,
+        sniDomainName: String? = nil,
+        timestamp: TimeInterval = 1
+    ) -> PacketSummary {
+        packet(
+            number: number,
+            timestamp: timestamp,
+            transportHint: .tls,
+            source: source,
+            sourcePort: 52_000,
+            destination: destination,
+            destinationPort: destinationPort,
+            streamID: streamID,
+            direction: direction,
+            sniDomainName: sniDomainName
+        )
+    }
+
+    private func packet(
+        number: UInt64,
+        timestamp: TimeInterval,
+        transportHint: TransportProtocolHint,
+        source: String,
+        sourcePort: UInt16,
+        destination: String,
+        destinationPort: UInt16,
+        streamID: UInt32? = nil,
+        direction: PacketDirection? = nil,
+        sniDomainName: String? = nil,
+        dnsResolutions: [DNSResolutionObservation]? = nil
+    ) -> PacketSummary {
+        PacketSummary(
+            packetNumber: number,
+            timestamp: Date(timeIntervalSince1970: timestamp),
+            source: .offline,
+            transportHint: transportHint,
+            protocolSummary: transportHint.rawValue.uppercased(),
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: source, port: sourcePort),
+                destination: PacketEndpoint(address: destination, port: destinationPort)
+            ),
+            originalLength: 100,
+            capturedLength: 100,
+            streamID: streamID,
+            direction: direction,
+            infoSummary: "Fixture",
+            layers: [],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: sniDomainName,
+            dnsResolutions: dnsResolutions
+        )
+    }
+}
+
+private final class DNSAttributionClientResolver: PacketClientResolving {
+    func reset() {}
+    func client(for packet: PacketSummary) -> PacketClient? { nil }
+}

--- a/scripts/bootstrap-wireshark-deps.sh
+++ b/scripts/bootstrap-wireshark-deps.sh
@@ -108,6 +108,8 @@ export PKG_CONFIG_PATH="$INSTALL_ROOT/lib/pkgconfig:$INSTALL_ROOT/share/pkgconfi
 export PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH"
 export CMAKE_PREFIX_PATH="$INSTALL_ROOT"
 export PATH="$INSTALL_ROOT/bin:$PATH"
+# Meson detects Ninja separately, so pass the absolute path resolved outside Xcode's restricted PATH.
+export NINJA="$NINJA_BIN"
 export CC="${CC:-/usr/bin/clang}"
 export CXX="${CXX:-/usr/bin/clang++}"
 unset CPATH
@@ -273,7 +275,16 @@ build_cmake "pcre2" "$(extract_archive "pcre2-$PCRE2_VERSION" "pcre2-$PCRE2_VERS
   -DPCRE2_BUILD_PCRE2_32=OFF
 
 download_archive "glib-$GLIB_VERSION.tar.xz" "https://download.gnome.org/sources/glib/2.88/glib-$GLIB_VERSION.tar.xz" "51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e"
-build_meson "glib" "$(extract_archive "glib-$GLIB_VERSION" "glib-$GLIB_VERSION.tar.xz")" \
+GLIB_SOURCE_DIR="$(extract_archive "glib-$GLIB_VERSION" "glib-$GLIB_VERSION.tar.xz")"
+GLIB_PATCH_FILE="$PROJECT_DIR/scripts/patches/glib-2.88.1-macos-pipe2-availability.patch"
+# Keep patching idempotent because extracted dependency sources are cached between builds.
+if /usr/bin/patch -d "$GLIB_SOURCE_DIR" -p1 --forward --dry-run < "$GLIB_PATCH_FILE" >/dev/null 2>&1; then
+  /usr/bin/patch -d "$GLIB_SOURCE_DIR" -p1 --forward < "$GLIB_PATCH_FILE"
+elif ! /usr/bin/patch -d "$GLIB_SOURCE_DIR" -p1 --reverse --dry-run < "$GLIB_PATCH_FILE" >/dev/null 2>&1; then
+  echo "error: could not apply the GLib macOS availability patch." >&2
+  exit 1
+fi
+build_meson "glib" "$GLIB_SOURCE_DIR" \
   -Dtests=false \
   -Dinstalled_tests=false \
   -Dintrospection=disabled \
@@ -318,7 +329,8 @@ download_archive "brotli-$BROTLI_VERSION.tar.gz" "https://github.com/google/brot
 build_cmake "brotli" "$(extract_archive "brotli-$BROTLI_VERSION" "brotli-$BROTLI_VERSION.tar.gz")" -DBUILD_SHARED_LIBS=ON -DBROTLI_DISABLE_TESTS=ON
 
 download_archive "c-ares-$CARES_VERSION.tar.gz" "https://github.com/c-ares/c-ares/releases/download/v$CARES_VERSION/c-ares-$CARES_VERSION.tar.gz" "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5"
-build_cmake "c-ares" "$(extract_archive "c-ares-$CARES_VERSION" "c-ares-$CARES_VERSION.tar.gz")" -DCARES_SHARED=ON -DCARES_STATIC=OFF -DCARES_BUILD_TOOLS=OFF -DCARES_BUILD_TESTS=OFF
+# SDK 27 exposes pipe2, but c-ares must retain its portable fallback for the macOS 15 target.
+build_cmake "c-ares" "$(extract_archive "c-ares-$CARES_VERSION" "c-ares-$CARES_VERSION.tar.gz")" -DCARES_SHARED=ON -DCARES_STATIC=OFF -DCARES_BUILD_TOOLS=OFF -DCARES_BUILD_TESTS=OFF -DHAVE_PIPE2=0
 
 download_archive "lz4-$LZ4_VERSION.tar.gz" "https://github.com/lz4/lz4/archive/refs/tags/v$LZ4_VERSION.tar.gz" "537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b"
 (

--- a/scripts/bootstrap-wireshark.sh
+++ b/scripts/bootstrap-wireshark.sh
@@ -242,7 +242,9 @@ if [ -f "$STAMP_FILE" ] && [ "$(cat "$STAMP_FILE")" = "$CURRENT_STAMP_CONTENT" ]
   exit 0
 fi
 
-if ! command -v pkg-config >/dev/null 2>&1; then
+# Xcode omits Homebrew from PATH, so resolve pkg-config from its standard absolute locations.
+PKG_CONFIG_BIN="$(find_tool "${PKG_CONFIG:-}" pkg-config /opt/homebrew/bin/pkg-config /usr/local/bin/pkg-config)"
+if [ -z "$PKG_CONFIG_BIN" ]; then
   echo "error: pkg-config is required for Wireshark dependency discovery." >&2
   echo "       Install build tools with: brew install pkg-config cmake ninja meson autoconf automake libtool" >&2
   exit 1
@@ -309,6 +311,7 @@ mkdir -p "$INSTALL_ROOT"
 export MACOSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET"
 export PKG_CONFIG_PATH="$DEPS_INSTALL_ROOT/lib/pkgconfig:$DEPS_INSTALL_ROOT/share/pkgconfig"
 export PKG_CONFIG_LIBDIR="$PKG_CONFIG_PATH"
+export PKG_CONFIG="$PKG_CONFIG_BIN"
 export CMAKE_PREFIX_PATH="$DEPS_INSTALL_ROOT"
 export PATH="$DEPS_INSTALL_ROOT/bin:$PATH"
 export CC="${CC:-/usr/bin/clang}"
@@ -330,6 +333,7 @@ export LDFLAGS="-L$DEPS_INSTALL_ROOT/lib -mmacosx-version-min=$DEPLOYMENT_TARGET
 
 "$CMAKE_BIN" -S "$SOURCE_DIR" -B "$BUILD_DIR" -G Ninja \
   -DCMAKE_MAKE_PROGRAM="$NINJA_BIN" \
+  -DPKG_CONFIG_EXECUTABLE="$PKG_CONFIG_BIN" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX="$INSTALL_ROOT" \
   -DCMAKE_OSX_ARCHITECTURES="$CMAKE_ARCHITECTURES" \
@@ -350,6 +354,7 @@ export LDFLAGS="-L$DEPS_INSTALL_ROOT/lib -mmacosx-version-min=$DEPLOYMENT_TARGET
   -DENABLE_PLUGINS=OFF \
   -DENABLE_AMRNB=OFF \
   -DENABLE_OPUS=OFF \
+  -DENABLE_SPANDSP=OFF \
   -DBUILD_androiddump=OFF \
   -DBUILD_ciscodump=OFF \
   -DBUILD_capinfos=OFF \

--- a/scripts/patches/glib-2.88.1-macos-pipe2-availability.patch
+++ b/scripts/patches/glib-2.88.1-macos-pipe2-availability.patch
@@ -1,0 +1,13 @@
+--- a/glib/glib-unixprivate.h
++++ b/glib/glib-unixprivate.h
+@@ -45,6 +45,10 @@ g_unix_open_pipe_internal (int *fds,
+                            gboolean nonblock)
+   {
+ #ifdef HAVE_PIPE2
++#ifdef __APPLE__
++  /* pipe2 was added in macOS 27, so keep the fallback for older supported releases. */
++  if (__builtin_available (macOS 27.0, *))
++#endif
+   do
+     {
+       int ecode;


### PR DESCRIPTION
## Summary

- Parse plaintext DNS responses on UDP/53, including A, AAAA, CNAME, compression, and TTL data.
- Reassemble bounded DNS-over-TCP streams so split and coalesced responses also produce resolution observations.
- Cache IP-to-domain observations in memory with average O(1) lookup, TTL expiry, retention limits, and bounded capacity.
- Use cached DNS evidence when SNI is unavailable while continuing to prefer SNI when both sources exist.
- Surface the resolved domain and source consistently across the packet table, filters, pins, saved sessions, source lists, and MCP output.

## Why

Some applications, including Spotify, reuse encrypted connections or omit an observable TLS ClientHello/SNI in the captured packet range. Those packets previously displayed only destination IP addresses even when a plaintext DNS response had already associated the IP with a hostname.

This change passively records DNS evidence during capture and applies it to later packets without performing active reverse-DNS requests.

## Implementation notes

- Stream and cache state are incremental and bounded for high-throughput live capture.
- DNS attribution is best-effort because CDNs and shared IP addresses may legitimately map several hostnames to one address.
- DNS-over-HTTPS and DNS-over-TLS remain opaque without decryption and are intentionally not parsed as plaintext DNS.

## Validation

- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'`
- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
- Focused DNS parser, stream reassembly, cache, attribution, and inspector pipeline tests.

## AI assistance disclosure

This pull request was substantially assisted by OpenAI Codex. The resulting changes were reviewed through local diff inspection and verified with the tests and build commands above.
