### PR TITLE
Add a Homebrew-only release workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,6 @@ TCPVIEWER_PUBLISH_RELEASE_TO_BACKEND=false
 TCPVIEWER_RELEASE_BACKEND_URL=
 TCPVIEWER_RELEASE_BACKEND_SCRIPT_SECRET=
 
-# Required only when a production release creates an initial or updated Homebrew Cask PR.
+# Required when a production release or release:homebrew creates a Homebrew Cask PR.
 # Use the path printed by: brew --repository homebrew/cask
 TCPVIEWER_HOMEBREW_CASK_REPO=/path/to/homebrew-cask

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release beta production nodejs-install
+.PHONY: build release beta production homebrew nodejs-install
 
 build: release
 
@@ -10,6 +10,9 @@ beta:
 
 production:
 	cd scripts/nodejs && npm start -- --type=production
+
+homebrew:
+	npm run release:homebrew
 
 nodejs-install:
 	npm install

--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ Production releases also:
 - Push the `v<version>` tag.
 - Publish the GitHub release.
 
+To create only the Homebrew Cask pull request for the latest public production
+release, run `make build` and choose `Homebrew Cask PR from latest release`.
+You can also run the direct command:
+
+```bash
+npm run release:homebrew
+```
+
+This verifies the public DMG against the GitHub release asset, pushes a branch to
+`ProxymanApp/homebrew-cask`, and opens the contribution pull request in
+`Homebrew/homebrew-cask`.
+
 Artifacts are written to:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "release": "node scripts/release.mjs",
+    "release:homebrew": "node scripts/release.mjs --homebrew-only",
     "test": "node --test tests/**/*.test.mjs"
   },
   "dependencies": {

--- a/scripts/homebrew/README.md
+++ b/scripts/homebrew/README.md
@@ -2,6 +2,24 @@
 
 The production release can create the initial TCP Viewer cask or update the existing cask.
 
+The Homebrew-only command submits the latest public production release:
+
+```bash
+npm run release:homebrew
+```
+
+It downloads the public production DMG and checks its size and SHA-256 against the
+matching GitHub release asset before changing the cask repository. It does not build,
+upload, tag, or republish TCP Viewer.
+
+You can also run `make build` and choose `Homebrew Cask PR from latest release`.
+The script shows the release and pull request branches, then asks for confirmation
+before it fetches or changes the Homebrew checkout.
+
+The pull request body starts from the current template in upstream `origin/main`.
+The script keeps its checklist text intact, marks completed actions, and adds the
+repository metrics and AI/LLM disclosure before creating the pull request.
+
 ## One-time setup
 
 ```bash
@@ -16,7 +34,7 @@ Set `TCPVIEWER_HOMEBREW_CASK_REPO` in the local `.env` file to the path printed 
 brew --repository homebrew/cask
 ```
 
-The release always creates its cask branch from current `origin/main`. It pushes only that branch to the `proxyman` fork remote, so a stale fork default branch cannot enter the pull request.
+The release always creates its cask branch from current `origin/main`. It pushes only that branch to the `proxyman` fork remote, so a stale fork default branch cannot enter the pull request. GitHub hosts the pull request in `Homebrew/homebrew-cask`, with `ProxymanApp:<branch>` as its source.
 
 ## Initial cask
 
@@ -46,6 +64,7 @@ Review Homebrew's current [cask acceptance](https://docs.brew.sh/Acceptable-Cask
 - `--no-bump-homebrew` skips Homebrew.
 - `--yes` skips Homebrew unless `--bump-homebrew` is also present.
 - `--homebrew-install-tested` confirms the initial install and uninstall checks already passed.
+- `--homebrew-only` submits the latest public production release without publishing it again.
 
 After Homebrew merges the initial cask, users can install the app with:
 

--- a/scripts/nodejs/README.md
+++ b/scripts/nodejs/README.md
@@ -10,7 +10,12 @@ release workflow.
 npm start
 npm start -- --type=beta
 npm start -- --type=production
+npm start -- --type=homebrew
+npm start -- --homebrew-only
 ```
+
+`--homebrew-only` creates a Homebrew Cask pull request for the production build
+in the latest public GitHub release. It does not rebuild or republish the app.
 
 All real signing, notarization, Sentry, and R2 values must stay in the
 ignored root `.env` file or the shell environment. Use `.env.example` for safe

--- a/scripts/nodejs/index.js
+++ b/scripts/nodejs/index.js
@@ -9,6 +9,7 @@ const releaseScriptPath = path.join(repoRoot, "scripts", "release.mjs");
 const RELEASE_TYPE = {
   BETA: "beta",
   PRODUCTION: "production",
+  HOMEBREW: "homebrew",
 };
 
 function parseArgs(argv) {
@@ -26,6 +27,8 @@ function parseArgs(argv) {
       args.bumpHomebrew = false;
     } else if (arg === "--homebrew-install-tested") {
       args.homebrewInstallTested = true;
+    } else if (arg === "--homebrew-only") {
+      args.homebrewOnly = true;
     }
   }
   return args;
@@ -81,16 +84,17 @@ async function resolveReleaseType(type) {
     if (Object.values(RELEASE_TYPE).includes(type)) {
       return type;
     }
-    throw new Error("Release type must be beta or production.");
+    throw new Error("Release type must be beta, production, or homebrew.");
   }
 
   const response = await prompts({
     type: "select",
     name: "type",
-    message: "What would you like to build?",
+    message: "What would you like to do?",
     choices: [
       { title: "BETA Build", value: RELEASE_TYPE.BETA },
       { title: "Production Build", value: RELEASE_TYPE.PRODUCTION },
+      { title: "Homebrew Cask PR from latest release", value: RELEASE_TYPE.HOMEBREW },
     ],
     initial: 0,
   });
@@ -102,7 +106,14 @@ async function resolveReleaseType(type) {
 }
 
 function buildReleaseArgs(type, args) {
-  const releaseArgs = [releaseScriptPath, `--type=${type}`];
+  const releaseArgs = [releaseScriptPath];
+  const homebrewOnly = args.homebrewOnly || type === RELEASE_TYPE.HOMEBREW;
+  if (type && !homebrewOnly) {
+    releaseArgs.push(`--type=${type}`);
+  }
+  if (homebrewOnly) {
+    releaseArgs.push("--homebrew-only");
+  }
   if (args.betaName) {
     releaseArgs.push(`--beta-name=${args.betaName}`);
   }
@@ -143,7 +154,7 @@ async function main() {
   console.log("-------------------------------");
 
   const args = parseArgs(process.argv.slice(2));
-  const type = await resolveReleaseType(args.type);
+  const type = args.homebrewOnly ? RELEASE_TYPE.HOMEBREW : await resolveReleaseType(args.type);
   await runRelease(type, args);
 }
 

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -360,49 +360,134 @@ export function validateHomebrewLivecheckOutput(output, expectedVersion) {
   }
 }
 
-export function makeHomebrewCaskPullRequestBody({ isInitialCask, githubMetrics, token = "tcpviewer" }) {
-  const lines = [
-    "-----",
-    "",
-    "- [x] The submission is for "
-    + "[a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or documented exception.",
-    `- [x] \`brew audit --cask --online ${token}\` is error-free.`,
-    `- [x] \`brew style --fix ${token}\` reports no offenses.`,
-    ""
-  ];
-  if (isInitialCask) {
-    if (!githubMetrics) {
-      throw new Error("GitHub metrics are required for an initial Homebrew Cask pull request.");
+export function validatePublishedGitHubReleaseAsset(release, { tagName, assetName }) {
+  if (release?.tagName !== tagName) {
+    throw new Error(`GitHub release must use tag ${tagName}.`);
+  }
+  if (release.isDraft || release.isPrerelease) {
+    throw new Error(`GitHub release ${tagName} must be a published production release.`);
+  }
+
+  const matches = Array.isArray(release.assets)
+    ? release.assets.filter((asset) => asset?.name === assetName)
+    : [];
+  if (matches.length !== 1) {
+    throw new Error(`GitHub release ${tagName} must contain exactly one ${assetName} asset.`);
+  }
+
+  const asset = matches[0];
+  const digest = String(asset.digest ?? "").trim().toLowerCase();
+  if (!/^sha256:[a-f0-9]{64}$/.test(digest)) {
+    throw new Error(`GitHub release asset ${assetName} must include a SHA-256 digest.`);
+  }
+  if (!Number.isSafeInteger(asset.size) || asset.size <= 0) {
+    throw new Error(`GitHub release asset ${assetName} must include a positive file size.`);
+  }
+
+  return {
+    name: assetName,
+    sha256: digest.slice("sha256:".length),
+    size: asset.size
+  };
+}
+
+export function resolvePublishedGitHubReleaseArtifact(release) {
+  const tagName = String(release?.tagName ?? "").trim();
+  if (!tagName.startsWith("v")) {
+    throw new Error("The latest GitHub release tag must start with v.");
+  }
+
+  const version = tagName.slice(1);
+  if (makeGitHubReleaseTagName(version) !== tagName) {
+    throw new Error(`The latest GitHub release tag is invalid: ${tagName}.`);
+  }
+
+  const prefix = `${releaseDMGAppName}_${version}_`;
+  const suffix = ".dmg";
+  const candidates = Array.isArray(release.assets)
+    ? release.assets.flatMap((asset) => {
+        const name = String(asset?.name ?? "");
+        if (!name.startsWith(prefix) || !name.endsWith(suffix)) {
+          return [];
+        }
+
+        const buildNumber = name.slice(prefix.length, -suffix.length);
+        try {
+          return makeDMGFileName({ version, buildNumber }) === name
+            ? [{ asset, buildNumber }]
+            : [];
+        } catch {
+          return [];
+        }
+      })
+    : [];
+  if (candidates.length !== 1) {
+    throw new Error(`GitHub release ${tagName} must contain exactly one production DMG asset.`);
+  }
+
+  const candidate = candidates[0];
+  const validated = validatePublishedGitHubReleaseAsset(release, {
+    tagName,
+    assetName: candidate.asset.name
+  });
+  return {
+    tagName,
+    version,
+    buildNumber: candidate.buildNumber,
+    dmgFileName: validated.name,
+    sha256: validated.sha256,
+    size: validated.size
+  };
+}
+
+export function makeHomebrewCaskPullRequestBody({ template, isInitialCask, githubMetrics }) {
+  const templateLines = String(template ?? "").replaceAll("\r\n", "\n").trim().split("\n");
+  const checkboxLines = templateLines.filter((line) => /^- \[ \] /.test(line));
+  if (checkboxLines.length === 0 || !checkboxLines.some((line) => /\b(?:AI|LLM)\b/i.test(line))) {
+    throw new Error("The Homebrew Cask pull request template is missing its checklist or AI disclosure.");
+  }
+  if (isInitialCask && !githubMetrics) {
+    throw new Error("GitHub metrics are required for an initial Homebrew Cask pull request.");
+  }
+
+  let inNewCaskSection = false;
+  const completedTemplate = templateLines.map((line) => {
+    if (line.startsWith("Additionally, if adding a new cask:")) {
+      inNewCaskSection = true;
+      return line;
     }
-    lines.push(
-      "Additionally, for this new cask:",
-      "",
-      "- [x] Named the cask according to the "
-      + "[token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).",
-      "- [x] Checked that the cask was not previously refused.",
-      `- [x] \`brew audit --cask --new ${token}\` worked successfully.`,
-      `- [x] \`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask ${token}\` worked successfully.`,
-      `- [x] \`brew uninstall --cask ${token}\` worked successfully.`,
-      "",
-      "Canonical repository: https://github.com/ProxymanApp/TCPViewer ",
-      `(${githubMetrics.stars} stars, ${githubMetrics.forks} forks, `
-      + `${githubMetrics.watchers} watchers when this PR was created).`,
+    if (inNewCaskSection && /^-+$/.test(line.trim())) {
+      inNewCaskSection = false;
+      return line;
+    }
+    if (/^- \[ \] /.test(line) && (isInitialCask || !inNewCaskSection)) {
+      return line.replace("- [ ] ", "- [x] ");
+    }
+    return line;
+  });
+
+  const finalSeparatorIndex = completedTemplate.findLastIndex((line) => /^-+$/.test(line.trim()));
+  if (finalSeparatorIndex === -1) {
+    throw new Error("The Homebrew Cask pull request template is missing its final separator.");
+  }
+
+  const details = [];
+  if (isInitialCask) {
+    details.push(
+      "Canonical repository: https://github.com/ProxymanApp/TCPViewer",
+      `Repository metrics: ${githubMetrics.stars} stars, ${githubMetrics.forks} forks, `
+      + `${githubMetrics.watchers} watchers when this PR was created.`,
       ""
     );
   }
-  lines.push(
-    "-----",
-    "",
-    "- [x] I disclosed the AI/LLM tool below and reviewed its output, including the "
-    + "[zap stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths; I did not attribute commits to AI "
-    + "and will answer maintainer questions and review comments myself without AI/LLM.",
-    "",
-    "OpenAI Codex assisted with the release automation that updated this cask. The maintainer reviewed the "
-    + "cask, verified the release artifact, and ran the checked Homebrew validation commands.",
-    "",
-    "-----"
+  details.push(
+    "AI/LLM disclosure: OpenAI Codex assisted with the release automation that updated this cask. The maintainer "
+    + "reviewed the cask, verified the release artifact, and ran the checked Homebrew validation commands.",
+    ""
   );
-  return lines.join("\n");
+
+  completedTemplate.splice(finalSeparatorIndex, 0, ...details);
+  return completedTemplate.join("\n");
 }
 
 export function parseHomebrewCaskVersion(content) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { createReadStream } from "node:fs";
+import { createReadStream, createWriteStream } from "node:fs";
 import { createHash } from "node:crypto";
 import {
   access,
@@ -16,6 +16,8 @@ import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import prompts from "prompts";
 import {
   assertReleaseTitleReflectsChanges,
@@ -48,6 +50,7 @@ import {
   redactEnvValue,
   releaseBackendRequiredEnvNames,
   releaseNotesToMarkdown,
+  resolvePublishedGitHubReleaseArtifact,
   requiredEnvNames,
   signR2Request,
   updateHomebrewCaskContent,
@@ -69,10 +72,17 @@ const homebrewCaskForkRemote = "proxyman";
 const homebrewCaskDefaultBranch = "main";
 const homebrewCaskToken = "tcpviewer";
 const homebrewCaskRelativePath = "Casks/t/tcpviewer.rb";
+const homebrewPullRequestTemplateRelativePath = ".github/PULL_REQUEST_TEMPLATE.md";
 const homebrewCaskTemplatePath = path.join(repoRoot, "scripts/homebrew/tcpviewer.rb");
+const githubReleaseRepo = "ProxymanApp/TCPViewer";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  if (args.homebrewOnly) {
+    await createHomebrewPullRequestForExistingRelease(args);
+    return;
+  }
+
   const releaseType = args.type ?? await askReleaseType();
   if (!["beta", "production"].includes(releaseType)) {
     throw new Error("Release type must be beta or production.");
@@ -210,6 +220,76 @@ async function main() {
   }
 
   console.log(`${releaseType === "production" ? "Production" : "BETA"} release is ready: ${downloadURL}`);
+}
+
+// Submit an already published production DMG without recreating any release records.
+async function createHomebrewPullRequestForExistingRelease(args) {
+  if (args.type && args.type !== "production") {
+    throw new Error("--homebrew-only supports production releases only.");
+  }
+  if (args.bumpHomebrew === false) {
+    throw new Error("--homebrew-only cannot be combined with --no-bump-homebrew.");
+  }
+
+  const { env, envFileExists } = await loadReleaseEnv();
+  const missing = missingRequiredEnv(env, ["TCPVIEWER_R2_PUBLIC_BASE_URL"]);
+  if (missing.length) {
+    throw new Error(`Missing required env values: ${missing.join(", ")}`);
+  }
+
+  const githubRelease = await loadLatestPublishedGitHubRelease();
+  const { version, buildNumber, dmgFileName } = githubRelease.asset;
+  const objectKey = makeR2ObjectKey({
+    releaseType: "production",
+    version,
+    buildNumber,
+    fileName: dmgFileName
+  });
+  const downloadURL = publicR2URL(env.TCPVIEWER_R2_PUBLIC_BASE_URL, objectKey);
+  const homebrewRelease = resolveHomebrewRelease({ env, version, buildNumber });
+
+  console.log("");
+  console.log("Homebrew release summary:");
+  console.log(`- App version: ${version}`);
+  console.log(`- Build number: ${buildNumber}`);
+  console.log(`- Existing GitHub release: ${githubRelease.repo} ${githubRelease.tagName}`);
+  console.log(`- Existing DMG: ${downloadURL}`);
+  console.log(`- Environment source: ${envFileExists ? ".env + shell environment" : "shell environment only"}`);
+  console.log(`- Fork branch: ${homebrewCaskForkRepo}:${homebrewRelease.branchName}`);
+  console.log(`- Pull request target: ${homebrewCaskUpstreamRepo}:${homebrewCaskDefaultBranch}`);
+  if (!args.yes && !await askHomebrewReleaseConfirmation()) {
+    console.log("Homebrew release cancelled.");
+    return;
+  }
+
+  await preflightHomebrewRelease(homebrewRelease);
+  if (
+    homebrewRelease.isInitialCask
+    && args.yes
+    && args.homebrewInstallTested !== true
+  ) {
+    throw new Error(
+      "Non-interactive initial Homebrew Cask publishing requires --homebrew-install-tested. "
+      + "Use an interactive release to pause and run the required install and uninstall checks."
+    );
+  }
+
+  const temporaryDirectory = await mkdtemp(path.join(tmpdir(), "tcpviewer-homebrew-"));
+  const dmgPath = path.join(temporaryDirectory, dmgFileName);
+  try {
+    await downloadPublishedDMG({ downloadURL, dmgPath, expectedAsset: githubRelease.asset });
+    await verifyFinalDMG({ dmgPath });
+    await createHomebrewCaskPullRequest({
+      homebrewRelease,
+      dmgPath,
+      installTested: args.homebrewInstallTested === true,
+      nonInteractive: args.yes === true
+    });
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+
+  console.log(`Homebrew Cask pull request is ready for ${version} (${buildNumber}).`);
 }
 
 async function loadReleaseEnv() {
@@ -463,6 +543,7 @@ async function preflightHomebrewRelease(homebrewRelease) {
     capture: true
   });
   await ensureHomebrewGitReady(homebrewRelease);
+  homebrewRelease.pullRequestTemplate = await readHomebrewPullRequestTemplate(homebrewRelease);
 
   const source = await readHomebrewCaskSource(homebrewRelease);
   const currentVersion = validateHomebrewCaskContent(source.content);
@@ -533,6 +614,18 @@ async function readHomebrewCaskSource(homebrewRelease) {
 
   const template = await readFile(homebrewRelease.templatePath, "utf8");
   return { content: template, isInitialCask: true };
+}
+
+async function readHomebrewPullRequestTemplate(homebrewRelease) {
+  const upstreamObject = `${homebrewCaskUpstreamRemote}/${homebrewCaskDefaultBranch}:${homebrewPullRequestTemplateRelativePath}`;
+  const result = await runCommand("git", ["show", upstreamObject], {
+    cwd: homebrewRelease.repoPath,
+    capture: true
+  });
+  if (!result.stdout.trim()) {
+    throw new Error("The upstream Homebrew Cask pull request template is empty.");
+  }
+  return result.stdout;
 }
 
 async function ensureHomebrewCaskWasNotRefused() {
@@ -646,6 +739,7 @@ async function createHomebrewCaskPullRequest({ homebrewRelease, dmgPath, install
       `tcpviewer ${homebrewRelease.version}`,
       "--body",
       makeHomebrewCaskPullRequestBody({
+        template: homebrewRelease.pullRequestTemplate,
         isInitialCask: source.isInitialCask,
         githubMetrics: homebrewRelease.githubMetrics
       })
@@ -1078,6 +1172,38 @@ async function ensureR2ObjectDoesNotExist(env, objectKey) {
   throw new Error(`R2 object already exists: ${objectKey}`);
 }
 
+// Read the latest public production release instead of trusting local project version settings.
+async function loadLatestPublishedGitHubRelease() {
+  await requireTool("gh", ["--version"]);
+  let result;
+  try {
+    result = await runCommand("gh", [
+      "release",
+      "view",
+      "--repo",
+      githubReleaseRepo,
+      "--json",
+      "assets,isDraft,isPrerelease,tagName"
+    ], { capture: true });
+  } catch (error) {
+    throw new Error(`The latest published GitHub release for ${githubReleaseRepo} was not found.\n${error.message}`);
+  }
+
+  let release;
+  try {
+    release = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`Could not parse the latest GitHub release for ${githubReleaseRepo}.`);
+  }
+
+  const asset = resolvePublishedGitHubReleaseArtifact(release);
+  return {
+    repo: githubReleaseRepo,
+    tagName: asset.tagName,
+    asset
+  };
+}
+
 async function preflightGitHubRelease({ githubRelease }) {
   await requireTool("gh", ["--version"]);
   await requireTool("gh", ["auth", "status"]);
@@ -1216,6 +1342,62 @@ async function sha256File(filePath) {
     hash.update(chunk);
   }
   return hash.digest("hex");
+}
+
+async function downloadPublishedDMG({ downloadURL, dmgPath, expectedAsset }) {
+  let requestedURL;
+  try {
+    requestedURL = new URL(downloadURL);
+  } catch {
+    throw new Error("The published DMG URL is invalid.");
+  }
+  if (requestedURL.protocol !== "https:") {
+    throw new Error("The published DMG URL must use HTTPS.");
+  }
+
+  console.log(`Downloading published DMG: ${downloadURL}`);
+  let response;
+  try {
+    response = await fetch(requestedURL, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(r2UploadAttemptTimeoutMs)
+    });
+  } catch (error) {
+    throw new Error(`Published DMG download failed: ${describeFetchError(error)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`Published DMG download failed: ${response.status} ${response.statusText}`);
+  }
+  if (!response.body) {
+    throw new Error("Published DMG download returned an empty response body.");
+  }
+  if (new URL(response.url).protocol !== "https:") {
+    throw new Error("The published DMG download redirected to a non-HTTPS URL.");
+  }
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isSafeInteger(contentLength) && contentLength > 0 && contentLength !== expectedAsset.size) {
+    throw new Error(
+      `Published DMG size ${contentLength} does not match GitHub release asset size ${expectedAsset.size}.`
+    );
+  }
+
+  await pipeline(
+    Readable.fromWeb(response.body),
+    createWriteStream(dmgPath, { mode: 0o600 })
+  );
+  const downloadedSize = (await stat(dmgPath)).size;
+  if (downloadedSize !== expectedAsset.size) {
+    throw new Error(
+      `Downloaded DMG size ${downloadedSize} does not match GitHub release asset size ${expectedAsset.size}.`
+    );
+  }
+
+  const downloadedSHA256 = await sha256File(dmgPath);
+  if (downloadedSHA256 !== expectedAsset.sha256) {
+    throw new Error("Downloaded DMG SHA-256 does not match the published GitHub release asset.");
+  }
+  console.log(`Published DMG verified: sha256 ${downloadedSHA256}`);
 }
 
 async function findSparkleSignUpdate(env, settings) {
@@ -1402,6 +1584,20 @@ async function askReleaseConfirmation() {
   return response.confirmed;
 }
 
+async function askHomebrewReleaseConfirmation() {
+  const response = await prompts({
+    type: "confirm",
+    name: "confirmed",
+    message: "Create the Homebrew Cask pull request from this published release?",
+    initial: false
+  });
+
+  if (typeof response.confirmed !== "boolean") {
+    throw new Error("Homebrew release cancelled.");
+  }
+  return response.confirmed;
+}
+
 function requirePromptValue(value, label) {
   if (value === undefined) {
     throw new Error(`${label} was cancelled.`);
@@ -1472,6 +1668,8 @@ function parseArgs(argv) {
       args.bumpHomebrew = false;
     } else if (arg === "--homebrew-install-tested") {
       args.homebrewInstallTested = true;
+    } else if (arg === "--homebrew-only") {
+      args.homebrewOnly = true;
     }
   }
   return args;

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -33,11 +33,13 @@ import {
   releaseBackendRequiredEnvNames,
   releaseNotesToMarkdown,
   releaseNotesToHTML,
+  resolvePublishedGitHubReleaseArtifact,
   requiredEnvNames,
   signR2Request,
   updateHomebrewCaskContent,
   validateHomebrewCaskContent,
-  validateHomebrewLivecheckOutput
+  validateHomebrewLivecheckOutput,
+  validatePublishedGitHubReleaseAsset
 } from "../scripts/release-lib.mjs";
 
 test("parses and validates release notes", () => {
@@ -256,19 +258,62 @@ test("builds Homebrew validation and pull request metadata", () => {
     ["audit", "--cask", "--online", "tcpviewer"]
   );
 
+  const pullRequestTemplate = [
+    "-----",
+    "",
+    "<!-- Do not tick a checkbox if you haven’t performed its action. -->",
+    "",
+    "After making any changes to a cask, existing or new, verify:",
+    "",
+    "- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).",
+    "- [ ] `brew audit --cask --online <cask>` is error-free.",
+    "- [ ] `brew style --fix <cask>` reports no offenses.",
+    "",
+    "Additionally, if adding a new cask:",
+    "",
+    "- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).",
+    "- [ ] Checked the cask was not [already refused](https://github.com/search?q=refused).",
+    "- [ ] `brew audit --cask --new <cask>` worked successfully.",
+    "- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.",
+    "- [ ] `brew uninstall --cask <cask>` worked successfully.",
+    "",
+    "-----",
+    "",
+    "- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output.",
+    "",
+    "<!-- If AI was used, explain below how it was used and how you verified the changes. -->",
+    "",
+    "-----",
+    ""
+  ].join("\n");
   const initialBody = makeHomebrewCaskPullRequestBody({
+    template: pullRequestTemplate,
     isInitialCask: true,
     githubMetrics: { stars: 163, forks: 7, watchers: 0 }
   });
-  assert.match(initialBody, /brew install --cask tcpviewer/);
+  assert.match(initialBody, /brew install --cask <cask>/);
   assert.match(initialBody, /163 stars, 7 forks, 0 watchers/);
-  assert.match(initialBody, /OpenAI Codex assisted/);
+  assert.match(initialBody, /AI\/LLM disclosure: OpenAI Codex assisted/);
+  assert.match(initialBody, /<!-- Do not tick a checkbox/);
+  for (const checkbox of pullRequestTemplate.split("\n").filter((line) => line.startsWith("- [ ] "))) {
+    assert.ok(initialBody.includes(checkbox.replace("- [ ] ", "- [x] ")));
+  }
 
-  const updateBody = makeHomebrewCaskPullRequestBody({ isInitialCask: false });
+  const updateBody = makeHomebrewCaskPullRequestBody({
+    template: pullRequestTemplate,
+    isInitialCask: false
+  });
   assert.doesNotMatch(updateBody, /brew install --cask tcpviewer/);
+  assert.match(updateBody, /- \[ \] `brew uninstall --cask <cask>`/);
+  assert.match(updateBody, /- \[x\] `brew audit --cask --online <cask>`/);
+  assert.match(updateBody, /- \[x\] I did not use AI\/LLM/);
   assert.throws(
-    () => makeHomebrewCaskPullRequestBody({ isInitialCask: true }),
+    () => makeHomebrewCaskPullRequestBody({ template: pullRequestTemplate, isInitialCask: true }),
     /GitHub metrics/
+  );
+  assert.throws(
+    () => makeHomebrewCaskPullRequestBody({ template: "missing checklist", isInitialCask: false }),
+    /missing its checklist/
   );
 
   const livecheck = JSON.stringify([{
@@ -281,6 +326,66 @@ test("builds Homebrew validation and pull request metadata", () => {
     /current and latest/
   );
   assert.throws(() => validateHomebrewLivecheckOutput("not json", "1.12.0,36"), /valid JSON/);
+});
+
+test("validates the published DMG used by a Homebrew-only release", () => {
+  const release = {
+    tagName: "v1.12.0",
+    isDraft: false,
+    isPrerelease: false,
+    assets: [{
+      name: "tcpviewer_1.12.0_36.dmg",
+      size: 45_209_211,
+      digest: `sha256:${"a".repeat(64)}`
+    }]
+  };
+  const expected = {
+    tagName: "v1.12.0",
+    assetName: "tcpviewer_1.12.0_36.dmg"
+  };
+
+  assert.deepEqual(validatePublishedGitHubReleaseAsset(release, expected), {
+    name: "tcpviewer_1.12.0_36.dmg",
+    size: 45_209_211,
+    sha256: "a".repeat(64)
+  });
+  assert.deepEqual(resolvePublishedGitHubReleaseArtifact(release), {
+    tagName: "v1.12.0",
+    version: "1.12.0",
+    buildNumber: "36",
+    dmgFileName: "tcpviewer_1.12.0_36.dmg",
+    size: 45_209_211,
+    sha256: "a".repeat(64)
+  });
+  assert.throws(
+    () => validatePublishedGitHubReleaseAsset({ ...release, isDraft: true }, expected),
+    /published production release/
+  );
+  assert.throws(
+    () => validatePublishedGitHubReleaseAsset({ ...release, assets: [] }, expected),
+    /exactly one/
+  );
+  assert.throws(
+    () => validatePublishedGitHubReleaseAsset({
+      ...release,
+      assets: [{ ...release.assets[0], digest: null }]
+    }, expected),
+    /SHA-256 digest/
+  );
+  assert.throws(
+    () => resolvePublishedGitHubReleaseArtifact({
+      ...release,
+      tagName: "latest"
+    }),
+    /must start with v/
+  );
+  assert.throws(
+    () => resolvePublishedGitHubReleaseArtifact({
+      ...release,
+      assets: [{ ...release.assets[0], name: "tcpviewer_1.11.0_35.dmg" }]
+    }),
+    /exactly one production DMG/
+  );
 });
 
 test("parses xcconfig-style env files and redacts secrets", () => {


### PR DESCRIPTION
## Summary

- Add a Homebrew-only command for the latest published production release.
- Verify the GitHub DMG asset size and SHA-256 before updating the cask repository.
- Preserve and complete the upstream pull request template, including AI/LLM disclosure.
- Document the new Make, npm, and Node.js release commands.

## Testing

- Added unit tests for published release asset validation and Homebrew pull request body generation.