### PR TITLE
Add tcpviewer-cli command interface

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,147 @@
+# tcpviewer-cli
+
+`tcpviewer-cli` automates TCP Viewer without linking Wireshark or the capture core into the command-line process. JSON is the default output and the stable automation interface.
+
+The executable is bundled at `TCP Viewer.app/Contents/MacOS/tcpviewer-cli`. Homebrew installations expose it on `PATH`:
+
+```bash
+brew install --cask tcp-viewer
+tcpviewer-cli --version
+```
+
+When TCP Viewer is closed, `--help`, `--version`, argument validation, and `app status` run locally. Other commands launch the app without activating it and leave it running. `packets reveal` is the one command that activates the app intentionally.
+
+## Commands
+
+```text
+tcpviewer-cli app status
+tcpviewer-cli interfaces list
+
+tcpviewer-cli capture status
+tcpviewer-cli capture start --interface ID [--bpf EXPRESSION]
+tcpviewer-cli capture pause
+tcpviewer-cli capture resume
+tcpviewer-cli capture stop
+
+tcpviewer-cli packets list [QUERY OPTIONS]
+tcpviewer-cli packets summary [QUERY OPTIONS]
+tcpviewer-cli packets details PACKET_ID [--max-depth 0...12] [--max-nodes 1...5000]
+tcpviewer-cli packets bytes PACKET_ID [--offset N] [--length 1...65536] [--encoding base64|hex]
+tcpviewer-cli packets clear --yes
+tcpviewer-cli packets reveal PACKET_ID
+
+tcpviewer-cli stream packets STREAM_ID [QUERY OPTIONS]
+tcpviewer-cli stream follow PACKET_ID [--direction both|client-to-server|server-to-client] [--encoding text|hex|base64]
+
+tcpviewer-cli file import PATH...
+tcpviewer-cli file export PATH --format pcap|pcapng (--all | QUERY SELECTOR) [--overwrite]
+tcpviewer-cli file export-session PATH [--overwrite]
+
+tcpviewer-cli license status
+tcpviewer-cli license activate
+tcpviewer-cli license revoke --yes
+
+tcpviewer-cli settings list
+tcpviewer-cli settings get KEY
+tcpviewer-cli settings set KEY VALUE
+tcpviewer-cli settings reset KEY
+tcpviewer-cli settings reset --all --yes
+```
+
+Every leaf command accepts `--output json|text`, `--pretty`, and `--timeout SECONDS`. The normal timeout is 30 seconds. License commands use 60 seconds; import, export, and TCP follow use 300 seconds. A timed-out long operation may still finish in the app.
+
+Start begins a new capture and clears the active packet workspace. `--bpf` is a persistent libpcap capture filter for future traffic, not a query over packets already captured.
+
+Packet byte output defaults to base64. Use `--encoding hex` only when a hexadecimal representation is more convenient.
+
+`file import` accepts one or more `.pcap`/`.pcapng` files, or one `.tcpviewsession` by itself. A session replaces the current workspace. Export never replaces an existing regular file unless `--overwrite` is present, and it refuses symbolic-link destinations.
+
+License activation never accepts a key argument. Pipe one key through standard input or enter it at the non-echoing prompt:
+
+```bash
+printf '%s\n' "$TCPVIEWER_LICENSE_KEY" | tcpviewer-cli license activate
+tcpviewer-cli license activate
+```
+
+Do not place license keys in scripts, committed files, shell arguments, or logs.
+
+## Packet queries
+
+These repeatable selectors are available to packet list/summary, stream packets, and packet export:
+
+- `--protocol NAME`
+- `--domain TEXT`
+- `--address TEXT`
+- `--port NUMBER`
+- `--client TEXT`
+- `--packet-id DECIMAL_ID`
+- `--stream-id NUMBER` (one value)
+- `--filter FIELD:OPERATOR:VALUE`
+
+Advanced filters split only their first two colons, so IPv6 values remain intact:
+
+```bash
+tcpviewer-cli packets list --filter 'source_address:equals:2001:db8::1' --limit 25
+```
+
+Supported fields are `packet_id`, `packet_number`, `protocol`, `domain`, `source_address`, `destination_address`, `address`, `source_port`, `destination_port`, `port`, `client`, `bundle_id`, `direction`, `decode_status`, `info`, `interface`, `stream_id`, `length`, `tcp_flags`, `truncated`, and `text`.
+
+Supported operators are `equals`, `not_equals`, `contains`, `not_contains`, `starts_with`, `ends_with`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, and `exists`.
+
+`--match and|or` controls only the advanced filter group. Protocol, domain, packet ID, and stream selectors are always ANDed with that group. Use `--case-sensitive` for advanced text filters.
+
+Queries return recent packets first unless `--order oldest` is used. Bounds are:
+
+- At most 20 advanced/address/port/client filters.
+- Result `--limit` defaults to 50 and is capped at 500.
+- Scan `--scan-limit` defaults to 50,000 and is capped at 100,000.
+- Continue result pages with `--offset` from `next_offset`.
+- Continue scan windows with `--scan-offset` from `next_scan_offset`.
+
+For selector-based file exports, `--limit` and `--offset` page the matched selection. `--all` exports the bounded scan and ignores result pagination.
+
+TCP follow scans at most 250,000 candidate packets and returns at most 4 MiB or 10,000 records.
+
+## Settings
+
+The supported keys are:
+
+| Key | Values |
+|---|---|
+| `theme` | `system`, `light`, `dark` |
+| `packet_font_size` | `10` through `24` |
+| `monospaced_font` | Boolean |
+| `analytics` | Boolean |
+| `crash_reports` | Boolean |
+| `quit_confirmation` | Boolean |
+| `mcp_enabled` | Boolean |
+| `mcp_redaction` | Boolean |
+
+Boolean values accept `true`/`false`, `yes`/`no`, `on`/`off`, or `1`/`0`.
+
+## JSON contract
+
+Success is written to standard output:
+
+```json
+{"schema_version":1,"request_id":"...","ok":true,"command":"capture.start","data":{}}
+```
+
+Failure is written to standard error:
+
+```json
+{"schema_version":1,"request_id":"...","ok":false,"command":"capture.start","error":{"code":"app_command_failed","message":"..."}}
+```
+
+Schema version 1 uses decimal strings for packet IDs, ISO 8601 timestamps, base64 for requested binary output, and lowercase snake-case enum values. License keys and receipt signatures are never returned. New optional fields may be added within schema version 1; existing field meanings and types remain stable.
+
+Exit codes are:
+
+| Code | Meaning |
+|---:|---|
+| `0` | Success |
+| `2` | Command usage or argument validation error |
+| `3` | App launch, transport, or timeout failure |
+| `4` | TCP Viewer rejected or failed the command |
+
+The app and CLI exchange UUID-correlated JSON files under `~/Library/Application Support/TCPViewer/CLI` and signal work with Darwin notifications. Directories are private to the user and stale responses are cleaned after 24 hours. The transport does not use XPC, sockets, or the MCP HTTP server.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TCP Viewer captures and reads network packets on macOS. It uses system `libpcap`
 - Follow a full TCP stream.
 - Export packets as PCAP or PCAPNG.
 - Ask an AI agent about your capture with TCP Viewer MCP.
+- Automate capture, packet queries, files, licenses, and settings with [`tcpviewer-cli`](CLI.md).
 - Review the full source code.
 
 ### Easy packet capture

--- a/TCPViewer.xcodeproj/project.pbxproj
+++ b/TCPViewer.xcodeproj/project.pbxproj
@@ -69,6 +69,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		BA2DC1D630440ACB00487713 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		BA63DEF8300E7E7700530A67 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -126,6 +135,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BA2DC1D830440ACB00487713 /* tcpviewer-cli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "tcpviewer-cli"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA4D26B42F9A2F760070BE17 /* PcapPlusPlusCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PcapPlusPlusCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA4D26BC2F9A2F770070BE17 /* PcapPlusPlusCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PcapPlusPlusCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA4D2DD82F9B3EF50070BE17 /* PcapPlusPlusCore.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PcapPlusPlusCore.xctestplan; sourceTree = "<group>"; };
@@ -157,6 +167,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		BA2DC1D930440ACB00487713 /* tcpviewer-cli */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "tcpviewer-cli";
+			sourceTree = "<group>";
+		};
 		BA4D26B52F9A2F760070BE17 /* PcapPlusPlusCore */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = PcapPlusPlusCore;
@@ -201,6 +216,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		BA2DC1D530440ACB00487713 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BA4D26B12F9A2F760070BE17 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,6 +291,7 @@
 				BA7A10032F9B00000070BE17 /* Vendor */,
 				BA63DEFB300E7E7700530A67 /* tcpviewer-mcp */,
 				BAMC0006300F00000070BE17 /* TCPViewerMCPShared */,
+				BA2DC1D930440ACB00487713 /* tcpviewer-cli */,
 				BA4D26862F9A2F490070BE17 /* Products */,
 				BAAE97052F9B810400C52A7C /* Recovered References */,
 			);
@@ -283,6 +306,7 @@
 				BAAE975D2F9B815F00C52A7C /* TCP Viewer.app */,
 				BAAE976F2F9B816000C52A7C /* TCPViewerTests.xctest */,
 				BA63DEFA300E7E7700530A67 /* tcpviewer-mcp */,
+				BA2DC1D830440ACB00487713 /* tcpviewer-cli */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -332,6 +356,28 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		BA2DC1D730440ACB00487713 /* tcpviewer-cli */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA2DC1DE30440ACB00487713 /* Build configuration list for PBXNativeTarget "tcpviewer-cli" */;
+			buildPhases = (
+				BA2DC1D430440ACB00487713 /* Sources */,
+				BA2DC1D530440ACB00487713 /* Frameworks */,
+				BA2DC1D630440ACB00487713 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				BA2DC1D930440ACB00487713 /* tcpviewer-cli */,
+			);
+			name = "tcpviewer-cli";
+			packageProductDependencies = (
+			);
+			productName = "tcpviewer-cli";
+			productReference = BA2DC1D830440ACB00487713 /* tcpviewer-cli */;
+			productType = "com.apple.product-type.tool";
+		};
 		BA4D26B32F9A2F760070BE17 /* PcapPlusPlusCore */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BA4D26C92F9A2F770070BE17 /* Build configuration list for PBXNativeTarget "PcapPlusPlusCore" */;
@@ -486,9 +532,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2650;
+				LastSwiftUpdateCheck = 2660;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
+					BA2DC1D730440ACB00487713 = {
+						CreatedOnToolsVersion = 26.6;
+					};
 					BA4D26B32F9A2F760070BE17 = {
 						CreatedOnToolsVersion = 26.4.1;
 					};
@@ -536,6 +585,7 @@
 				BA4D26BB2F9A2F770070BE17 /* PcapPlusPlusCoreTests */,
 				BACE00082F9C00000070BE17 /* TCPViewerHelperTool */,
 				BA63DEF9300E7E7700530A67 /* tcpviewer-mcp */,
+				BA2DC1D730440ACB00487713 /* tcpviewer-cli */,
 			);
 		};
 /* End PBXProject section */
@@ -725,6 +775,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		BA2DC1D430440ACB00487713 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BA4D26B02F9A2F760070BE17 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -803,6 +860,62 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		BA2DC1DC30440ACB00487713 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				AUTOMATION_APPLE_EVENTS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 57SKMSUCY8;
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=macosx*]" = "com.proxyman.tcpviewer-cli";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		BA2DC1DD30440ACB00487713 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				AUTOMATION_APPLE_EVENTS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 57SKMSUCY8;
+				ENABLE_HARDENED_RUNTIME = NO;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=macosx*]" = "com.proxyman.tcpviewer-cli";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		BA4D26A42F9A2F4B0070BE17 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BAE100012FA300000070BE17 /* TCPViewer.shared.xcconfig */;
@@ -1376,6 +1489,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		BA2DC1DE30440ACB00487713 /* Build configuration list for PBXNativeTarget "tcpviewer-cli" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BA2DC1DC30440ACB00487713 /* Debug */,
+				BA2DC1DD30440ACB00487713 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		BA4D26802F9A2F490070BE17 /* Build configuration list for PBXProject "TCPViewer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/TCPViewer.xcodeproj/project.pbxproj
+++ b/TCPViewer.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BA2DCC0030440B6800487713 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = BA2DCBFF30440B6800487713 /* ArgumentParser */; };
+		BACL0002304400000070BE17 /* tcpviewer-cli in Copy CLI Executable */ = {isa = PBXBuildFile; fileRef = BA2DC1D830440ACB00487713 /* tcpviewer-cli */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BA4D26BD2F9A2F770070BE17 /* PcapPlusPlusCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA4D26B42F9A2F760070BE17 /* PcapPlusPlusCore.framework */; };
 		BA5E00012FA800000070BE17 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = BA5E00032FA800000070BE17 /* Sentry */; };
 		BA9F00012FBF00000070BE17 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = BA9F00032FBF00000070BE17 /* ZIPFoundation */; };
@@ -45,6 +46,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = BA63DEF9300E7E7700530A67;
 			remoteInfo = "tcpviewer-mcp";
+		};
+		BACL0003304400000070BE17 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BA4D267D2F9A2F490070BE17 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BA2DC1D730440ACB00487713;
+			remoteInfo = "tcpviewer-cli";
 		};
 		BAPM00102F9D00000070BE17 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -97,6 +105,17 @@
 				BAMC0003300F00000070BE17 /* tcpviewer-mcp in Copy MCP Executable */,
 			);
 			name = "Copy MCP Executable";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BACL0004304400000070BE17 /* Copy CLI Executable */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				BACL0002304400000070BE17 /* tcpviewer-cli in Copy CLI Executable */,
+			);
+			name = "Copy CLI Executable";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BAPM00202F9D00000070BE17 /* Embed Frameworks */ = {
@@ -209,6 +228,11 @@
 			path = TCPViewerHelperTool;
 			sourceTree = "<group>";
 		};
+		BACL0001304400000070BE17 /* TCPViewerCLIShared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TCPViewerCLIShared;
+			sourceTree = "<group>";
+		};
 		BAMC0006300F00000070BE17 /* TCPViewerMCPShared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = TCPViewerMCPShared;
@@ -293,6 +317,7 @@
 				BA7A10032F9B00000070BE17 /* Vendor */,
 				BA63DEFB300E7E7700530A67 /* tcpviewer-mcp */,
 				BAMC0006300F00000070BE17 /* TCPViewerMCPShared */,
+				BACL0001304400000070BE17 /* TCPViewerCLIShared */,
 				BA2DC1D930440ACB00487713 /* tcpviewer-cli */,
 				BA4D26862F9A2F490070BE17 /* Products */,
 				BAAE97052F9B810400C52A7C /* Recovered References */,
@@ -372,6 +397,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				BA2DC1D930440ACB00487713 /* tcpviewer-cli */,
+				BACL0001304400000070BE17 /* TCPViewerCLIShared */,
 			);
 			name = "tcpviewer-cli";
 			packageProductDependencies = (
@@ -463,6 +489,7 @@
 				BAPM00212F9D00000070BE17 /* Copy Network Helper Executable */,
 				BAPM00222F9D00000070BE17 /* Copy Network Helper LaunchDaemon */,
 				BAMC0005300F00000070BE17 /* Copy MCP Executable */,
+				BACL0004304400000070BE17 /* Copy CLI Executable */,
 			);
 			buildRules = (
 			);
@@ -470,9 +497,11 @@
 				BAPM00302F9D00000070BE17 /* PBXTargetDependency */,
 				BAPM00312F9D00000070BE17 /* PBXTargetDependency */,
 				BAMC0007300F00000070BE17 /* PBXTargetDependency */,
+				BACL0005304400000070BE17 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				BAAE975E2F9B815F00C52A7C /* TCPViewer */,
+				BACL0001304400000070BE17 /* TCPViewerCLIShared */,
 				BAMC0006300F00000070BE17 /* TCPViewerMCPShared */,
 			);
 			name = TCPViewer;
@@ -846,6 +875,11 @@
 			target = BA63DEF9300E7E7700530A67 /* tcpviewer-mcp */;
 			targetProxy = BAMC0004300F00000070BE17 /* PBXContainerItemProxy */;
 		};
+		BACL0005304400000070BE17 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BA2DC1D730440ACB00487713 /* tcpviewer-cli */;
+			targetProxy = BACL0003304400000070BE17 /* PBXContainerItemProxy */;
+		};
 		BAPM00302F9D00000070BE17 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BA4D26B32F9A2F760070BE17 /* PcapPlusPlusCore */;
@@ -866,18 +900,22 @@
 /* Begin XCBuildConfiguration section */
 		BA2DC1DC30440ACB00487713 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BAE100012FA300000070BE17 /* TCPViewer.shared.xcconfig */;
 			buildSettings = {
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 57SKMSUCY8;
-				ENABLE_HARDENED_RUNTIME = NO;
+				CURRENT_PROJECT_VERSION = 36;
+				DEVELOPMENT_TEAM = "$(TCPVIEWER_DEVELOPMENT_TEAM)";
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
 				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.12.0;
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=macosx*]" = "com.proxyman.tcpviewer-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
@@ -894,18 +932,22 @@
 		};
 		BA2DC1DD30440ACB00487713 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BAE100012FA300000070BE17 /* TCPViewer.shared.xcconfig */;
 			buildSettings = {
 				AUTOMATION_APPLE_EVENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 57SKMSUCY8;
-				ENABLE_HARDENED_RUNTIME = NO;
+				CURRENT_PROJECT_VERSION = 36;
+				DEVELOPMENT_TEAM = "$(TCPVIEWER_DEVELOPMENT_TEAM)";
+				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
 				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
 				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MARKETING_VERSION = 1.12.0;
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=macosx*]" = "com.proxyman.tcpviewer-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;

--- a/TCPViewer.xcodeproj/project.pbxproj
+++ b/TCPViewer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BA2DCC0030440B6800487713 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = BA2DCBFF30440B6800487713 /* ArgumentParser */; };
 		BA4D26BD2F9A2F770070BE17 /* PcapPlusPlusCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA4D26B42F9A2F760070BE17 /* PcapPlusPlusCore.framework */; };
 		BA5E00012FA800000070BE17 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = BA5E00032FA800000070BE17 /* Sentry */; };
 		BA9F00012FBF00000070BE17 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = BA9F00032FBF00000070BE17 /* ZIPFoundation */; };
@@ -220,6 +221,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BA2DCC0030440B6800487713 /* ArgumentParser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,6 +375,7 @@
 			);
 			name = "tcpviewer-cli";
 			packageProductDependencies = (
+				BA2DCBFF30440B6800487713 /* ArgumentParser */,
 			);
 			productName = "tcpviewer-cli";
 			productReference = BA2DC1D830440ACB00487713 /* tcpviewer-cli */;
@@ -573,6 +576,7 @@
 				BA5E00022FA800000070BE17 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				BA9F00022FBF00000070BE17 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 				BAMC0008300F00000070BE17 /* XCRemoteSwiftPackageReference "swift-sdk" */,
+				BA2DCBFE30440B6800487713 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = BA4D26862F9A2F490070BE17 /* Products */;
@@ -953,7 +957,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "$(TCPVIEWER_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 3X57WP8E8V;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1018,7 +1022,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "$(TCPVIEWER_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 3X57WP8E8V;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1572,6 +1576,14 @@
 				version = 2.9.1;
 			};
 		};
+		BA2DCBFE30440B6800487713 /* XCRemoteSwiftPackageReference "swift-argument-parser" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-argument-parser.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.8.2;
+			};
+		};
 		BA5E00022FA800000070BE17 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
@@ -1579,6 +1591,8 @@
 				kind = upToNextMajorVersion;
 				minimumVersion = 9.14.0;
 			};
+			traits = (
+			);
 		};
 		BA9F00022FBF00000070BE17 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1603,6 +1617,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 47F2E4C3668133A54F097208 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		BA2DCBFF30440B6800487713 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA2DCBFE30440B6800487713 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
 		};
 		BA5E00032FA800000070BE17 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/TCPViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TCPViewer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3e44e163d635594ac6b465497dce4642b3eb05963e1435e1c36ad0dc7913c11",
+  "originHash" : "67711479b7260c8002ef9c8ebaa7681e2e76cde77db8c1961e464adfc7fca33a",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
         "version" : "2.9.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {

--- a/TCPViewer/App/AppDelegate.swift
+++ b/TCPViewer/App/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var configurationObserver: NSObjectProtocol?
     private lazy var sentryService = TCPViewerSentryService(configuration: appConfiguration)
     private lazy var factoryResetService = TCPViewerFactoryResetService(helperToolManager: networkHelperToolManager)
+    private lazy var cliCoordinator = TCPViewerCLICommandCoordinator(appDelegate: self)
     private var isHandlingTermination = false
     private var skipsNextQuitConfirmation = false
     private var isShowingRenewalRequiredAlert = false
@@ -39,6 +40,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        cliCoordinator.start()
         sentryService.start()
         appConfiguration.applyAppearance()
         observeLicenseStatusChanges()
@@ -83,6 +85,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
+        cliCoordinator.stop()
         TCPViewerMCPHTTPServer.shared.stop()
         if let licenseStatusObserver {
             NotificationCenter.default.removeObserver(licenseStatusObserver)
@@ -158,7 +161,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     // Imports captures into the current TCP Viewer window, creating one only when needed.
-    private func importCaptureURLs(_ urls: [URL], completion: ((Bool) -> Void)? = nil) {
+    private func importCaptureURLs(
+        _ urls: [URL],
+        focusesWindow: Bool = true,
+        presentsErrors: Bool = true,
+        completion: ((Bool) -> Void)? = nil
+    ) {
         let supportedURLs = urls.filter(TCPViewerCaptureFileImportPolicy.isSupportedCaptureFileURL)
         guard !supportedURLs.isEmpty else {
             completion?(false)
@@ -167,21 +175,46 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let sessionURLs = supportedURLs.filter(TCPViewerCaptureFileImportPolicy.isSessionFileURL)
         guard sessionURLs.isEmpty || (sessionURLs.count == 1 && supportedURLs.count == 1) else {
-            presentInvalidSessionOpenSelectionAlert()
+            if presentsErrors {
+                presentInvalidSessionOpenSelectionAlert()
+            }
             completion?(false)
             return
         }
 
         do {
             let windowController = try frontmostOrNewTCPViewerWindowController()
-            focusWindowController(windowController)
+            if focusesWindow {
+                focusWindowController(windowController)
+            }
             windowController.rootViewController.importDocuments(at: supportedURLs) {
                 completion?(true)
             }
         } catch {
-            NSDocumentController.shared.presentError(error)
+            if presentsErrors {
+                NSDocumentController.shared.presentError(error)
+            }
             completion?(false)
         }
+    }
+
+    // CLI commands share the active workspace but never activate TCP Viewer implicitly.
+    func cliWorkspaceViewModel() throws -> NetworkInspectorViewModel {
+        try frontmostOrNewTCPViewerWindowController().rootViewController.viewModel
+    }
+
+    func cliImportCaptureURLs(_ urls: [URL], completion: @escaping (Bool) -> Void) {
+        importCaptureURLs(urls, focusesWindow: false, presentsErrors: false, completion: completion)
+    }
+
+    func cliRefreshSettings() {
+        appConfiguration.applyAppearance()
+        updateMCPServerAvailability()
+    }
+
+    func cliRevealActiveWindow() {
+        guard let controller = frontmostTCPViewerWindowController() else { return }
+        focusWindowController(controller)
     }
 
     private func presentInvalidSessionOpenSelectionAlert() {

--- a/TCPViewer/App/Settings/AppConfiguration.swift
+++ b/TCPViewer/App/Settings/AppConfiguration.swift
@@ -164,6 +164,26 @@ final class AppConfiguration: NSObject {
         notifyChange()
     }
 
+    // Reset one CLI-exposed preference without affecting unrelated app state.
+    func resetCLISetting(named name: String) -> Bool {
+        let key: String
+        switch name {
+        case "theme": key = Key.appearanceTheme
+        case "packet_font_size": key = Key.packetFontSize
+        case "monospaced_font": key = Key.usesMonospacedPacketFont
+        case "analytics": key = Key.sharesAnalytics
+        case "crash_reports": key = Key.sharesCrashReports
+        case "quit_confirmation": key = Key.confirmsBeforeQuitting
+        case "mcp_enabled": key = Key.isMCPServerEnabled
+        case "mcp_redaction": key = Key.mcpRedactsSensitiveData
+        default: return false
+        }
+        defaults.removeObject(forKey: key)
+        registerDefaults()
+        notifyChange()
+        return true
+    }
+
     private func registerDefaults() {
         defaults.register(defaults: [
             Key.sharesAnalytics: true,

--- a/TCPViewer/Features/CLI/TCPViewerCLICommandCoordinator.swift
+++ b/TCPViewer/Features/CLI/TCPViewerCLICommandCoordinator.swift
@@ -1,0 +1,76 @@
+//
+//  TCPViewerCLICommandCoordinator.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+
+final class TCPViewerCLICommandCoordinator {
+    private let fileStore: TCPViewerCLIFileStore
+    private let notificationCenter: any TCPViewerCLINotificationCentering
+    private let router: any TCPViewerCLICommandRouting
+    private let workerQueue = DispatchQueue(label: "com.proxyman.tcpviewer.cli.requests", qos: .userInitiated)
+    private var requestObserver: (any TCPViewerCLINotificationObserving)?
+    private var isProcessing = false
+
+    init(
+        appDelegate: AppDelegate,
+        fileStore: TCPViewerCLIFileStore = TCPViewerCLIFileStore(),
+        notificationCenter: any TCPViewerCLINotificationCentering = TCPViewerCLIDarwinNotificationCenter.shared
+    ) {
+        self.fileStore = fileStore
+        self.notificationCenter = notificationCenter
+        self.router = TCPViewerCLICommandRouter(appDelegate: appDelegate)
+    }
+
+    init(
+        fileStore: TCPViewerCLIFileStore,
+        notificationCenter: any TCPViewerCLINotificationCentering,
+        router: any TCPViewerCLICommandRouting
+    ) {
+        self.fileStore = fileStore
+        self.notificationCenter = notificationCenter
+        self.router = router
+    }
+
+    // Register before scanning so startup cannot lose a request arriving between those operations.
+    func start() {
+        guard requestObserver == nil else { return }
+        requestObserver = notificationCenter.observe(TCPViewerCLINotificationName.request) { [weak self] in
+            self?.scheduleDrain()
+        }
+        scheduleDrain()
+    }
+
+    func stop() {
+        requestObserver = nil
+    }
+
+    private func scheduleDrain() {
+        workerQueue.async { [weak self] in
+            self?.drainNextRequest()
+        }
+    }
+
+    private func drainNextRequest() {
+        guard !isProcessing else { return }
+        try? fileStore.prepareDirectories()
+        fileStore.cleanupOrphans()
+        guard let request = fileStore.pendingRequests().first else { return }
+        isProcessing = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.router.route(request) { response in
+                self.workerQueue.async {
+                    try? self.fileStore.writeResponse(response)
+                    self.fileStore.removeRequest(requestID: request.requestID)
+                    self.notificationCenter.post(TCPViewerCLINotificationName.response)
+                    self.isProcessing = false
+                    self.drainNextRequest()
+                }
+            }
+        }
+    }
+}

--- a/TCPViewer/Features/CLI/TCPViewerCLICommandRouter.swift
+++ b/TCPViewer/Features/CLI/TCPViewerCLICommandRouter.swift
@@ -1,0 +1,593 @@
+//
+//  TCPViewerCLICommandRouter.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import AppKit
+import Foundation
+import PcapPlusPlusCore
+
+protocol TCPViewerCLICommandRouting: AnyObject {
+    func route(_ request: TCPViewerCLIRequest, completion: @escaping (TCPViewerCLIResponse) -> Void)
+}
+
+final class TCPViewerCLICommandRouter: TCPViewerCLICommandRouting {
+    private enum Limit {
+        static let maximumImportedFiles = 100
+        static let maximumFollowCandidates = 250_000
+        static let maximumFollowBytes = 4 * 1_024 * 1_024
+        static let maximumFollowRecords = 10_000
+    }
+
+    private weak var appDelegate: AppDelegate?
+    private let fileManager: FileManager
+    private let licenseService: TCPViewerLicenseService
+    private lazy var mcpRouter = TCPViewerMCPCommandRouter(
+        dataSourceProvider: { TCPViewerMCPServiceProvider.shared.activeSource() },
+        isLicenseAuthorized: { [licenseService] in licenseService.isLicenseAuthorized },
+        requiresAuthorizedLicense: false,
+        redactionEnabled: { false }
+    )
+
+    init(
+        appDelegate: AppDelegate,
+        fileManager: FileManager = .default,
+        licenseService: TCPViewerLicenseService = .shared
+    ) {
+        self.appDelegate = appDelegate
+        self.fileManager = fileManager
+        self.licenseService = licenseService
+    }
+
+    // Route one validated request while keeping AppKit and workspace access on the main thread.
+    func route(_ request: TCPViewerCLIRequest, completion: @escaping (TCPViewerCLIResponse) -> Void) {
+        precondition(Thread.isMainThread)
+        switch request.command {
+        case .licenseStatus:
+            completion(success(request, data: licenseStatusData()))
+        case .licenseActivate:
+            activateLicense(request, completion: completion)
+        case .licenseRevoke:
+            revokeLicense(request, completion: completion)
+        case .settingsList, .settingsGet, .settingsSet, .settingsReset:
+            routeSettings(request, completion: completion)
+        case .fileImport:
+            importFiles(request, completion: completion)
+        case .fileExportSession:
+            exportSession(request, completion: completion)
+        case .streamFollow:
+            followStream(request, completion: completion)
+        default:
+            routeThroughMCP(request, completion: completion)
+        }
+    }
+
+    private func routeThroughMCP(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        guard let appDelegate else {
+            completion(failure(request, code: "app_unavailable", message: "TCP Viewer is unavailable."))
+            return
+        }
+        if request.command != .appStatus {
+            do {
+                _ = try appDelegate.cliWorkspaceViewModel()
+            } catch {
+                completion(failure(request, code: "no_active_window", error: error))
+                return
+            }
+        }
+        guard let command = mcpCommand(for: request.command) else {
+            completion(failure(request, code: "unsupported_command", message: "The command is not supported."))
+            return
+        }
+
+        var parameters = request.params.mapValues(mcpValue)
+        if request.command == .captureStart, request.string("capture_filter") != nil {
+            parameters["confirm_bpf_filter"] = .bool(true)
+        }
+        if request.command == .fileExport {
+            parameters["apply_result_pagination"] = .bool(true)
+        }
+        mcpRouter.route(TCPViewerMCPRequest(command: command.rawValue, params: parameters)) { response in
+            guard response.success, let data = response.data else {
+                completion(self.failure(
+                    request,
+                    code: "app_command_failed",
+                    message: response.error ?? "TCP Viewer could not complete the command."
+                ))
+                return
+            }
+            if request.command == .packetsReveal {
+                appDelegate.cliRevealActiveWindow()
+            }
+            var cliData = data.mapValuesWithKeys { key, value in self.cliValue(value, key: key) }
+            if request.command == .appStatus {
+                let snapshot = TCPViewerMCPServiceProvider.shared.activeSource()?.mcpWorkspaceSnapshot()
+                cliData["running"] = .bool(true)
+                cliData["cli_version"] = .string(TCPViewerLicenseAppVersion.current.appVersion)
+                cliData["cli_build"] = .string(TCPViewerLicenseAppVersion.current.buildNumber)
+                cliData["license_state"] = .string(self.licenseService.isLicenseAuthorized ? "authorized" : "not_activated")
+                cliData["active_document"] = snapshot?.documentURL.map { .string($0.path) } ?? .null
+            }
+            completion(self.success(request, data: cliData))
+        }
+    }
+
+    private func mcpCommand(for command: TCPViewerCLICommand) -> TCPViewerMCPCommand? {
+        switch command {
+        case .appStatus: .getAppStatus
+        case .interfacesList: .listInterfaces
+        case .captureStatus: .getCaptureOverview
+        case .captureStart: .startCapture
+        case .capturePause: .pauseCapture
+        case .captureResume: .resumeCapture
+        case .captureStop: .stopCapture
+        case .packetsList: .queryPackets
+        case .packetsSummary: .summarizeCapture
+        case .packetsDetails: .getPacketDetails
+        case .packetsBytes: .getPacketBytes
+        case .packetsClear: .clearPackets
+        case .packetsReveal: .revealPacket
+        case .streamPackets: .listStreamPackets
+        case .fileExport: .exportPackets
+        default: nil
+        }
+    }
+
+    private func importFiles(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        do {
+            guard let appDelegate else {
+                throw CLIError(code: "app_unavailable", message: "TCP Viewer is unavailable.")
+            }
+            let paths = try stringArray(request, key: "paths", maximumCount: Limit.maximumImportedFiles)
+            guard !paths.isEmpty else {
+                throw CLIError(code: "invalid_parameter", message: "At least one import path is required.")
+            }
+            let urls = try paths.map(validImportURL)
+            let sessionCount = urls.filter(TCPViewerCaptureFileImportPolicy.isSessionFileURL).count
+            guard sessionCount == 0 || (sessionCount == 1 && urls.count == 1) else {
+                throw CLIError(code: "invalid_parameter", message: "A tcpviewsession must be imported by itself.")
+            }
+            appDelegate.cliImportCaptureURLs(urls) { succeeded in
+                guard succeeded else {
+                    completion(self.failure(request, code: "import_failed", message: "TCP Viewer could not import the selected file."))
+                    return
+                }
+                let packetCount = (try? appDelegate.cliWorkspaceViewModel().mcpWorkspaceSnapshot().totalPacketCount) ?? 0
+                completion(self.success(request, data: [
+                    "imported_files": .array(urls.map { .string($0.path) }),
+                    "imported_file_count": .int(urls.count),
+                    "packet_count": .int(packetCount),
+                ]))
+            }
+        } catch let error as CLIError {
+            completion(failure(request, code: error.code, message: error.message))
+        } catch {
+            completion(failure(request, code: "invalid_parameter", error: error))
+        }
+    }
+
+    private func exportSession(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        do {
+            guard let appDelegate else {
+                throw CLIError(code: "app_unavailable", message: "TCP Viewer is unavailable.")
+            }
+            let destination = try exportSessionDestination(
+                path: request.string("path"),
+                overwrite: request.bool("overwrite") ?? false
+            )
+            let viewModel = try appDelegate.cliWorkspaceViewModel()
+            viewModel.exportTCPViewSession(to: destination) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success:
+                        completion(self.success(request, data: ["path": .string(destination.path)]))
+                    case .failure(let error):
+                        completion(self.failure(request, code: "export_failed", error: error))
+                    }
+                }
+            }
+        } catch let error as CLIError {
+            completion(failure(request, code: error.code, message: error.message))
+        } catch {
+            completion(failure(request, code: "export_failed", error: error))
+        }
+    }
+
+    private func followStream(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        do {
+            guard let appDelegate else {
+                throw CLIError(code: "app_unavailable", message: "TCP Viewer is unavailable.")
+            }
+            guard let rawID = request.string("packet_id"), let packetID = PacketSummary.ID(rawID) else {
+                throw CLIError(code: "invalid_parameter", message: "packet_id must be a valid UInt64 string.")
+            }
+            let maximumBytes = try bounded(request.int("max_bytes") ?? Limit.maximumFollowBytes, range: 1...Limit.maximumFollowBytes, name: "max_bytes")
+            let maximumRecords = try bounded(request.int("max_records") ?? Limit.maximumFollowRecords, range: 1...Limit.maximumFollowRecords, name: "max_records")
+            let direction = request.string("direction") ?? "both"
+            guard ["both", "client-to-server", "server-to-client"].contains(direction) else {
+                throw CLIError(code: "invalid_parameter", message: "direction is invalid.")
+            }
+            let encoding = request.string("encoding") ?? "text"
+            guard ["text", "hex", "base64"].contains(encoding) else {
+                throw CLIError(code: "invalid_parameter", message: "encoding is invalid.")
+            }
+            let viewModel = try appDelegate.cliWorkspaceViewModel()
+            let limits = TCPFollowLimits(
+                maximumCandidatePacketCount: Limit.maximumFollowCandidates,
+                maximumPayloadBytes: maximumBytes,
+                maximumRecordCount: maximumRecords
+            )
+            viewModel.followTCPStream(
+                containing: packetID,
+                limits: limits,
+                progress: nil,
+                shouldCancel: nil
+            ) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let stream):
+                        completion(self.success(request, data: self.followData(
+                            stream,
+                            direction: direction,
+                            encoding: encoding,
+                            maximumBytes: maximumBytes,
+                            maximumRecords: maximumRecords
+                        )))
+                    case .failure(let error):
+                        completion(self.failure(request, code: "follow_failed", error: error))
+                    }
+                }
+            }
+        } catch let error as CLIError {
+            completion(failure(request, code: error.code, message: error.message))
+        } catch {
+            completion(failure(request, code: "follow_failed", error: error))
+        }
+    }
+
+    private func followData(
+        _ stream: TCPFollowStream,
+        direction: String,
+        encoding: String,
+        maximumBytes: Int,
+        maximumRecords: Int
+    ) -> [String: TCPViewerCLIValue] {
+        var returnedBytes = 0
+        var records: [TCPViewerCLIValue] = []
+        var wasLimited = stream.isTruncated
+        for record in stream.records where includes(record.direction, selection: direction) {
+            guard records.count < maximumRecords, returnedBytes < maximumBytes else {
+                wasLimited = true
+                break
+            }
+            let data = Data(record.data.prefix(maximumBytes - returnedBytes))
+            if data.count < record.data.count { wasLimited = true }
+            returnedBytes += data.count
+            records.append(.object([
+                "direction": .string(record.direction == .clientToServer ? "client_to_server" : "server_to_client"),
+                "packet_id": .string(String(record.packetID)),
+                "timestamp": .string(Self.iso8601.string(from: record.timestamp)),
+                "sequence_number": .string(String(record.sequenceNumber)),
+                "data": .string(encoded(data, as: encoding)),
+                "byte_count": .int(data.count),
+            ]))
+            if data.count < record.data.count { break }
+        }
+        return [
+            "client": endpointValue(stream.client),
+            "server": endpointValue(stream.server),
+            "encoding": .string(encoding),
+            "direction": .string(direction.replacingOccurrences(of: "-", with: "_")),
+            "records": .array(records),
+            "returned_record_count": .int(records.count),
+            "returned_byte_count": .int(returnedBytes),
+            "captured_through_packet_id": .string(String(stream.capturedThroughPacketID)),
+            "captured_at": .string(Self.iso8601.string(from: stream.capturedAt)),
+            "truncated": .bool(wasLimited),
+        ]
+    }
+
+    private func activateLicense(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        guard let key = request.string("license_key"), key.hasPrefix("TCPV-"), key.utf8.count <= 4_096 else {
+            completion(failure(request, code: "invalid_parameter", message: "A valid TCP Viewer license key is required."))
+            return
+        }
+        licenseService.activate(licenseKey: key) { status in
+            guard status.isAuthorized else {
+                let message: String
+                if case .unauthorized(let error) = status {
+                    message = error.localizedDescription.replacingOccurrences(of: key, with: "<redacted>")
+                } else {
+                    message = "The license could not be activated."
+                }
+                completion(self.failure(request, code: "license_activation_failed", message: message))
+                return
+            }
+            completion(self.success(request, data: self.licenseStatusData()))
+        }
+    }
+
+    private func revokeLicense(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        guard request.bool("confirm") == true else {
+            completion(failure(request, code: "confirmation_required", message: "License revocation requires confirmation."))
+            return
+        }
+        licenseService.revokeCurrentDevice { result in
+            switch result {
+            case .success:
+                completion(self.success(request, data: ["authorized": .bool(false), "revoked": .bool(true)]))
+            case .failure(let error):
+                completion(self.failure(request, code: "license_revoke_failed", error: error))
+            }
+        }
+    }
+
+    private func licenseStatusData() -> [String: TCPViewerCLIValue] {
+        guard let license = licenseService.currentLicense, licenseService.isLicenseAuthorized else {
+            return ["authorized": .bool(false)]
+        }
+        return [
+            "authorized": .bool(true),
+            "email": .string(license.email),
+            "license_type": .string(license.licenseType.rawValue),
+            "update_expiry": .string(license.expiryDate),
+            "lifetime_updates": .bool(license.hasLifetimeUpdates),
+        ]
+    }
+
+    private func routeSettings(
+        _ request: TCPViewerCLIRequest,
+        completion: @escaping (TCPViewerCLIResponse) -> Void
+    ) {
+        guard let appDelegate else {
+            completion(failure(request, code: "app_unavailable", message: "TCP Viewer is unavailable."))
+            return
+        }
+        let configuration = appDelegate.appConfiguration
+        do {
+            switch request.command {
+            case .settingsList:
+                completion(success(request, data: ["settings": .object(settings(configuration))]))
+            case .settingsGet:
+                guard let key = request.string("key"), let value = settings(configuration)[key] else {
+                    throw CLIError(code: "unknown_setting", message: "The setting key is not supported.")
+                }
+                completion(success(request, data: ["key": .string(key), "value": value]))
+            case .settingsSet:
+                guard let key = request.string("key"), let rawValue = request.string("value") else {
+                    throw CLIError(code: "invalid_parameter", message: "A setting key and value are required.")
+                }
+                try setSetting(key, value: rawValue, configuration: configuration)
+                appDelegate.cliRefreshSettings()
+                completion(success(request, data: ["key": .string(key), "value": settings(configuration)[key] ?? .null]))
+            case .settingsReset:
+                if request.bool("all") == true {
+                    for key in settings(configuration).keys { _ = configuration.resetCLISetting(named: key) }
+                    appDelegate.cliRefreshSettings()
+                    completion(success(request, data: ["settings": .object(settings(configuration))]))
+                } else if let key = request.string("key"), configuration.resetCLISetting(named: key) {
+                    appDelegate.cliRefreshSettings()
+                    completion(success(request, data: ["key": .string(key), "value": settings(configuration)[key] ?? .null]))
+                } else {
+                    throw CLIError(code: "unknown_setting", message: "The setting key is not supported.")
+                }
+            default:
+                throw CLIError(code: "unsupported_command", message: "The settings command is not supported.")
+            }
+        } catch let error as CLIError {
+            completion(failure(request, code: error.code, message: error.message))
+        } catch {
+            completion(failure(request, code: "invalid_parameter", error: error))
+        }
+    }
+
+    private func settings(_ configuration: AppConfiguration) -> [String: TCPViewerCLIValue] {
+        [
+            "theme": .string(configuration.appearanceTheme.rawValue),
+            "packet_font_size": .double(Double(configuration.packetFontSize)),
+            "monospaced_font": .bool(configuration.usesMonospacedPacketFont),
+            "analytics": .bool(configuration.sharesAnalytics),
+            "crash_reports": .bool(configuration.sharesCrashReports),
+            "quit_confirmation": .bool(configuration.confirmsBeforeQuitting),
+            "mcp_enabled": .bool(configuration.isMCPServerEnabled),
+            "mcp_redaction": .bool(configuration.mcpRedactsSensitiveData),
+        ]
+    }
+
+    private func setSetting(_ key: String, value: String, configuration: AppConfiguration) throws {
+        switch key {
+        case "theme":
+            guard let theme = AppAppearanceTheme(rawValue: value.lowercased()) else {
+                throw CLIError(code: "invalid_setting_value", message: "theme must be system, light, or dark.")
+            }
+            configuration.appearanceTheme = theme
+        case "packet_font_size":
+            guard let size = Double(value), size.isFinite,
+                  Double(AppConfiguration.minimumPacketFontSize)...Double(AppConfiguration.maximumPacketFontSize) ~= size else {
+                throw CLIError(code: "invalid_setting_value", message: "packet_font_size must be between 10 and 24.")
+            }
+            configuration.packetFontSize = CGFloat(size)
+        case "monospaced_font": configuration.usesMonospacedPacketFont = try boolean(value)
+        case "analytics": configuration.sharesAnalytics = try boolean(value)
+        case "crash_reports": configuration.sharesCrashReports = try boolean(value)
+        case "quit_confirmation": configuration.confirmsBeforeQuitting = try boolean(value)
+        case "mcp_enabled": configuration.isMCPServerEnabled = try boolean(value)
+        case "mcp_redaction": configuration.mcpRedactsSensitiveData = try boolean(value)
+        default:
+            throw CLIError(code: "unknown_setting", message: "The setting key is not supported.")
+        }
+    }
+
+    private func validImportURL(_ path: String) throws -> URL {
+        guard (path as NSString).isAbsolutePath, !path.contains("\0"), path.utf8.count <= 4_096 else {
+            throw CLIError(code: "invalid_parameter", message: "Import paths must be absolute file paths.")
+        }
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard TCPViewerCaptureFileImportPolicy.isSupportedCaptureFileURL(url) else {
+            throw CLIError(code: "unsupported_file", message: "Import accepts pcap, pcapng, or tcpviewsession files.")
+        }
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard values.isRegularFile == true, values.isSymbolicLink != true else {
+            throw CLIError(code: "unsafe_file", message: "Import paths must point to regular files and cannot be symbolic links.")
+        }
+        return url
+    }
+
+    private func exportSessionDestination(path: String?, overwrite: Bool) throws -> URL {
+        guard let path, (path as NSString).isAbsolutePath, !path.contains("\0"), path.utf8.count <= 4_096 else {
+            throw CLIError(code: "invalid_parameter", message: "path must be an absolute file path.")
+        }
+        var destination = URL(fileURLWithPath: path).standardizedFileURL
+        if destination.pathExtension.isEmpty {
+            destination.appendPathExtension(TCPViewSessionFormat.fileExtension)
+        } else if destination.pathExtension.lowercased() != TCPViewSessionFormat.fileExtension {
+            throw CLIError(code: "invalid_parameter", message: "path must use the .tcpviewsession extension.")
+        }
+        let parent = destination.deletingLastPathComponent()
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: parent.path, isDirectory: &isDirectory), isDirectory.boolValue,
+              fileManager.isWritableFile(atPath: parent.path) else {
+            throw CLIError(code: "invalid_parameter", message: "The destination directory must exist and be writable.")
+        }
+        if fileManager.fileExists(atPath: destination.path) {
+            let values = try destination.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .isDirectoryKey])
+            guard values.isRegularFile == true, values.isSymbolicLink != true, values.isDirectory != true else {
+                throw CLIError(code: "unsafe_file", message: "The existing destination must be a regular file and cannot be a symbolic link.")
+            }
+            guard overwrite else {
+                throw CLIError(code: "file_exists", message: "The destination exists. Use --overwrite to replace it.")
+            }
+        }
+        return destination
+    }
+
+    private func stringArray(_ request: TCPViewerCLIRequest, key: String, maximumCount: Int) throws -> [String] {
+        guard let values = request.array(key), values.count <= maximumCount else {
+            throw CLIError(code: "invalid_parameter", message: "\(key) must contain at most \(maximumCount) strings.")
+        }
+        return try values.map { value in
+            guard let string = value.stringValue else {
+                throw CLIError(code: "invalid_parameter", message: "\(key) must contain only strings.")
+            }
+            return string
+        }
+    }
+
+    private func boolean(_ value: String) throws -> Bool {
+        switch value.lowercased() {
+        case "true", "yes", "1", "on": true
+        case "false", "no", "0", "off": false
+        default: throw CLIError(code: "invalid_setting_value", message: "Boolean settings accept true or false.")
+        }
+    }
+
+    private func bounded(_ value: Int, range: ClosedRange<Int>, name: String) throws -> Int {
+        guard range.contains(value) else {
+            throw CLIError(code: "invalid_parameter", message: "\(name) is outside its supported range.")
+        }
+        return value
+    }
+
+    private func includes(_ direction: TCPFollowDirection, selection: String) -> Bool {
+        selection == "both" ||
+            (selection == "client-to-server" && direction == .clientToServer) ||
+            (selection == "server-to-client" && direction == .serverToClient)
+    }
+
+    private func encoded(_ data: Data, as encoding: String) -> String {
+        switch encoding {
+        case "base64": data.base64EncodedString()
+        case "hex": data.map { String(format: "%02x", $0) }.joined()
+        default: String(decoding: data, as: UTF8.self)
+        }
+    }
+
+    private func endpointValue(_ endpoint: PacketEndpoint) -> TCPViewerCLIValue {
+        var value: [String: TCPViewerCLIValue] = [:]
+        if let address = endpoint.address { value["address"] = .string(address) }
+        if let port = endpoint.port { value["port"] = .int(Int(port)) }
+        return .object(value)
+    }
+
+    private func mcpValue(_ value: TCPViewerCLIValue) -> TCPViewerMCPValue {
+        switch value {
+        case .string(let value): .string(value)
+        case .int(let value): .int(value)
+        case .double(let value): .double(value)
+        case .bool(let value): .bool(value)
+        case .array(let value): .array(value.map(mcpValue))
+        case .object(let value): .object(value.mapValues(mcpValue))
+        case .null: .null
+        }
+    }
+
+    private func cliValue(_ value: TCPViewerMCPValue, key: String? = nil) -> TCPViewerCLIValue {
+        switch value {
+        case .string(let value):
+            if key == "direction" {
+                return .string(value.replacingOccurrences(of: "clientToServer", with: "client_to_server")
+                    .replacingOccurrences(of: "serverToClient", with: "server_to_client"))
+            }
+            return .string(value)
+        case .int(let value): return .int(value)
+        case .double(let value):
+            if ["timestamp", "earliest_timestamp", "latest_timestamp"].contains(key) {
+                return .string(Self.iso8601.string(from: Date(timeIntervalSince1970: value)))
+            }
+            return .double(value)
+        case .bool(let value): return .bool(value)
+        case .array(let value): return .array(value.map { cliValue($0) })
+        case .object(let value): return .object(value.mapValuesWithKeys { key, value in cliValue(value, key: key) })
+        case .null: return .null
+        }
+    }
+
+    private func success(_ request: TCPViewerCLIRequest, data: [String: TCPViewerCLIValue]) -> TCPViewerCLIResponse {
+        .success(requestID: request.requestID, command: request.command, data: data)
+    }
+
+    private func failure(_ request: TCPViewerCLIRequest, code: String, error: Error) -> TCPViewerCLIResponse {
+        failure(request, code: code, message: error.localizedDescription)
+    }
+
+    private func failure(_ request: TCPViewerCLIRequest, code: String, message: String) -> TCPViewerCLIResponse {
+        .failure(requestID: request.requestID, command: request.command, code: code, message: message)
+    }
+
+    private struct CLIError: Error {
+        let code: String
+        let message: String
+    }
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}
+
+private extension Dictionary {
+    func mapValuesWithKeys<T>(_ transform: (Key, Value) -> T) -> [Key: T] {
+        Dictionary<Key, T>(uniqueKeysWithValues: map { key, value in (key, transform(key, value)) })
+    }
+}

--- a/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
+++ b/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
@@ -113,6 +113,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
 
     private let dataSourceProvider: () -> (any TCPViewerMCPDataSource)?
     private let isLicenseAuthorized: () -> Bool
+    private let requiresAuthorizedLicense: Bool
     private let redactionEnabled: () -> Bool
     private let versionProvider: () -> TCPViewerLicenseAppVersion
     private let exportPathPolicy: TCPViewerMCPExportPathPolicy
@@ -126,6 +127,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
         isLicenseAuthorized: @escaping () -> Bool = {
             TCPViewerLicenseService.shared.isLicenseAuthorized
         },
+        requiresAuthorizedLicense: Bool = true,
         redactionEnabled: @escaping () -> Bool = {
             (NSApp.delegate as? AppDelegate)?.appConfiguration.mcpRedactsSensitiveData ?? true
         },
@@ -138,6 +140,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
     ) {
         self.dataSourceProvider = dataSourceProvider
         self.isLicenseAuthorized = isLicenseAuthorized
+        self.requiresAuthorizedLicense = requiresAuthorizedLicense
         self.redactionEnabled = redactionEnabled
         self.versionProvider = versionProvider
         self.exportPathPolicy = exportPathPolicy
@@ -153,7 +156,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
             }
             return
         }
-        guard isLicenseAuthorized() else {
+        guard !requiresAuthorizedLicense || isLicenseAuthorized() else {
             completion(failure(TCPViewerMCPCommandRouterError.proRequired))
             return
         }
@@ -208,7 +211,7 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
                 "app": .string("TCP Viewer"),
                 "version": .string(version.appVersion),
                 "build": .string(version.buildNumber),
-                "pro_authorized": .bool(true),
+                "pro_authorized": .bool(self.isLicenseAuthorized()),
                 "redaction_enabled": .bool(self.redactionEnabled()),
                 "has_active_window": .bool(snapshot != nil),
                 "capture_phase": .string(snapshot?.capturePhase ?? "unavailable"),
@@ -390,7 +393,8 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
                 let selection = self.exportSelection(
                     query: query,
                     packets: snapshot.packets,
-                    totalPacketCount: snapshot.totalPacketCount
+                    totalPacketCount: snapshot.totalPacketCount,
+                    appliesResultPagination: request.bool("apply_result_pagination") == true && !exportsAll
                 )
                 guard !selection.ids.isEmpty else {
                     completion(self.failure(TCPViewerMCPCommandRouterError.invalidParameter("No packets matched the export selection.")))
@@ -408,6 +412,8 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
                                 "format": .string(format.rawValue),
                                 "exported_packet_count": .int(selection.ids.count),
                                 "selection_truncated": .bool(selection.isTruncated),
+                                "next_offset": selection.nextOffset.map(TCPViewerMCPValue.int) ?? .null,
+                                "next_scan_offset": selection.nextScanOffset.map(TCPViewerMCPValue.int) ?? .null,
                             ]))
                         }
                     case .failure(let error):
@@ -754,30 +760,43 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
     private func exportSelection(
         query: TCPViewerMCPPacketQuery,
         packets: [PacketSummary],
-        totalPacketCount: Int
-    ) -> (ids: [PacketSummary.ID], isTruncated: Bool) {
+        totalPacketCount: Int,
+        appliesResultPagination: Bool
+    ) -> (ids: [PacketSummary.ID], isTruncated: Bool, nextOffset: Int?, nextScanOffset: Int?) {
         let scannedCount = min(packets.count, query.scanLimit)
         let candidates: ArraySlice<PacketSummary> = query.order == .recent
             ? packets.suffix(scannedCount)
             : packets.prefix(scannedCount)
         var ids: [PacketSummary.ID] = []
         ids.reserveCapacity(min(scannedCount, Limit.maximumExportPacketCount))
+        let maximumSelectedCount = appliesResultPagination
+            ? min(query.limit, Limit.maximumExportPacketCount)
+            : Limit.maximumExportPacketCount
+        var matchedCount = 0
         var matchedBeyondLimit = false
         for packet in candidates where TCPViewerMCPPacketQueryService.matches(packet, query: query) {
-            if ids.count < Limit.maximumExportPacketCount {
+            let matchIndex = matchedCount
+            matchedCount += 1
+            if appliesResultPagination && matchIndex < query.offset {
+                continue
+            }
+            if ids.count < maximumSelectedCount {
                 ids.append(packet.id)
             } else {
                 matchedBeyondLimit = true
                 break
             }
         }
+        let hasMoreUnscannedPackets = hasMorePackets(
+            totalPacketCount: totalPacketCount,
+            scanOffset: query.scanOffset,
+            scannedCount: scannedCount
+        )
         return (
             ids,
-            matchedBeyondLimit || hasMorePackets(
-                totalPacketCount: totalPacketCount,
-                scanOffset: query.scanOffset,
-                scannedCount: scannedCount
-            )
+            matchedBeyondLimit || hasMoreUnscannedPackets,
+            matchedBeyondLimit && appliesResultPagination ? query.offset + ids.count : nil,
+            !matchedBeyondLimit && hasMoreUnscannedPackets ? query.scanOffset + scannedCount : nil
         )
     }
 

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -2166,12 +2166,14 @@ final class NetworkInspectorViewModel {
 
     func followTCPStream(
         containing identifier: PacketSummary.ID,
+        limits: TCPFollowLimits = .default,
         progress: TCPFollowProgressHandler?,
         shouldCancel: TCPFollowCancellationCheck?,
         completion: @escaping TCPViewerCompletion<TCPFollowStream>
     ) {
         controller.followTCPStream(
             containing: identifier,
+            limits: limits,
             progress: progress,
             shouldCancel: shouldCancel,
             completion: completion

--- a/TCPViewerCLIShared/TCPViewerCLIDarwinNotificationCenter.swift
+++ b/TCPViewerCLIShared/TCPViewerCLIDarwinNotificationCenter.swift
@@ -1,0 +1,68 @@
+//
+//  TCPViewerCLIDarwinNotificationCenter.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+
+enum TCPViewerCLINotificationName {
+    static let request = "com.proxyman.tcpviewer.cli.request"
+    static let response = "com.proxyman.tcpviewer.cli.response"
+}
+protocol TCPViewerCLINotificationObserving: AnyObject {}
+
+protocol TCPViewerCLINotificationCentering {
+    func post(_ name: String)
+    func observe(_ name: String, handler: @escaping () -> Void) -> any TCPViewerCLINotificationObserving
+}
+
+final class TCPViewerCLIDarwinNotificationCenter: TCPViewerCLINotificationCentering {
+    static let shared = TCPViewerCLIDarwinNotificationCenter()
+
+    func post(_ name: String) {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(name as CFString),
+            nil,
+            nil,
+            true
+        )
+    }
+
+    func observe(_ name: String, handler: @escaping () -> Void) -> any TCPViewerCLINotificationObserving {
+        TCPViewerCLIDarwinObserver(name: name, handler: handler)
+    }
+}
+
+private final class TCPViewerCLIDarwinObserver: TCPViewerCLINotificationObserving {
+    private let name: String
+    private let handler: () -> Void
+
+    init(name: String, handler: @escaping () -> Void) {
+        self.name = name
+        self.handler = handler
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            { _, observer, _, _, _ in
+                guard let observer else { return }
+                let instance = Unmanaged<TCPViewerCLIDarwinObserver>.fromOpaque(observer).takeUnretainedValue()
+                instance.handler()
+            },
+            name as CFString,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    deinit {
+        CFNotificationCenterRemoveObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            CFNotificationName(name as CFString),
+            nil
+        )
+    }
+}

--- a/TCPViewerCLIShared/TCPViewerCLIFileStore.swift
+++ b/TCPViewerCLIShared/TCPViewerCLIFileStore.swift
@@ -1,0 +1,281 @@
+//
+//  TCPViewerCLIFileStore.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Darwin
+import Foundation
+
+enum TCPViewerCLIFileStoreError: Error, LocalizedError {
+    case invalidIdentifier
+    case unavailable
+    case unsafeFile
+    case fileTooLarge
+    case invalidPayload
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidIdentifier:
+            return "The CLI request identifier is invalid."
+        case .unavailable:
+            return "The CLI request file is unavailable."
+        case .unsafeFile:
+            return "The CLI request file has unsafe metadata."
+        case .fileTooLarge:
+            return "The CLI request file is too large."
+        case .invalidPayload:
+            return "The CLI request file contains invalid JSON."
+        }
+    }
+}
+
+final class TCPViewerCLIFileStore {
+    static let requestMaximumByteCount = 1 * 1_024 * 1_024
+    // Text JSON can expand a 4 MiB TCP payload, so leave bounded headroom for escaping and record metadata.
+    static let responseMaximumByteCount = 32 * 1_024 * 1_024
+    static let orphanMaximumAge: TimeInterval = 24 * 60 * 60
+
+    private let fileManager: FileManager
+    private let rootURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileManager: FileManager = .default, rootURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.rootURL = rootURL ?? Self.defaultRootURL(fileManager: fileManager)
+        self.encoder = JSONEncoder()
+        self.encoder.dateEncodingStrategy = .iso8601
+        self.decoder = JSONDecoder()
+        self.decoder.dateDecodingStrategy = .iso8601
+    }
+
+    var requestsDirectoryURL: URL {
+        rootURL.appendingPathComponent("Requests", isDirectory: true)
+    }
+
+    var responsesDirectoryURL: URL {
+        rootURL.appendingPathComponent("Responses", isDirectory: true)
+    }
+
+    func prepareDirectories() throws {
+        try createPrivateDirectory(rootURL)
+        try createPrivateDirectory(requestsDirectoryURL)
+        try createPrivateDirectory(responsesDirectoryURL)
+    }
+
+    func writeRequest(_ request: TCPViewerCLIRequest) throws {
+        try prepareDirectories()
+        try writeSecurely(
+            encoder.encode(request),
+            to: try requestURL(for: request.requestID),
+            maximumByteCount: Self.requestMaximumByteCount
+        )
+    }
+
+    func writeResponse(_ response: TCPViewerCLIResponse) throws {
+        try prepareDirectories()
+        try writeSecurely(
+            encoder.encode(response),
+            to: try responseURL(for: response.requestID),
+            maximumByteCount: Self.responseMaximumByteCount
+        )
+    }
+
+    func readResponse(requestID: String) throws -> TCPViewerCLIResponse {
+        let data = try readSecurely(
+            at: try responseURL(for: requestID),
+            maximumByteCount: Self.responseMaximumByteCount
+        )
+        guard let response = try? decoder.decode(TCPViewerCLIResponse.self, from: data),
+              response.schemaVersion == TCPViewerCLIResponse.schemaVersion,
+              response.requestID == requestID else {
+            throw TCPViewerCLIFileStoreError.invalidPayload
+        }
+        return response
+    }
+
+    // Read valid work in creation order and delete unsafe or expired request files.
+    func pendingRequests(now: Date = Date()) -> [TCPViewerCLIRequest] {
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: requestsDirectoryURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return urls.compactMap { url in
+            guard url.pathExtension == "json" else {
+                try? fileManager.removeItem(at: url)
+                return nil
+            }
+            do {
+                let data = try readSecurely(at: url, maximumByteCount: Self.requestMaximumByteCount)
+                let request = try decoder.decode(TCPViewerCLIRequest.self, from: data)
+                let expectedName = try requestURL(for: request.requestID).lastPathComponent
+                guard request.schemaVersion == TCPViewerCLIRequest.schemaVersion,
+                      expectedName == url.lastPathComponent,
+                      request.expiresAt > now else {
+                    try? fileManager.removeItem(at: url)
+                    return nil
+                }
+                return request
+            } catch {
+                try? fileManager.removeItem(at: url)
+                return nil
+            }
+        }
+        .sorted {
+            if $0.createdAt == $1.createdAt { return $0.requestID < $1.requestID }
+            return $0.createdAt < $1.createdAt
+        }
+    }
+
+    func removeRequest(requestID: String) {
+        guard let url = try? requestURL(for: requestID) else { return }
+        try? fileManager.removeItem(at: url)
+    }
+
+    func removeResponse(requestID: String) {
+        guard let url = try? responseURL(for: requestID) else { return }
+        try? fileManager.removeItem(at: url)
+    }
+
+    func cleanupOrphans(now: Date = Date()) {
+        cleanup(directory: requestsDirectoryURL, olderThan: now.addingTimeInterval(-Self.orphanMaximumAge))
+        cleanup(directory: responsesDirectoryURL, olderThan: now.addingTimeInterval(-Self.orphanMaximumAge))
+    }
+
+    private func requestURL(for requestID: String) throws -> URL {
+        try fileURL(for: requestID, in: requestsDirectoryURL)
+    }
+
+    private func responseURL(for requestID: String) throws -> URL {
+        try fileURL(for: requestID, in: responsesDirectoryURL)
+    }
+
+    private func fileURL(for identifier: String, in directory: URL) throws -> URL {
+        guard UUID(uuidString: identifier) != nil,
+              !identifier.contains("/"),
+              !identifier.contains("\\") else {
+            throw TCPViewerCLIFileStoreError.invalidIdentifier
+        }
+        return directory.appendingPathComponent(identifier.lowercased()).appendingPathExtension("json")
+    }
+
+    private func createPrivateDirectory(_ url: URL) throws {
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        var metadata = stat()
+        guard lstat(url.path, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFDIR,
+              metadata.st_uid == geteuid() else {
+            throw TCPViewerCLIFileStoreError.unsafeFile
+        }
+        guard chmod(url.path, 0o700) == 0 else {
+            throw TCPViewerCLIFileStoreError.unavailable
+        }
+    }
+
+    private func writeSecurely(_ data: Data, to url: URL, maximumByteCount: Int) throws {
+        guard data.count <= maximumByteCount else {
+            throw TCPViewerCLIFileStoreError.fileTooLarge
+        }
+        let temporaryURL = url.deletingLastPathComponent().appendingPathComponent(
+            ".\(url.lastPathComponent).\(UUID().uuidString.lowercased()).tmp"
+        )
+        let descriptor = Darwin.open(
+            temporaryURL.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            0o600
+        )
+        guard descriptor >= 0 else {
+            throw errno == ELOOP ? TCPViewerCLIFileStoreError.unsafeFile : .unavailable
+        }
+        var shouldRemoveTemporaryFile = true
+        defer {
+            _ = Darwin.close(descriptor)
+            if shouldRemoveTemporaryFile { try? fileManager.removeItem(at: temporaryURL) }
+        }
+
+        var writtenByteCount = 0
+        while writtenByteCount < data.count {
+            let result = data.withUnsafeBytes { buffer in
+                Darwin.write(
+                    descriptor,
+                    buffer.baseAddress?.advanced(by: writtenByteCount),
+                    buffer.count - writtenByteCount
+                )
+            }
+            if result < 0 && errno == EINTR { continue }
+            guard result > 0 else { throw TCPViewerCLIFileStoreError.unavailable }
+            writtenByteCount += result
+        }
+        guard fsync(descriptor) == 0 else { throw TCPViewerCLIFileStoreError.unavailable }
+        guard renamex_np(temporaryURL.path, url.path, UInt32(RENAME_EXCL)) == 0 else {
+            throw TCPViewerCLIFileStoreError.unavailable
+        }
+        shouldRemoveTemporaryFile = false
+    }
+
+    private func readSecurely(at url: URL, maximumByteCount: Int) throws -> Data {
+        let descriptor = Darwin.open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else {
+            throw errno == ELOOP ? TCPViewerCLIFileStoreError.unsafeFile : .unavailable
+        }
+        defer { _ = Darwin.close(descriptor) }
+
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0 else { throw TCPViewerCLIFileStoreError.unavailable }
+        guard metadata.st_mode & S_IFMT == S_IFREG,
+              metadata.st_uid == geteuid(),
+              metadata.st_mode & 0o077 == 0 else {
+            throw TCPViewerCLIFileStoreError.unsafeFile
+        }
+        guard metadata.st_size >= 0, metadata.st_size <= maximumByteCount else {
+            throw TCPViewerCLIFileStoreError.fileTooLarge
+        }
+
+        var bytes = [UInt8](repeating: 0, count: Int(metadata.st_size))
+        var readByteCount = 0
+        while readByteCount < bytes.count {
+            let result = bytes.withUnsafeMutableBytes { buffer in
+                Darwin.read(
+                    descriptor,
+                    buffer.baseAddress?.advanced(by: readByteCount),
+                    buffer.count - readByteCount
+                )
+            }
+            if result < 0 && errno == EINTR { continue }
+            guard result >= 0 else { throw TCPViewerCLIFileStoreError.unavailable }
+            guard result > 0 else { break }
+            readByteCount += result
+        }
+        return Data(bytes.prefix(readByteCount))
+    }
+
+    private func cleanup(directory: URL, olderThan cutoff: Date) {
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: []
+        ) else {
+            return
+        }
+        for url in urls {
+            let date = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+            if date.map({ $0 < cutoff }) ?? true {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+    }
+
+    private static func defaultRootURL(fileManager: FileManager) -> URL {
+        let applicationSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+        return applicationSupport
+            .appendingPathComponent("TCPViewer", isDirectory: true)
+            .appendingPathComponent("CLI", isDirectory: true)
+    }
+}

--- a/TCPViewerCLIShared/TCPViewerCLIModels.swift
+++ b/TCPViewerCLIShared/TCPViewerCLIModels.swift
@@ -1,0 +1,218 @@
+//
+//  TCPViewerCLIModels.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+
+enum TCPViewerCLICommand: String, Codable, CaseIterable {
+    case appStatus = "app.status"
+    case interfacesList = "interfaces.list"
+    case captureStatus = "capture.status"
+    case captureStart = "capture.start"
+    case capturePause = "capture.pause"
+    case captureResume = "capture.resume"
+    case captureStop = "capture.stop"
+    case packetsList = "packets.list"
+    case packetsSummary = "packets.summary"
+    case packetsDetails = "packets.details"
+    case packetsBytes = "packets.bytes"
+    case packetsClear = "packets.clear"
+    case packetsReveal = "packets.reveal"
+    case streamPackets = "stream.packets"
+    case streamFollow = "stream.follow"
+    case fileImport = "file.import"
+    case fileExport = "file.export"
+    case fileExportSession = "file.export_session"
+    case licenseStatus = "license.status"
+    case licenseActivate = "license.activate"
+    case licenseRevoke = "license.revoke"
+    case settingsList = "settings.list"
+    case settingsGet = "settings.get"
+    case settingsSet = "settings.set"
+    case settingsReset = "settings.reset"
+}
+
+enum TCPViewerCLIValue: Codable, Equatable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case array([TCPViewerCLIValue])
+    case object([String: TCPViewerCLIValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([TCPViewerCLIValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: TCPViewerCLIValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported CLI JSON value."
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var intValue: Int? {
+        switch self {
+        case .int(let value):
+            return value
+        case .double(let value) where value.isFinite && value.rounded() == value:
+            return Int(exactly: value)
+        default:
+            return nil
+        }
+    }
+
+    var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    var arrayValue: [TCPViewerCLIValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    var objectValue: [String: TCPViewerCLIValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+}
+
+struct TCPViewerCLIRequest: Codable, Equatable {
+    static let schemaVersion = 1
+
+    let schemaVersion: Int
+    let requestID: String
+    let command: TCPViewerCLICommand
+    let params: [String: TCPViewerCLIValue]
+    let createdAt: Date
+    let expiresAt: Date
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case requestID = "request_id"
+        case command
+        case params
+        case createdAt = "created_at"
+        case expiresAt = "expires_at"
+    }
+
+    init(
+        requestID: String = UUID().uuidString.lowercased(),
+        command: TCPViewerCLICommand,
+        params: [String: TCPViewerCLIValue] = [:],
+        createdAt: Date = Date(),
+        expiresAt: Date
+    ) {
+        self.schemaVersion = Self.schemaVersion
+        self.requestID = requestID
+        self.command = command
+        self.params = params
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+    }
+
+    func value(_ key: String) -> TCPViewerCLIValue? { params[key] }
+    func string(_ key: String) -> String? { params[key]?.stringValue }
+    func int(_ key: String) -> Int? { params[key]?.intValue }
+    func bool(_ key: String) -> Bool? { params[key]?.boolValue }
+    func array(_ key: String) -> [TCPViewerCLIValue]? { params[key]?.arrayValue }
+}
+
+struct TCPViewerCLIErrorPayload: Codable, Equatable {
+    let code: String
+    let message: String
+}
+
+struct TCPViewerCLIResponse: Codable, Equatable {
+    static let schemaVersion = 1
+
+    let schemaVersion: Int
+    let requestID: String
+    let ok: Bool
+    let command: TCPViewerCLICommand
+    let data: [String: TCPViewerCLIValue]?
+    let error: TCPViewerCLIErrorPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case requestID = "request_id"
+        case ok
+        case command
+        case data
+        case error
+    }
+
+    static func success(
+        requestID: String,
+        command: TCPViewerCLICommand,
+        data: [String: TCPViewerCLIValue]
+    ) -> TCPViewerCLIResponse {
+        TCPViewerCLIResponse(
+            schemaVersion: schemaVersion,
+            requestID: requestID,
+            ok: true,
+            command: command,
+            data: data,
+            error: nil
+        )
+    }
+
+    static func failure(
+        requestID: String,
+        command: TCPViewerCLICommand,
+        code: String,
+        message: String
+    ) -> TCPViewerCLIResponse {
+        TCPViewerCLIResponse(
+            schemaVersion: schemaVersion,
+            requestID: requestID,
+            ok: false,
+            command: command,
+            data: nil,
+            error: TCPViewerCLIErrorPayload(code: code, message: message)
+        )
+    }
+}

--- a/TCPViewerTests/Features/CLI/TCPViewerCLICommandCoordinatorTests.swift
+++ b/TCPViewerTests/Features/CLI/TCPViewerCLICommandCoordinatorTests.swift
@@ -1,0 +1,143 @@
+//
+//  TCPViewerCLICommandCoordinatorTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+@MainActor
+struct TCPViewerCLICommandCoordinatorTests {
+    @Test func startupScanProcessesRequestsWrittenBeforeTheObserver() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let request = fixture.request(.captureStatus)
+        try fixture.store.writeRequest(request)
+
+        fixture.coordinator.start()
+        #expect(await fixture.notifications.waitForResponses(count: 1))
+
+        let response = try fixture.store.readResponse(requestID: request.requestID)
+        #expect(response.requestID == request.requestID)
+        #expect(response.command == .captureStatus)
+        #expect(response.data?["handled"] == .bool(true))
+    }
+
+    @Test func correlatesAndSerializesConcurrentInvocations() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        fixture.coordinator.start()
+        let requests = (0..<12).map { index in
+            fixture.request(index.isMultiple(of: 2) ? .packetsList : .interfacesList)
+        }
+        for request in requests {
+            try fixture.store.writeRequest(request)
+            fixture.notifications.post(TCPViewerCLINotificationName.request)
+        }
+
+        #expect(await fixture.notifications.waitForResponses(count: requests.count))
+        #expect(fixture.router.maximumConcurrentRouteCount == 1)
+        #expect(Set(fixture.router.requestIDs) == Set(requests.map(\.requestID)))
+        for request in requests {
+            let response = try fixture.store.readResponse(requestID: request.requestID)
+            #expect(response.requestID == request.requestID)
+            #expect(response.command == request.command)
+        }
+    }
+
+    private final class Fixture {
+        let root: URL
+        let store: TCPViewerCLIFileStore
+        let notifications = FakeNotificationCenter()
+        let router = FakeRouter()
+        let coordinator: TCPViewerCLICommandCoordinator
+
+        init() throws {
+            root = FileManager.default.temporaryDirectory.appendingPathComponent("TCPViewerCLICoordinatorTests-\(UUID().uuidString)")
+            store = TCPViewerCLIFileStore(rootURL: root)
+            try store.prepareDirectories()
+            coordinator = TCPViewerCLICommandCoordinator(
+                fileStore: store,
+                notificationCenter: notifications,
+                router: router
+            )
+        }
+
+        func request(_ command: TCPViewerCLICommand) -> TCPViewerCLIRequest {
+            TCPViewerCLIRequest(command: command, expiresAt: Date().addingTimeInterval(30))
+        }
+
+        func remove() {
+            coordinator.stop()
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    private final class FakeRouter: TCPViewerCLICommandRouting {
+        private let lock = NSLock()
+        private var concurrentRouteCount = 0
+        private(set) var maximumConcurrentRouteCount = 0
+        private(set) var requestIDs: [String] = []
+
+        func route(_ request: TCPViewerCLIRequest, completion: @escaping (TCPViewerCLIResponse) -> Void) {
+            lock.lock()
+            concurrentRouteCount += 1
+            maximumConcurrentRouteCount = max(maximumConcurrentRouteCount, concurrentRouteCount)
+            requestIDs.append(request.requestID)
+            lock.unlock()
+            completion(.success(
+                requestID: request.requestID,
+                command: request.command,
+                data: ["handled": .bool(true)]
+            ))
+            lock.lock()
+            concurrentRouteCount -= 1
+            lock.unlock()
+        }
+    }
+
+    private final class FakeNotificationCenter: TCPViewerCLINotificationCentering {
+        private let lock = NSLock()
+        private var handlers: [String: () -> Void] = [:]
+        private var responseCount = 0
+
+        func post(_ name: String) {
+            lock.lock()
+            let handler = handlers[name]
+            if name == TCPViewerCLINotificationName.response {
+                responseCount += 1
+            }
+            lock.unlock()
+            handler?()
+        }
+
+        func observe(_ name: String, handler: @escaping () -> Void) -> any TCPViewerCLINotificationObserving {
+            lock.lock()
+            handlers[name] = handler
+            lock.unlock()
+            return Token()
+        }
+
+        // Yield the main actor while the coordinator returns app routing work to it.
+        func waitForResponses(count expectedCount: Int) async -> Bool {
+            let deadline = Date().addingTimeInterval(5)
+            while Date() < deadline {
+                lock.lock()
+                let hasReceivedAllResponses = responseCount >= expectedCount
+                lock.unlock()
+                if hasReceivedAllResponses { return true }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            lock.lock()
+            let hasReceivedAllResponses = responseCount >= expectedCount
+            lock.unlock()
+            return hasReceivedAllResponses
+        }
+
+        private final class Token: TCPViewerCLINotificationObserving {}
+    }
+}

--- a/TCPViewerTests/Features/CLI/TCPViewerCLIFileStoreTests.swift
+++ b/TCPViewerTests/Features/CLI/TCPViewerCLIFileStoreTests.swift
@@ -1,0 +1,138 @@
+//
+//  TCPViewerCLIFileStoreTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Darwin
+import Foundation
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct TCPViewerCLIFileStoreTests {
+    @Test func roundTripsCorrelatedResponseWithPrivatePermissions() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let requestID = UUID().uuidString.lowercased()
+        let response = TCPViewerCLIResponse.success(
+            requestID: requestID,
+            command: .packetsBytes,
+            data: ["packet_id": .string(String(UInt64.max)), "data": .string("AQID")]
+        )
+
+        try fixture.store.writeResponse(response)
+        #expect(try fixture.store.readResponse(requestID: requestID) == response)
+        #expect(try mode(fixture.store.requestsDirectoryURL) == 0o700)
+        #expect(try mode(fixture.store.responsesDirectoryURL) == 0o700)
+        #expect(try mode(fixture.responseURL(requestID)) == 0o600)
+    }
+
+    @Test func scansPendingRequestsInCreationOrderAndDropsExpiredWork() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let now = Date()
+        let later = TCPViewerCLIRequest(
+            command: .captureStatus,
+            createdAt: now.addingTimeInterval(1),
+            expiresAt: now.addingTimeInterval(60)
+        )
+        let first = TCPViewerCLIRequest(
+            command: .interfacesList,
+            createdAt: now,
+            expiresAt: now.addingTimeInterval(60)
+        )
+        let expired = TCPViewerCLIRequest(
+            command: .packetsList,
+            createdAt: now.addingTimeInterval(-2),
+            expiresAt: now.addingTimeInterval(-1)
+        )
+        try fixture.store.writeRequest(later)
+        try fixture.store.writeRequest(first)
+        try fixture.store.writeRequest(expired)
+
+        #expect(fixture.store.pendingRequests(now: now).map(\.requestID) == [first.requestID, later.requestID])
+        #expect(!FileManager.default.fileExists(atPath: fixture.requestURL(expired.requestID).path))
+    }
+
+    @Test func rejectsSymlinkedResponsesAndOversizedRequests() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let requestID = UUID().uuidString.lowercased()
+        let target = fixture.root.appendingPathComponent("target.json")
+        try Data("{}".utf8).write(to: target)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+        try FileManager.default.createSymbolicLink(at: fixture.responseURL(requestID), withDestinationURL: target)
+
+        #expect(throws: TCPViewerCLIFileStoreError.self) {
+            try fixture.store.readResponse(requestID: requestID)
+        }
+
+        let oversizedID = UUID().uuidString.lowercased()
+        let oversizedURL = fixture.requestURL(oversizedID)
+        let oversizedData = Data(repeating: 0x20, count: TCPViewerCLIFileStore.requestMaximumByteCount + 1)
+        try oversizedData.write(to: oversizedURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: oversizedURL.path)
+        #expect(fixture.store.pendingRequests().isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: oversizedURL.path))
+    }
+
+    @Test func cleansOrphanedResponsesAfterTwentyFourHours() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let requestID = UUID().uuidString.lowercased()
+        try fixture.store.writeResponse(.success(requestID: requestID, command: .appStatus, data: [:]))
+        let oldDate = Date().addingTimeInterval(-TCPViewerCLIFileStore.orphanMaximumAge - 1)
+        try FileManager.default.setAttributes([.modificationDate: oldDate], ofItemAtPath: fixture.responseURL(requestID).path)
+
+        fixture.store.cleanupOrphans()
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.responseURL(requestID).path))
+    }
+
+    @Test func rejectsSymlinkedTransportDirectory() throws {
+        let parent = FileManager.default.temporaryDirectory.appendingPathComponent("TCPViewerCLISymlinkDirectoryTests-\(UUID().uuidString)")
+        let target = parent.appendingPathComponent("target", isDirectory: true)
+        let root = parent.appendingPathComponent("CLI", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        try FileManager.default.createSymbolicLink(at: root, withDestinationURL: target)
+        let store = TCPViewerCLIFileStore(rootURL: root)
+
+        #expect(throws: TCPViewerCLIFileStoreError.self) {
+            try store.prepareDirectories()
+        }
+    }
+
+    private func mode(_ url: URL) throws -> mode_t {
+        var metadata = stat()
+        guard lstat(url.path, &metadata) == 0 else {
+            throw TCPViewerCLIFileStoreError.unavailable
+        }
+        return metadata.st_mode & 0o777
+    }
+
+    private struct Fixture {
+        let root: URL
+        let store: TCPViewerCLIFileStore
+
+        init() throws {
+            root = FileManager.default.temporaryDirectory.appendingPathComponent("TCPViewerCLIFileStoreTests-\(UUID().uuidString)")
+            store = TCPViewerCLIFileStore(rootURL: root)
+            try store.prepareDirectories()
+        }
+
+        func requestURL(_ requestID: String) -> URL {
+            store.requestsDirectoryURL.appendingPathComponent(requestID).appendingPathExtension("json")
+        }
+
+        func responseURL(_ requestID: String) -> URL {
+            store.responsesDirectoryURL.appendingPathComponent(requestID).appendingPathExtension("json")
+        }
+
+        func remove() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+}

--- a/TCPViewerTests/Features/CLI/TCPViewerCLIModelsTests.swift
+++ b/TCPViewerTests/Features/CLI/TCPViewerCLIModelsTests.swift
@@ -1,0 +1,70 @@
+//
+//  TCPViewerCLIModelsTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+import Testing
+@testable import TCPViewer
+
+struct TCPViewerCLIModelsTests {
+    @Test func encodesStableEnvelopePacketIDsAndBinaryAsStrings() throws {
+        let response = TCPViewerCLIResponse.success(
+            requestID: "d733d28a-2c43-4d61-917c-32388fa7c052",
+            command: .packetsBytes,
+            data: [
+                "packet_id": .string(String(UInt64.max)),
+                "encoding": .string("base64"),
+                "data": .string(Data([0, 1, 2]).base64EncodedString()),
+            ]
+        )
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(response)) as? [String: Any])
+        let data = try #require(object["data"] as? [String: Any])
+
+        #expect(object["schema_version"] as? Int == 1)
+        #expect(object["ok"] as? Bool == true)
+        #expect(object["command"] as? String == "packets.bytes")
+        #expect(data["packet_id"] as? String == "18446744073709551615")
+        #expect(data["data"] as? String == "AAEC")
+    }
+
+    @Test func failureEnvelopeDoesNotContainLicenseSecrets() throws {
+        let response = TCPViewerCLIResponse.failure(
+            requestID: UUID().uuidString.lowercased(),
+            command: .licenseActivate,
+            code: "license_activation_failed",
+            message: "Invalid license key."
+        )
+        let json = try #require(String(data: JSONEncoder().encode(response), encoding: .utf8))
+
+        #expect(json.contains("license_activation_failed"))
+        #expect(!json.contains("license_key"))
+        #expect(!json.contains("signature"))
+    }
+
+    @Test func roundTripsIPv6FilterValueWithoutChangingColons() throws {
+        let request = TCPViewerCLIRequest(
+            command: .packetsList,
+            params: [
+                "filters": .array([.object([
+                    "field": .string("source_address"),
+                    "operator": .string("equals"),
+                    "value": .string("2001:db8::1"),
+                ])]),
+            ],
+            expiresAt: Date().addingTimeInterval(30)
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoded = try decoder.decode(TCPViewerCLIRequest.self, from: encoder.encode(request))
+
+        #expect(decoded.requestID == request.requestID)
+        #expect(decoded.command == request.command)
+        #expect(decoded.params == request.params)
+        #expect(decoded.array("filters")?.first?.objectValue?["value"] == .string("2001:db8::1"))
+    }
+}

--- a/TCPViewerTests/Features/CLI/TCPViewerCLIProcessSmokeTests.swift
+++ b/TCPViewerTests/Features/CLI/TCPViewerCLIProcessSmokeTests.swift
@@ -1,0 +1,97 @@
+//
+//  TCPViewerCLIProcessSmokeTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct TCPViewerCLIProcessSmokeTests {
+    @Test func helpAndVersionRunWithoutContactingTheApp() throws {
+        let version = try run(["--version"])
+        #expect(version.status == 0)
+        #expect(version.output.contains(TCPViewerLicenseAppVersion.current.appVersion))
+
+        let commands = [
+            ["app", "status"], ["interfaces", "list"],
+            ["capture", "status"], ["capture", "start"], ["capture", "pause"], ["capture", "resume"], ["capture", "stop"],
+            ["packets", "list"], ["packets", "summary"], ["packets", "details"], ["packets", "bytes"], ["packets", "clear"], ["packets", "reveal"],
+            ["stream", "packets"], ["stream", "follow"],
+            ["file", "import"], ["file", "export"], ["file", "export-session"],
+            ["license", "status"], ["license", "activate"], ["license", "revoke"],
+            ["settings", "list"], ["settings", "get"], ["settings", "set"], ["settings", "reset"],
+        ]
+        for command in commands {
+            let result = try run(command + ["--help"])
+            #expect(result.status == 0, "Expected help to succeed for \(command.joined(separator: " "))")
+            #expect(result.output.contains("USAGE:"))
+        }
+    }
+
+    @Test func invalidArgumentsUseUsageExitCodeTwo() throws {
+        let cases = [
+            ["capture", "start"],
+            ["packets", "details", "not-a-packet"],
+            ["packets", "list", "--limit", "501"],
+            ["packets", "list", "--scan-limit", "100001"],
+            ["packets", "list", "--port", "65536"],
+            ["packets", "list", "--filter", "address:equals"],
+            ["packets", "list", "--filter", "source_address:equals:2001:db8::1", "--limit", "0"],
+            ["packets", "details", "1", "--max-depth", "13"],
+            ["packets", "details", "1", "--max-nodes", "5001"],
+            ["packets", "bytes", "1", "--length", "65537"],
+            ["packets", "clear"],
+            ["stream", "follow", "1", "--max-bytes", "4194305"],
+            ["stream", "follow", "1", "--max-records", "10001"],
+            ["file", "import", "/tmp/one.tcpviewsession", "/tmp/two.pcap"],
+            ["file", "export", "/tmp/export.pcapng"],
+            ["file", "export", "/tmp/export.pcapng", "--all"],
+            ["file", "export", "/tmp/export.pcapng", "--format", "pcapng", "--all", "--protocol", "tcp"],
+            ["license", "revoke"],
+            ["settings", "reset", "--all"],
+            ["settings", "reset", "theme", "--all", "--yes"],
+            ["app", "status", "--output", "text", "--pretty"],
+            ["app", "status", "--timeout", "0"],
+        ]
+        for arguments in cases {
+            let result = try run(arguments)
+            #expect(result.status == 2, "Expected usage exit code for \(arguments.joined(separator: " "))")
+            #expect(result.error.contains("Error:"))
+        }
+    }
+
+    private func run(_ arguments: [String]) throws -> (status: Int32, output: String, error: String) {
+        let process = Process()
+        process.executableURL = try executableURL()
+        process.arguments = arguments
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+        try process.run()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: standardOutput.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            String(decoding: standardError.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        )
+    }
+
+    private func executableURL() throws -> URL {
+        let bundled = Bundle.main.bundleURL.appendingPathComponent("Contents/MacOS/tcpviewer-cli")
+        if FileManager.default.isExecutableFile(atPath: bundled.path) {
+            return bundled
+        }
+        if let products = ProcessInfo.processInfo.environment["BUILT_PRODUCTS_DIR"] {
+            let product = URL(fileURLWithPath: products).appendingPathComponent("tcpviewer-cli")
+            if FileManager.default.isExecutableFile(atPath: product.path) {
+                return product
+            }
+        }
+        throw CocoaError(.fileNoSuchFile)
+    }
+}

--- a/TCPViewerTests/Features/MCP/TCPViewerMCPCommandRouterTests.swift
+++ b/TCPViewerTests/Features/MCP/TCPViewerMCPCommandRouterTests.swift
@@ -166,6 +166,29 @@ struct TCPViewerMCPCommandRouterTests {
         #expect(source.exportedURL?.pathExtension == "pcapng")
         #expect(source.exportedFormat == .pcapng)
 
+        let paginatedExport = await routeMCP(router, command: .exportPackets, params: [
+            "path": .string(directory.appendingPathComponent("paginated.pcapng").path),
+            "all": .bool(true),
+            "apply_result_pagination": .bool(true),
+            "offset": .int(1),
+            "limit": .int(1),
+        ])
+        #expect(paginatedExport.success)
+        #expect(source.exportedIDs == [1, 2])
+
+        let selectedPage = await routeMCP(router, command: .exportPackets, params: [
+            "path": .string(directory.appendingPathComponent("selected-page.pcapng").path),
+            "filters": .array([.object([
+                "field": .string("packet_id"),
+                "operator": .string("exists"),
+            ])]),
+            "apply_result_pagination": .bool(true),
+            "offset": .int(1),
+            "limit": .int(1),
+        ])
+        #expect(selectedPage.success)
+        #expect(source.exportedIDs == [2])
+
         let start = await routeMCP(router, command: .startCapture, params: [
             "interface_id": .string("en0"),
             "capture_filter": .string("tcp port 443"),
@@ -222,6 +245,16 @@ struct TCPViewerMCPCommandRouterTests {
             redactionEnabled: { true }
         )
         #expect(!(await routeMCP(unauthorized, command: .getAppStatus)).success)
+
+        let cliAuthorizedRouter = TCPViewerMCPCommandRouter(
+            dataSourceProvider: { source },
+            isLicenseAuthorized: { false },
+            requiresAuthorizedLicense: false,
+            redactionEnabled: { false }
+        )
+        let cliStatus = await routeMCP(cliAuthorizedRouter, command: .getAppStatus)
+        #expect(cliStatus.success)
+        #expect(cliStatus.value("pro_authorized") == .bool(false))
 
         let unavailable = TCPViewerMCPCommandRouter(
             dataSourceProvider: { nil },

--- a/scripts/homebrew/README.md
+++ b/scripts/homebrew/README.md
@@ -70,3 +70,5 @@ After Homebrew merges the initial cask, users can install the app with:
 ```bash
 brew install --cask tcp-viewer
 ```
+
+The cask links the executable bundled at `TCP Viewer.app/Contents/MacOS/tcpviewer-cli`, so `tcpviewer-cli` is available on `PATH` after installation. Verify it with `tcpviewer-cli --version`.

--- a/scripts/homebrew/tcp-viewer.rb
+++ b/scripts/homebrew/tcp-viewer.rb
@@ -17,6 +17,7 @@ cask "tcp-viewer" do
   depends_on macos: :sequoia
 
   app "TCP Viewer.app"
+  binary "#{appdir}/TCP Viewer.app/Contents/MacOS/tcpviewer-cli"
 
   uninstall launchctl: "com.proxyman.tcpviewer.helpertool",
             quit:      "com.proxyman.tcpviewer",

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -524,6 +524,9 @@ export function validateHomebrewCaskContent(content) {
   if (!/^  app "TCP Viewer\.app"$/m.test(current)) {
     throw new Error("TCP Viewer Homebrew Cask must install TCP Viewer.app.");
   }
+  if (!/^  binary "#\{appdir\}\/TCP Viewer\.app\/Contents\/MacOS\/tcpviewer-cli"$/m.test(current)) {
+    throw new Error("TCP Viewer Homebrew Cask must expose the bundled tcpviewer-cli executable.");
+  }
 
   return parsedVersion;
 }

--- a/tcpviewer-cli/Commands/AppCaptureCommands.swift
+++ b/tcpviewer-cli/Commands/AppCaptureCommands.swift
@@ -1,0 +1,111 @@
+//
+//  AppCaptureCommands.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import ArgumentParser
+import Foundation
+
+struct AppCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "app",
+        abstract: "Inspect TCP Viewer.",
+        subcommands: [AppStatusCommand.self]
+    )
+}
+
+struct AppStatusCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "status", abstract: "Show TCP Viewer status.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+
+    func run() throws {
+        try execute(.appStatus, launchIfNeeded: false)
+    }
+}
+
+struct InterfacesCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "interfaces",
+        abstract: "Inspect capture interfaces.",
+        subcommands: [InterfacesListCommand.self]
+    )
+}
+
+struct InterfacesListCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List capture interfaces.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+
+    func run() throws {
+        try execute(.interfacesList)
+    }
+}
+
+struct CaptureCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "capture",
+        abstract: "Control live capture.",
+        subcommands: [
+            CaptureStatusCommand.self,
+            CaptureStartCommand.self,
+            CapturePauseCommand.self,
+            CaptureResumeCommand.self,
+            CaptureStopCommand.self,
+        ]
+    )
+}
+
+struct CaptureStatusCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "status", abstract: "Show capture status.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+
+    func run() throws {
+        try execute(.captureStatus)
+    }
+}
+
+struct CaptureStartCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "start", abstract: "Start a new live capture.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+
+    @Option(name: .long, help: "Capture interface ID from interfaces list.")
+    var interface: String
+
+    @Option(name: .long, help: "Persistent libpcap BPF filter for future packets.")
+    var bpf: String?
+
+    func validate() throws {
+        if interface.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || interface.utf8.count > 256 {
+            throw ValidationError("--interface must contain between 1 and 256 UTF-8 bytes.")
+        }
+        if let bpf, bpf.utf8.count > 4_096 {
+            throw ValidationError("--bpf cannot exceed 4096 UTF-8 bytes.")
+        }
+    }
+
+    func run() throws {
+        var params: [String: TCPViewerCLIValue] = [:]
+        params["interface_id"] = .string(interface)
+        if let bpf { params["capture_filter"] = .string(bpf) }
+        try execute(.captureStart, params: params)
+    }
+}
+
+struct CapturePauseCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "pause", abstract: "Pause live capture.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    func run() throws { try execute(.capturePause) }
+}
+
+struct CaptureResumeCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "resume", abstract: "Resume paused capture.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    func run() throws { try execute(.captureResume) }
+}
+
+struct CaptureStopCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "stop", abstract: "Stop live capture.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    func run() throws { try execute(.captureStop) }
+}

--- a/tcpviewer-cli/Commands/FileLicenseSettingsCommands.swift
+++ b/tcpviewer-cli/Commands/FileLicenseSettingsCommands.swift
@@ -1,0 +1,202 @@
+//
+//  FileLicenseSettingsCommands.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import ArgumentParser
+import Darwin
+import Foundation
+
+struct FileCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "file",
+        abstract: "Import and export capture files.",
+        subcommands: [FileImportCommand.self, FileExportCommand.self, FileExportSessionCommand.self]
+    )
+}
+
+struct FileImportCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "import", abstract: "Import pcap, pcapng, or one tcpviewsession file.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Capture file paths.") var paths: [String]
+
+    func validate() throws {
+        guard !paths.isEmpty, paths.count <= 100 else {
+            throw ValidationError("file import requires between 1 and 100 paths.")
+        }
+        let extensions = paths.map { URL(fileURLWithPath: $0).pathExtension.lowercased() }
+        guard extensions.allSatisfy({ ["pcap", "pcapng", "tcpviewsession"].contains($0) }) else {
+            throw ValidationError("file import accepts only pcap, pcapng, and tcpviewsession files.")
+        }
+        if extensions.contains("tcpviewsession") && paths.count != 1 {
+            throw ValidationError("A tcpviewsession must be imported by itself.")
+        }
+    }
+
+    func run() throws {
+        let absolutePaths = paths.map(TCPViewerCLIPath.absolute)
+        try execute(.fileImport, params: [
+            "paths": .array(absolutePaths.map(TCPViewerCLIValue.string)),
+        ], defaultTimeout: 300)
+    }
+}
+
+enum FileExportFormat: String, ExpressibleByArgument {
+    case pcap
+    case pcapng
+}
+
+struct FileExportCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "export", abstract: "Export selected packets to pcap or pcapng.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Destination path.") var path: String
+    @Option(name: .long) var format: FileExportFormat
+    @Flag(name: .long, help: "Export the bounded scan when no selectors are supplied.") var all = false
+    @Flag(name: .long, help: "Replace an existing regular file.") var overwrite = false
+    @OptionGroup var query: TCPViewerCLIPacketQueryOptions
+
+    func validate() throws {
+        try query.validate()
+        guard all || query.hasSelector else {
+            throw ValidationError("file export requires --all or at least one packet selector.")
+        }
+        guard !(all && query.hasSelector) else {
+            throw ValidationError("file export accepts --all or packet selectors, but not both.")
+        }
+    }
+
+    func run() throws {
+        var params = try query.params()
+        params["path"] = .string(TCPViewerCLIPath.absolute(path))
+        params["format"] = .string(format.rawValue)
+        params["all"] = .bool(all)
+        params["overwrite"] = .bool(overwrite)
+        try execute(.fileExport, params: params, defaultTimeout: 300)
+    }
+}
+
+struct FileExportSessionCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "export-session", abstract: "Export the active TCP Viewer session.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Destination tcpviewsession path.") var path: String
+    @Flag(name: .long, help: "Replace an existing regular file.") var overwrite = false
+
+    func run() throws {
+        try execute(.fileExportSession, params: [
+            "path": .string(TCPViewerCLIPath.absolute(path)),
+            "overwrite": .bool(overwrite),
+        ], defaultTimeout: 300)
+    }
+}
+
+struct LicenseCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "license",
+        abstract: "Manage the TCP Viewer license.",
+        subcommands: [LicenseStatusCommand.self, LicenseActivateCommand.self, LicenseRevokeCommand.self]
+    )
+}
+
+struct LicenseStatusCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "status", abstract: "Show license status without exposing the receipt.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    func run() throws { try execute(.licenseStatus, defaultTimeout: 60) }
+}
+
+struct LicenseActivateCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "activate", abstract: "Activate a license key read from stdin or a secure prompt.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+
+    func run() throws {
+        let key = try TCPViewerCLILicenseKeyReader.read()
+        try execute(.licenseActivate, params: ["license_key": .string(key)], defaultTimeout: 60)
+    }
+}
+
+struct LicenseRevokeCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "revoke", abstract: "Revoke this Mac's license seat.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Flag(name: .long, help: "Confirm license revocation.") var yes = false
+    func validate() throws { if !yes { throw ValidationError("license revoke requires --yes.") } }
+    func run() throws { try execute(.licenseRevoke, params: ["confirm": .bool(true)], defaultTimeout: 60) }
+}
+
+struct SettingsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "settings",
+        abstract: "Read and change TCP Viewer settings.",
+        subcommands: [SettingsListCommand.self, SettingsGetCommand.self, SettingsSetCommand.self, SettingsResetCommand.self]
+    )
+}
+
+struct SettingsListCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List supported settings and current values.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    func run() throws { try execute(.settingsList) }
+}
+
+struct SettingsGetCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "get", abstract: "Read one setting.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument var key: String
+    func run() throws { try execute(.settingsGet, params: ["key": .string(key)]) }
+}
+
+struct SettingsSetCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "set", abstract: "Change one setting.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument var key: String
+    @Argument var value: String
+    func run() throws { try execute(.settingsSet, params: ["key": .string(key), "value": .string(value)]) }
+}
+
+struct SettingsResetCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "reset", abstract: "Reset one setting or every supported setting.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument var key: String?
+    @Flag(name: .long, help: "Reset every supported setting.") var all = false
+    @Flag(name: .long, help: "Confirm resetting all supported settings.") var yes = false
+
+    func validate() throws {
+        guard (key != nil) != all else {
+            throw ValidationError("Provide one setting key or --all.")
+        }
+        if all && !yes {
+            throw ValidationError("settings reset --all requires --yes.")
+        }
+    }
+
+    func run() throws {
+        var params: [String: TCPViewerCLIValue] = ["all": .bool(all)]
+        if let key { params["key"] = .string(key) }
+        try execute(.settingsReset, params: params)
+    }
+}
+
+enum TCPViewerCLIPath {
+    static func absolute(_ path: String) -> String {
+        let baseURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        return URL(fileURLWithPath: path, relativeTo: baseURL).standardizedFileURL.path
+    }
+}
+
+enum TCPViewerCLILicenseKeyReader {
+    static func read() throws -> String {
+        let value: String
+        if isatty(STDIN_FILENO) == 1 {
+            guard let pointer = getpass("License key: ") else {
+                throw ValidationError("Could not read the license key.")
+            }
+            value = String(cString: pointer)
+        } else {
+            value = readLine() ?? ""
+        }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.hasPrefix("TCPV-") else {
+            throw ValidationError("A TCP Viewer license key must start with TCPV-.")
+        }
+        return normalized
+    }
+}

--- a/tcpviewer-cli/Commands/PacketQueryOptions.swift
+++ b/tcpviewer-cli/Commands/PacketQueryOptions.swift
@@ -1,0 +1,187 @@
+//
+//  PacketQueryOptions.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import ArgumentParser
+import Foundation
+
+enum TCPViewerCLIQueryMatch: String, ExpressibleByArgument {
+    case and
+    case or
+}
+
+enum TCPViewerCLIQueryOrder: String, ExpressibleByArgument {
+    case recent
+    case oldest
+}
+
+struct TCPViewerCLIPacketQueryOptions: ParsableArguments {
+    @Option(name: .customLong("protocol"), help: "Protocol name. Repeat to match any protocol.")
+    var protocols: [String] = []
+
+    @Option(name: .customLong("domain"), help: "Domain fragment. Repeat to match any domain.")
+    var domains: [String] = []
+
+    @Option(name: .customLong("address"), help: "Source or destination address fragment.")
+    var addresses: [String] = []
+
+    @Option(name: .customLong("port"), help: "Source or destination port.")
+    var ports: [Int] = []
+
+    @Option(name: .customLong("client"), help: "Client application name fragment.")
+    var clients: [String] = []
+
+    @Option(name: .customLong("packet-id"), help: "Packet ID. Repeat to match any listed packet.")
+    var packetIDs: [String] = []
+
+    @Option(name: .customLong("stream-id"), help: "TCP or UDP stream ID.")
+    var streamID: UInt32?
+
+    @Option(name: .customLong("filter"), help: "Advanced field:operator:value filter. Repeat for more filters.")
+    var filters: [String] = []
+
+    @Option(name: .customLong("match"), help: "How advanced filters are combined.")
+    var match: TCPViewerCLIQueryMatch = .and
+
+    @Flag(name: .customLong("case-sensitive"), help: "Use case-sensitive advanced text filters.")
+    var caseSensitive = false
+
+    @Option(name: .customLong("order"), help: "Read recent or oldest packets first.")
+    var order: TCPViewerCLIQueryOrder = .recent
+
+    @Option(name: .customLong("limit"), help: "Maximum returned packets, from 1 through 500.")
+    var limit = 50
+
+    @Option(name: .customLong("offset"), help: "Matched packets to skip.")
+    var offset = 0
+
+    @Option(name: .customLong("scan-limit"), help: "Maximum packets to scan, up to 100000.")
+    var scanLimit = 50_000
+
+    @Option(name: .customLong("scan-offset"), help: "Packets to skip before the bounded scan.")
+    var scanOffset = 0
+
+    var hasSelector: Bool {
+        !protocols.isEmpty || !domains.isEmpty || !addresses.isEmpty || !ports.isEmpty ||
+            !clients.isEmpty || !packetIDs.isEmpty || streamID != nil || !filters.isEmpty
+    }
+
+    func validate() throws {
+        guard (1...500).contains(limit) else {
+            throw ValidationError("--limit must be between 1 and 500.")
+        }
+        guard (0...100_000).contains(offset) else {
+            throw ValidationError("--offset must be between 0 and 100000.")
+        }
+        guard (1...100_000).contains(scanLimit) else {
+            throw ValidationError("--scan-limit must be between 1 and 100000.")
+        }
+        guard scanOffset >= 0 else {
+            throw ValidationError("--scan-offset cannot be negative.")
+        }
+        guard filters.count + addresses.count + ports.count + clients.count <= 20 else {
+            throw ValidationError("At most 20 advanced, address, port, and client filters are allowed.")
+        }
+        guard protocols.count <= 100, protocols.allSatisfy({ !$0.isEmpty && $0.utf8.count <= 256 }) else {
+            throw ValidationError("--protocol accepts at most 100 nonempty values of up to 256 UTF-8 bytes.")
+        }
+        guard domains.count <= 100, domains.allSatisfy({ !$0.isEmpty && $0.utf8.count <= 255 }) else {
+            throw ValidationError("--domain accepts at most 100 nonempty values of up to 255 UTF-8 bytes.")
+        }
+        guard addresses.allSatisfy({ !$0.isEmpty && $0.utf8.count <= 4_096 }) else {
+            throw ValidationError("--address values must contain between 1 and 4096 UTF-8 bytes.")
+        }
+        guard clients.allSatisfy({ !$0.isEmpty && $0.utf8.count <= 4_096 }) else {
+            throw ValidationError("--client values must contain between 1 and 4096 UTF-8 bytes.")
+        }
+        guard packetIDs.count <= 10_000 else {
+            throw ValidationError("--packet-id accepts at most 10000 values.")
+        }
+        for port in ports where !(0...65_535).contains(port) {
+            throw ValidationError("--port must be between 0 and 65535.")
+        }
+        for packetID in packetIDs where UInt64(packetID) == nil {
+            throw ValidationError("--packet-id must be an unsigned decimal integer.")
+        }
+        _ = try parsedAdvancedFilters()
+    }
+
+    func params(includesPagination: Bool = true) throws -> [String: TCPViewerCLIValue] {
+        try validate()
+        var result: [String: TCPViewerCLIValue] = [
+            "combination": .string(match.rawValue),
+            "order": .string(order.rawValue),
+            "scan_limit": .int(scanLimit),
+            "scan_offset": .int(scanOffset),
+        ]
+        if includesPagination {
+            result["limit"] = .int(limit)
+            result["offset"] = .int(offset)
+        }
+        if !protocols.isEmpty { result["protocols"] = .array(protocols.map(TCPViewerCLIValue.string)) }
+        if !domains.isEmpty { result["domains"] = .array(domains.map(TCPViewerCLIValue.string)) }
+        if !packetIDs.isEmpty { result["packet_ids"] = .array(packetIDs.map(TCPViewerCLIValue.string)) }
+        if let streamID { result["stream_id"] = .int(Int(streamID)) }
+
+        var parsedFilters = try parsedAdvancedFilters()
+        parsedFilters += addresses.map { filter(field: "address", operation: "contains", value: .string($0)) }
+        parsedFilters += ports.map { filter(field: "port", operation: "equals", value: .int($0)) }
+        parsedFilters += clients.map { filter(field: "client", operation: "contains", value: .string($0)) }
+        if !parsedFilters.isEmpty { result["filters"] = .array(parsedFilters) }
+        return result
+    }
+
+    private func parsedAdvancedFilters() throws -> [TCPViewerCLIValue] {
+        try filters.map { rawFilter in
+            let components = rawFilter.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+            guard components.count == 3 else {
+                throw ValidationError("--filter must use field:operator:value syntax.")
+            }
+            let field = String(components[0])
+            let operation = String(components[1])
+            let value = String(components[2])
+            guard Self.fields.contains(field) else {
+                throw ValidationError("Unsupported filter field: \(field).")
+            }
+            guard Self.operators.contains(operation) else {
+                throw ValidationError("Unsupported filter operator: \(operation).")
+            }
+            guard value.utf8.count <= 4_096 else {
+                throw ValidationError("A filter value cannot exceed 4096 UTF-8 bytes.")
+            }
+            return filter(field: field, operation: operation, value: scalar(value))
+        }
+    }
+
+    private func filter(field: String, operation: String, value: TCPViewerCLIValue) -> TCPViewerCLIValue {
+        .object([
+            "field": .string(field),
+            "operator": .string(operation),
+            "value": value,
+            "case_sensitive": .bool(caseSensitive),
+        ])
+    }
+
+    private func scalar(_ value: String) -> TCPViewerCLIValue {
+        if value == "true" { return .bool(true) }
+        if value == "false" { return .bool(false) }
+        if let integer = Int(value) { return .int(integer) }
+        if let double = Double(value), double.isFinite { return .double(double) }
+        return .string(value)
+    }
+
+    private static let fields: Set<String> = [
+        "packet_id", "packet_number", "protocol", "domain", "source_address",
+        "destination_address", "address", "source_port", "destination_port", "port",
+        "client", "bundle_id", "direction", "decode_status", "info", "interface",
+        "stream_id", "length", "tcp_flags", "truncated", "text",
+    ]
+
+    private static let operators: Set<String> = [
+        "equals", "not_equals", "contains", "not_contains", "starts_with", "ends_with",
+        "greater_than", "greater_than_or_equal", "less_than", "less_than_or_equal", "exists",
+    ]
+}

--- a/tcpviewer-cli/Commands/PacketStreamCommands.swift
+++ b/tcpviewer-cli/Commands/PacketStreamCommands.swift
@@ -1,0 +1,167 @@
+//
+//  PacketStreamCommands.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import ArgumentParser
+import Foundation
+
+struct PacketsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "packets",
+        abstract: "Query and inspect packets.",
+        subcommands: [
+            PacketsListCommand.self,
+            PacketsSummaryCommand.self,
+            PacketsDetailsCommand.self,
+            PacketsBytesCommand.self,
+            PacketsClearCommand.self,
+            PacketsRevealCommand.self,
+        ]
+    )
+}
+
+struct PacketsListCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List bounded matching packets.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @OptionGroup var query: TCPViewerCLIPacketQueryOptions
+    func validate() throws { try query.validate() }
+    func run() throws { try execute(.packetsList, params: query.params()) }
+}
+
+struct PacketsSummaryCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "summary", abstract: "Summarize bounded matching packets.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @OptionGroup var query: TCPViewerCLIPacketQueryOptions
+    func validate() throws { try query.validate() }
+    func run() throws { try execute(.packetsSummary, params: query.params(includesPagination: false)) }
+}
+
+struct PacketsDetailsCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "details", abstract: "Decode one packet's protocol tree.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Packet ID.") var packetID: String
+    @Option(name: .long) var maxDepth = 12
+    @Option(name: .long) var maxNodes = 5_000
+
+    func validate() throws {
+        guard UInt64(packetID) != nil else { throw ValidationError("packet-id must be an unsigned decimal integer.") }
+        guard (0...12).contains(maxDepth) else { throw ValidationError("--max-depth must be between 0 and 12.") }
+        guard (1...5_000).contains(maxNodes) else { throw ValidationError("--max-nodes must be between 1 and 5000.") }
+    }
+
+    func run() throws {
+        try execute(.packetsDetails, params: [
+            "packet_id": .string(packetID),
+            "max_depth": .int(maxDepth),
+            "max_nodes": .int(maxNodes),
+        ])
+    }
+}
+
+enum PacketBytesEncoding: String, ExpressibleByArgument {
+    case hex
+    case base64
+}
+
+struct PacketsBytesCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "bytes", abstract: "Read a bounded raw packet byte range.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Packet ID.") var packetID: String
+    @Option(name: .long) var offset = 0
+    @Option(name: .long) var length = 4_096
+    @Option(name: .long) var encoding: PacketBytesEncoding = .base64
+
+    func validate() throws {
+        guard UInt64(packetID) != nil else { throw ValidationError("packet-id must be an unsigned decimal integer.") }
+        guard offset >= 0 else { throw ValidationError("--offset cannot be negative.") }
+        guard (1...65_536).contains(length) else { throw ValidationError("--length must be between 1 and 65536.") }
+    }
+
+    func run() throws {
+        try execute(.packetsBytes, params: [
+            "packet_id": .string(packetID),
+            "offset": .int(offset),
+            "length": .int(length),
+            "encoding": .string(encoding.rawValue),
+        ])
+    }
+}
+
+struct PacketsClearCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "clear", abstract: "Remove every packet from the active window.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Flag(name: .long, help: "Confirm removal of all packets.") var yes = false
+    func validate() throws { if !yes { throw ValidationError("packets clear requires --yes.") } }
+    func run() throws { try execute(.packetsClear, params: ["confirm": .bool(true)]) }
+}
+
+struct PacketsRevealCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "reveal", abstract: "Reveal one packet in TCP Viewer.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Packet ID.") var packetID: String
+    func validate() throws { if UInt64(packetID) == nil { throw ValidationError("packet-id must be an unsigned decimal integer.") } }
+    func run() throws { try execute(.packetsReveal, params: ["packet_id": .string(packetID)]) }
+}
+
+struct StreamCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stream",
+        abstract: "Inspect TCP or UDP streams.",
+        subcommands: [StreamPacketsCommand.self, StreamFollowCommand.self]
+    )
+}
+
+struct StreamPacketsCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "packets", abstract: "List packets in one stream.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "TCP or UDP stream ID.") var streamID: UInt32
+    @OptionGroup var query: TCPViewerCLIPacketQueryOptions
+
+    func validate() throws { try query.validate() }
+    func run() throws {
+        var params = try query.params()
+        params["stream_id"] = .int(Int(streamID))
+        try execute(.streamPackets, params: params)
+    }
+}
+
+enum StreamFollowDirection: String, ExpressibleByArgument {
+    case both
+    case clientToServer = "client-to-server"
+    case serverToClient = "server-to-client"
+}
+
+enum StreamFollowEncoding: String, ExpressibleByArgument {
+    case text
+    case hex
+    case base64
+}
+
+struct StreamFollowCommand: ParsableCommand, TCPViewerCLIRequestCommand {
+    static let configuration = CommandConfiguration(commandName: "follow", abstract: "Reconstruct the TCP stream containing one packet.")
+    @OptionGroup var global: TCPViewerCLIGlobalOptions
+    @Argument(help: "Packet ID in the TCP stream.") var packetID: String
+    @Option(name: .long) var direction: StreamFollowDirection = .both
+    @Option(name: .long) var encoding: StreamFollowEncoding = .text
+    @Option(name: .customLong("max-bytes")) var maxBytes = 4 * 1_024 * 1_024
+    @Option(name: .customLong("max-records")) var maxRecords = 10_000
+
+    func validate() throws {
+        guard UInt64(packetID) != nil else { throw ValidationError("packet-id must be an unsigned decimal integer.") }
+        guard (1...(4 * 1_024 * 1_024)).contains(maxBytes) else { throw ValidationError("--max-bytes must be between 1 and 4194304.") }
+        guard (1...10_000).contains(maxRecords) else { throw ValidationError("--max-records must be between 1 and 10000.") }
+    }
+
+    func run() throws {
+        try execute(.streamFollow, params: [
+            "packet_id": .string(packetID),
+            "direction": .string(direction.rawValue),
+            "encoding": .string(encoding.rawValue),
+            "max_bytes": .int(maxBytes),
+            "max_records": .int(maxRecords),
+        ], defaultTimeout: 300)
+    }
+}

--- a/tcpviewer-cli/TCPViewerCLI.swift
+++ b/tcpviewer-cli/TCPViewerCLI.swift
@@ -1,0 +1,213 @@
+//
+//  TCPViewerCLI.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import ArgumentParser
+import Darwin
+import Foundation
+
+enum TCPViewerCLIOutputFormat: String, ExpressibleByArgument {
+    case json
+    case text
+}
+
+struct TCPViewerCLIGlobalOptions: ParsableArguments {
+    @Option(name: .long, help: "Output format.")
+    var output: TCPViewerCLIOutputFormat = .json
+
+    @Flag(name: .long, help: "Pretty-print JSON output.")
+    var pretty = false
+
+    @Option(name: .long, help: "Maximum seconds to wait for TCP Viewer.")
+    var timeout: Int?
+
+    func validate() throws {
+        if pretty && output == .text {
+            throw ValidationError("--pretty can only be used with --output json.")
+        }
+    }
+
+    func resolvedTimeout(default defaultValue: Int) throws -> TimeInterval {
+        let value = timeout ?? defaultValue
+        guard (1...3_600).contains(value) else {
+            throw ValidationError("--timeout must be between 1 and 3600 seconds.")
+        }
+        return TimeInterval(value)
+    }
+}
+
+struct TCPViewerCLI: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tcpviewer-cli",
+        abstract: "Control TCP Viewer from the command line.",
+        version: TCPViewerCLIVersion.current,
+        subcommands: [
+            AppCommand.self,
+            InterfacesCommand.self,
+            CaptureCommand.self,
+            PacketsCommand.self,
+            StreamCommand.self,
+            FileCommand.self,
+            LicenseCommand.self,
+            SettingsCommand.self,
+        ]
+    )
+
+    // Keep ArgumentParser's messages while using the CLI's documented exit-code contract.
+    static func main(_ arguments: [String]? = nil) {
+        do {
+            var command = try parseAsRoot(arguments)
+            try command.run()
+        } catch let exitCode as ExitCode {
+            Darwin.exit(exitCode.rawValue)
+        } catch {
+            let message = fullMessage(for: error)
+            let isCleanExit = !message.hasPrefix("Error:")
+            if !message.isEmpty {
+                let handle = isCleanExit ? FileHandle.standardOutput : FileHandle.standardError
+                handle.write(Data(message.utf8))
+                handle.write(Data("\n".utf8))
+            }
+            Darwin.exit(isCleanExit ? 0 : 2)
+        }
+    }
+
+    static func main() {
+        main(nil)
+    }
+}
+
+enum TCPViewerCLIVersion {
+    static var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.12.0"
+    }
+
+    static var build: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "36"
+    }
+
+    static var current: String {
+        return "\(version) (\(build))"
+    }
+}
+
+protocol TCPViewerCLIRequestCommand {
+    var global: TCPViewerCLIGlobalOptions { get }
+}
+
+extension TCPViewerCLIRequestCommand {
+    func execute(
+        _ command: TCPViewerCLICommand,
+        params: [String: TCPViewerCLIValue] = [:],
+        defaultTimeout: Int = 30,
+        launchIfNeeded: Bool = true
+    ) throws {
+        let timeout = try global.resolvedTimeout(default: defaultTimeout)
+        let runner = TCPViewerCLIEnvironment.current.runner
+        let response: TCPViewerCLIResponse
+        do {
+            response = try runner.run(
+                command: command,
+                params: params,
+                timeout: timeout,
+                launchIfNeeded: launchIfNeeded
+            )
+        } catch {
+            let requestFailure = error as? TCPViewerCLIRequestFailure
+            let failure = TCPViewerCLIResponse.failure(
+                requestID: requestFailure?.requestID ?? UUID().uuidString.lowercased(),
+                command: command,
+                code: TCPViewerCLIErrorCode.code(for: error),
+                message: error.localizedDescription
+            )
+            TCPViewerCLIOutput.write(failure, format: global.output, pretty: global.pretty, toStandardError: true)
+            throw ExitCode(3)
+        }
+
+        TCPViewerCLIOutput.write(response, format: global.output, pretty: global.pretty, toStandardError: !response.ok)
+        if !response.ok {
+            throw ExitCode(4)
+        }
+    }
+}
+
+enum TCPViewerCLIOutput {
+    static func write(
+        _ response: TCPViewerCLIResponse,
+        format: TCPViewerCLIOutputFormat,
+        pretty: Bool,
+        toStandardError: Bool
+    ) {
+        let data: Data
+        switch format {
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = pretty ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
+            data = (try? encoder.encode(response)) ?? Data()
+        case .text:
+            let text: String
+            if response.ok {
+                text = humanReadable(response.data ?? [:])
+            } else {
+                text = response.error?.message ?? "TCP Viewer command failed."
+            }
+            data = Data(text.utf8)
+        }
+
+        let handle = toStandardError ? FileHandle.standardError : FileHandle.standardOutput
+        handle.write(data)
+        handle.write(Data("\n".utf8))
+    }
+
+    private static func humanReadable(_ values: [String: TCPViewerCLIValue]) -> String {
+        values.keys.sorted().map { key in
+            "\(key): \(text(values[key] ?? .null))"
+        }.joined(separator: "\n")
+    }
+
+    private static func text(_ value: TCPViewerCLIValue) -> String {
+        switch value {
+        case .string(let value): return value
+        case .int(let value): return String(value)
+        case .double(let value): return String(value)
+        case .bool(let value): return value ? "true" : "false"
+        case .null: return "null"
+        case .array, .object:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            return (try? encoder.encode(value)).flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        }
+    }
+}
+
+enum TCPViewerCLIErrorCode {
+    static func code(for error: Error) -> String {
+        switch error {
+        case let failure as TCPViewerCLIRequestFailure:
+            return failure.code
+        case TCPViewerCLIClientError.appNotFound:
+            return "app_not_found"
+        case TCPViewerCLIClientError.launchFailed:
+            return "launch_failed"
+        case TCPViewerCLIClientError.timeout:
+            return "timeout"
+        case is TCPViewerCLIFileStoreError:
+            return "transport_error"
+        default:
+            return "transport_error"
+        }
+    }
+}
+
+final class TCPViewerCLIEnvironment {
+    static var current = TCPViewerCLIEnvironment()
+
+    let runner: TCPViewerCLIRequestRunning
+
+    init(runner: TCPViewerCLIRequestRunning = TCPViewerCLIClient()) {
+        self.runner = runner
+    }
+}

--- a/tcpviewer-cli/TCPViewerCLIClient.swift
+++ b/tcpviewer-cli/TCPViewerCLIClient.swift
@@ -1,0 +1,216 @@
+//
+//  TCPViewerCLIClient.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import AppKit
+import Foundation
+
+protocol TCPViewerCLIRequestRunning {
+    func run(
+        command: TCPViewerCLICommand,
+        params: [String: TCPViewerCLIValue],
+        timeout: TimeInterval,
+        launchIfNeeded: Bool
+    ) throws -> TCPViewerCLIResponse
+}
+
+enum TCPViewerCLIClientError: Error, LocalizedError {
+    case appNotFound
+    case launchFailed(String)
+    case timeout
+
+    var errorDescription: String? {
+        switch self {
+        case .appNotFound:
+            return "TCP Viewer.app could not be found."
+        case .launchFailed(let message):
+            return "TCP Viewer could not be launched: \(message)"
+        case .timeout:
+            return "TCP Viewer did not respond before the timeout."
+        }
+    }
+}
+
+struct TCPViewerCLIRequestFailure: Error, LocalizedError {
+    let requestID: String
+    let code: String
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+protocol TCPViewerCLIAppLaunching {
+    var isRunning: Bool { get }
+    func launchQuietly(completion: @escaping (Result<Void, Error>) -> Void) throws
+}
+
+final class TCPViewerCLIClient: TCPViewerCLIRequestRunning {
+    private let fileStore: TCPViewerCLIFileStore
+    private let notifications: any TCPViewerCLINotificationCentering
+    private let appLauncher: any TCPViewerCLIAppLaunching
+
+    init(
+        fileStore: TCPViewerCLIFileStore = TCPViewerCLIFileStore(),
+        notifications: any TCPViewerCLINotificationCentering = TCPViewerCLIDarwinNotificationCenter.shared,
+        appLauncher: any TCPViewerCLIAppLaunching = TCPViewerCLIWorkspaceLauncher()
+    ) {
+        self.fileStore = fileStore
+        self.notifications = notifications
+        self.appLauncher = appLauncher
+    }
+
+    func run(
+        command: TCPViewerCLICommand,
+        params: [String: TCPViewerCLIValue],
+        timeout: TimeInterval,
+        launchIfNeeded: Bool
+    ) throws -> TCPViewerCLIResponse {
+        let appWasRunning = appLauncher.isRunning
+        if command == .appStatus && !appWasRunning {
+            return .success(
+                requestID: UUID().uuidString.lowercased(),
+                command: command,
+                data: [
+                    "running": .bool(false),
+                    "app": .string("TCP Viewer"),
+                    "version": .string(TCPViewerCLIVersion.version),
+                    "build": .string(TCPViewerCLIVersion.build),
+                    "cli_version": .string(TCPViewerCLIVersion.version),
+                    "cli_build": .string(TCPViewerCLIVersion.build),
+                    "license_state": .string("unavailable_while_closed"),
+                    "active_document": .null,
+                    "capture_phase": .string("unavailable"),
+                    "packet_count": .int(0),
+                ]
+            )
+        }
+        guard appWasRunning || launchIfNeeded else {
+            throw TCPViewerCLIClientError.timeout
+        }
+
+        fileStore.cleanupOrphans()
+        let request = TCPViewerCLIRequest(
+            command: command,
+            params: params,
+            expiresAt: Date().addingTimeInterval(timeout)
+        )
+        let responseSignal = DispatchSemaphore(value: 0)
+        let observer = notifications.observe(TCPViewerCLINotificationName.response) {
+            responseSignal.signal()
+        }
+        defer { withExtendedLifetime(observer) {} }
+        do {
+            try fileStore.writeRequest(request)
+        } catch {
+            throw TCPViewerCLIRequestFailure(
+                requestID: request.requestID,
+                code: "transport_error",
+                message: error.localizedDescription
+            )
+        }
+
+        let launchError = LockedError()
+        if appWasRunning {
+            notifications.post(TCPViewerCLINotificationName.request)
+        } else {
+            do {
+                try appLauncher.launchQuietly { result in
+                    if case .failure(let error) = result {
+                        launchError.set(error)
+                        responseSignal.signal()
+                    }
+                }
+            } catch {
+                fileStore.removeRequest(requestID: request.requestID)
+                throw TCPViewerCLIRequestFailure(
+                    requestID: request.requestID,
+                    code: error is TCPViewerCLIClientError ? TCPViewerCLIErrorCode.code(for: error) : "launch_failed",
+                    message: error.localizedDescription
+                )
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let response = try? fileStore.readResponse(requestID: request.requestID) {
+                fileStore.removeResponse(requestID: request.requestID)
+                return response
+            }
+            if let error = launchError.value() {
+                fileStore.removeRequest(requestID: request.requestID)
+                throw TCPViewerCLIRequestFailure(
+                    requestID: request.requestID,
+                    code: "launch_failed",
+                    message: TCPViewerCLIClientError.launchFailed(error.localizedDescription).localizedDescription
+                )
+            }
+            let remaining = max(deadline.timeIntervalSinceNow, 0)
+            _ = responseSignal.wait(timeout: .now() + min(remaining, 0.1))
+        }
+
+        fileStore.removeRequest(requestID: request.requestID)
+        throw TCPViewerCLIRequestFailure(
+            requestID: request.requestID,
+            code: "timeout",
+            message: TCPViewerCLIClientError.timeout.localizedDescription
+        )
+    }
+}
+
+private final class LockedError {
+    private let lock = NSLock()
+    private var storedError: Error?
+
+    func set(_ error: Error) {
+        lock.lock()
+        storedError = error
+        lock.unlock()
+    }
+
+    func value() -> Error? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedError
+    }
+}
+
+final class TCPViewerCLIWorkspaceLauncher: TCPViewerCLIAppLaunching {
+    private static let bundleIdentifier = "com.proxyman.tcpviewer"
+
+    var isRunning: Bool {
+        !NSRunningApplication.runningApplications(withBundleIdentifier: Self.bundleIdentifier).isEmpty
+    }
+
+    func launchQuietly(completion: @escaping (Result<Void, Error>) -> Void) throws {
+        guard let appURL = installedApplicationURL() else {
+            throw TCPViewerCLIClientError.appNotFound
+        }
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = false
+        configuration.addsToRecentItems = false
+        configuration.createsNewApplicationInstance = false
+        NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
+            if let error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+
+    private func installedApplicationURL() -> URL? {
+        let executableURL = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
+        let candidate = executableURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        if candidate.pathExtension == "app",
+           Bundle(url: candidate)?.bundleIdentifier == Self.bundleIdentifier {
+            return candidate
+        }
+        return NSWorkspace.shared.urlForApplication(withBundleIdentifier: Self.bundleIdentifier)
+    }
+}

--- a/tcpviewer-cli/main.swift
+++ b/tcpviewer-cli/main.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import ArgumentParser
 
 print("Hello, World!")
 

--- a/tcpviewer-cli/main.swift
+++ b/tcpviewer-cli/main.swift
@@ -1,12 +1,10 @@
 //
 //  main.swift
-//  tcpviewer-cli
+//  TCPViewer
 //
-//  Created by Nghia Tran on 30/8/26.
+//  Created by Proxyman LLC on 30/8/26.
 //
 
-import Foundation
 import ArgumentParser
 
-print("Hello, World!")
-
+TCPViewerCLI.main()

--- a/tcpviewer-cli/main.swift
+++ b/tcpviewer-cli/main.swift
@@ -1,0 +1,11 @@
+//
+//  main.swift
+//  tcpviewer-cli
+//
+//  Created by Nghia Tran on 30/8/26.
+//
+
+import Foundation
+
+print("Hello, World!")
+

--- a/tests/release-lib.test.mjs
+++ b/tests/release-lib.test.mjs
@@ -200,6 +200,7 @@ test("updates only Homebrew Cask release metadata", () => {
     "  depends_on arch: :arm64",
     "",
     '  app "TCP Viewer.app"',
+    '  binary "#{appdir}/TCP Viewer.app/Contents/MacOS/tcpviewer-cli"',
     "end",
     ""
   ].join("\n");
@@ -212,6 +213,7 @@ test("updates only Homebrew Cask release metadata", () => {
   assert.deepEqual(parseHomebrewCaskVersion(updated), { version: "1.10.0", buildNumber: "31" });
   assert.match(updated, new RegExp(`sha256 "${"b".repeat(64)}"`));
   assert.match(updated, /app "TCP Viewer\.app"/);
+  assert.match(updated, /binary "#\{appdir\}\/TCP Viewer\.app\/Contents\/MacOS\/tcpviewer-cli"/);
   assert.match(updated, /depends_on arch: :arm64/);
   assert.equal(homebrewCaskToken, "tcp-viewer");
   assert.equal(makeHomebrewCaskBranchName({ version: "1.10.0", buildNumber: "31" }), "tcpviewer-1.10.0-31");
@@ -231,6 +233,10 @@ test("updates only Homebrew Cask release metadata", () => {
     () => validateHomebrewCaskContent(cask.replace('cask "tcp-viewer"', 'cask "tcpviewer"')),
     /tcp-viewer token/
   );
+  assert.throws(
+    () => validateHomebrewCaskContent(cask.replace(/  binary .*\n/, "")),
+    /bundled tcpviewer-cli/
+  );
 });
 
 test("ships an initial Homebrew Cask template for the ARM64 release", () => {
@@ -242,6 +248,7 @@ test("ships an initial Homebrew Cask template for the ARM64 release", () => {
   assert.match(content, /homepage "https:\/\/tcpviewer\.proxyman\.com\/"/);
   assert.match(content, /strategy :sparkle/);
   assert.match(content, /uninstall launchctl: "com\.proxyman\.tcpviewer\.helpertool"/);
+  assert.match(content, /binary "#\{appdir\}\/TCP Viewer\.app\/Contents\/MacOS\/tcpviewer-cli"/);
   assert.doesNotMatch(content, /verified:/);
   assert.match(documentation, /brew tap --force homebrew\/cask/);
   assert.match(documentation, /--homebrew-install-tested/);


### PR DESCRIPTION
## Summary

- Add tcpviewer-cli commands for app status, interfaces, capture control, packet queries, TCP streams, file import and export, licenses, and settings.
- Add a schema-versioned JSON bridge using Application Support request files and Darwin notifications for both closed-app and running-app workflows.
- Bundle and sign the CLI inside TCP Viewer.app, expose it through the Homebrew cask, and document the automation contract.
- Reuse the existing app-side packet query and control services while keeping the MCP PRO gate unchanged.

## Testing

- xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' (641 passed, 0 failed, 0 skipped)
- xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build
- npm test (21 passed)
- Process smoke tests for help, version, closed-app status, invalid arguments, and quiet app launch
- git diff --check
- Secret and generated-artifact scan

## Notes

This pull request was substantially AI-assisted. The diff and verification results were reviewed during implementation.
