### PR TITLE
Fix tcpviewer-cli review findings

### DIFF
--- a/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
@@ -308,8 +308,9 @@ final class WiresharkEpanSession {
                 TCPViewerWiresharkSessionCancelFollowTCPStream(handle)
             }
         }
+        let direction = wiresharkFollowDirection(limits.includedDirection)
         try withContext(for: selectedRecord) { context in
-            guard TCPViewerWiresharkSessionBeginFollowTCPStream(handle, context) else {
+            guard TCPViewerWiresharkSessionBeginFollowTCPStream(handle, context, direction) else {
                 if let criticalError = criticalExceptionErrorIfNeeded() {
                     throw criticalError
                 }
@@ -326,7 +327,8 @@ final class WiresharkEpanSession {
                 TCPViewerWiresharkSessionProcessFollowPacket(
                     handle,
                     context,
-                    limits.maximumPayloadBytes
+                    limits.maximumPayloadBytes,
+                    direction
                 )
             }
             if status == TCPViewerWiresharkFollowPacketFailed {
@@ -348,7 +350,8 @@ final class WiresharkEpanSession {
         guard let resultPointer = TCPViewerWiresharkSessionFinishFollowTCPStream(
             handle,
             limits.maximumPayloadBytes,
-            limits.maximumRecordCount
+            limits.maximumRecordCount,
+            direction
         ) else {
             throw unavailableError("Wireshark returned no TCP stream result.")
         }
@@ -376,6 +379,19 @@ final class WiresharkEpanSession {
             serverByteCount: Int(clamping: result.serverByteCount),
             isTruncated: result.isTruncated
         )
+    }
+
+    private func wiresharkFollowDirection(
+        _ direction: TCPFollowDirection?
+    ) -> TCPViewerWiresharkFollowDirection {
+        switch direction {
+        case .clientToServer:
+            return TCPViewerWiresharkFollowClientToServer
+        case .serverToClient:
+            return TCPViewerWiresharkFollowServerToClient
+        case nil:
+            return TCPViewerWiresharkFollowBothDirections
+        }
     }
 
     private static func validateFollowRequest(

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
@@ -1165,6 +1165,7 @@ private:
 struct TCPViewerWiresharkSession {
     struct TCPFollowTapContext {
         TCPViewerWiresharkSession *session = nullptr;
+        TCPViewerWiresharkFollowDirection direction = TCPViewerWiresharkFollowBothDirections;
     };
 
     mutable std::mutex mutex;
@@ -1254,13 +1255,15 @@ struct TCPViewerWiresharkSession {
             || session->followInfo == nullptr || session->tcpFollower == nullptr) {
             return TAP_PACKET_DONT_REDRAW;
         }
-        return get_follow_tap_handler(session->tcpFollower)(
+        const auto status = get_follow_tap_handler(session->tcpFollower)(
             session->followInfo,
             packetInfo,
             dissect,
             data,
             flags
         );
+        session->discardExcludedNewestFollowPayloadLocked(context->direction);
+        return status;
     }
 
     void recordTCPStreamFrameLocked(uint32_t frameNumber, uint32_t streamNumber)
@@ -1672,7 +1675,10 @@ struct TCPViewerWiresharkSession {
         followNewestPayloadItem = nullptr;
     }
 
-    bool beginTCPFollowLocked(const PacketContextView &selectedContext)
+    bool beginTCPFollowLocked(
+        const PacketContextView &selectedContext,
+        TCPViewerWiresharkFollowDirection direction
+    )
     {
         cancelFollowLocked();
         if (!hasSession() || activeSession() != this) {
@@ -1786,6 +1792,7 @@ struct TCPViewerWiresharkSession {
             return false;
         }
         followTapContext->session = this;
+        followTapContext->direction = direction;
         GString *registrationError = register_tap_listener(
             get_follow_tap_string(tcpFollower),
             followTapContext,
@@ -1823,7 +1830,8 @@ struct TCPViewerWiresharkSession {
 
     TCPViewerWiresharkFollowPacketStatus processFollowPacketLocked(
         const PacketContextView &context,
-        size_t maximumPayloadBytes
+        size_t maximumPayloadBytes,
+        TCPViewerWiresharkFollowDirection direction
     ) {
         if (!followTapRegistered || followInfo == nullptr || activeFollowSession() != this) {
             unavailableReason = "The TCP stream reassembly is not active.";
@@ -1895,7 +1903,7 @@ struct TCPViewerWiresharkSession {
         // Wireshark does not add released out-of-order fragments to bytes_written, so count new payload records directly.
         for (GList *item = followInfo->payload; item != followNewestPayloadItem; item = g_list_next(item)) {
             auto *record = static_cast<follow_record_t *>(item->data);
-            if (record != nullptr && record->data != nullptr) {
+            if (record != nullptr && record->data != nullptr && includesFollowRecord(record, direction)) {
                 followPayloadByteCount += record->data->len;
             }
         }
@@ -1909,7 +1917,8 @@ struct TCPViewerWiresharkSession {
 
     TCPViewerWiresharkFollowResult *finishTCPFollowLocked(
         size_t maximumPayloadBytes,
-        size_t maximumRecordCount
+        size_t maximumRecordCount,
+        TCPViewerWiresharkFollowDirection direction
     )
     {
         auto *result = static_cast<TCPViewerWiresharkFollowResult *>(std::calloc(1, sizeof(TCPViewerWiresharkFollowResult)));
@@ -1964,7 +1973,14 @@ struct TCPViewerWiresharkSession {
             }
         }
 
-        const size_t availableRecordCount = static_cast<size_t>(g_list_length(followInfo->payload));
+        size_t availableRecordCount = 0;
+        for (GList *item = followInfo->payload; item != nullptr; item = g_list_next(item)) {
+            auto *record = static_cast<follow_record_t *>(item->data);
+            if (record != nullptr && record->data != nullptr && record->data->len > 0
+                && includesFollowRecord(record, direction)) {
+                availableRecordCount += 1;
+            }
+        }
         const size_t allocatedRecordCount = std::min(availableRecordCount, maximumRecordCount);
         result->recordCount = allocatedRecordCount;
         result->isTruncated = followTruncated
@@ -1988,7 +2004,8 @@ struct TCPViewerWiresharkSession {
              item != nullptr && outputIndex < allocatedRecordCount && remainingPayloadBytes > 0;
              item = g_list_previous(item)) {
             auto *source = static_cast<follow_record_t *>(item->data);
-            if (source == nullptr || source->data == nullptr || source->data->len == 0) {
+            if (source == nullptr || source->data == nullptr || source->data->len == 0
+                || !includesFollowRecord(source, direction)) {
                 continue;
             }
             auto &destination = result->records[outputIndex];
@@ -2029,6 +2046,42 @@ struct TCPViewerWiresharkSession {
         followPayloadByteCount = 0;
         followNewestPayloadItem = nullptr;
         return result;
+    }
+
+    static bool includesFollowRecord(
+        const follow_record_t *record,
+        TCPViewerWiresharkFollowDirection direction
+    ) {
+        switch (direction) {
+            case TCPViewerWiresharkFollowClientToServer:
+                return !record->is_server;
+            case TCPViewerWiresharkFollowServerToClient:
+                return record->is_server;
+            case TCPViewerWiresharkFollowBothDirections:
+            default:
+                return true;
+        }
+    }
+
+    // Remove completed payload from the unrequested side before it can consume the follow budget.
+    void discardExcludedNewestFollowPayloadLocked(TCPViewerWiresharkFollowDirection direction)
+    {
+        if (direction == TCPViewerWiresharkFollowBothDirections || followInfo == nullptr) {
+            return;
+        }
+
+        for (GList *item = followInfo->payload; item != followNewestPayloadItem;) {
+            GList *next = g_list_next(item);
+            auto *record = static_cast<follow_record_t *>(item->data);
+            if (record != nullptr && !includesFollowRecord(record, direction)) {
+                if (record->data != nullptr) {
+                    g_byte_array_free(record->data, true);
+                }
+                g_free(record);
+                followInfo->payload = g_list_delete_link(followInfo->payload, item);
+            }
+            item = next;
+        }
     }
 
     WiresharkDissectionResult runSecondPassLocked(const PacketContextView &context, bool buildTree)
@@ -2423,7 +2476,11 @@ TCPViewerWiresharkInspectionResult *TCPViewerWiresharkSessionInspectPacket(TCPVi
     return result;
 }
 
-bool TCPViewerWiresharkSessionBeginFollowTCPStream(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *selectedContext)
+bool TCPViewerWiresharkSessionBeginFollowTCPStream(
+    TCPViewerWiresharkSession *session,
+    const TCPViewerWiresharkPacketContext *selectedContext,
+    TCPViewerWiresharkFollowDirection direction
+)
 {
     if (session == nullptr || selectedContext == nullptr) {
         return false;
@@ -2431,26 +2488,28 @@ bool TCPViewerWiresharkSessionBeginFollowTCPStream(TCPViewerWiresharkSession *se
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
     session->clearCriticalExceptionsLocked();
-    return session->beginTCPFollowLocked(ContextViewFromC(selectedContext));
+    return session->beginTCPFollowLocked(ContextViewFromC(selectedContext), direction);
 }
 
 TCPViewerWiresharkFollowPacketStatus TCPViewerWiresharkSessionProcessFollowPacket(
     TCPViewerWiresharkSession *session,
     const TCPViewerWiresharkPacketContext *context,
-    size_t maximumPayloadBytes
+    size_t maximumPayloadBytes,
+    TCPViewerWiresharkFollowDirection direction
 ) {
     if (session == nullptr || context == nullptr || maximumPayloadBytes == 0) {
         return TCPViewerWiresharkFollowPacketFailed;
     }
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
-    return session->processFollowPacketLocked(ContextViewFromC(context), maximumPayloadBytes);
+    return session->processFollowPacketLocked(ContextViewFromC(context), maximumPayloadBytes, direction);
 }
 
 TCPViewerWiresharkFollowResult *TCPViewerWiresharkSessionFinishFollowTCPStream(
     TCPViewerWiresharkSession *session,
     size_t maximumPayloadBytes,
-    size_t maximumRecordCount
+    size_t maximumRecordCount,
+    TCPViewerWiresharkFollowDirection direction
 ) {
     if (session == nullptr || maximumPayloadBytes == 0 || maximumRecordCount == 0) {
         auto *result = static_cast<TCPViewerWiresharkFollowResult *>(std::calloc(1, sizeof(TCPViewerWiresharkFollowResult)));
@@ -2461,7 +2520,7 @@ TCPViewerWiresharkFollowResult *TCPViewerWiresharkSessionFinishFollowTCPStream(
     }
     std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
     std::lock_guard<std::mutex> sessionLock(session->mutex);
-    return session->finishTCPFollowLocked(maximumPayloadBytes, maximumRecordCount);
+    return session->finishTCPFollowLocked(maximumPayloadBytes, maximumRecordCount, direction);
 }
 
 void TCPViewerWiresharkSessionCancelFollowTCPStream(TCPViewerWiresharkSession *session)

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
@@ -120,6 +120,12 @@ typedef enum TCPViewerWiresharkFollowPacketStatus {
     TCPViewerWiresharkFollowPacketLimitReached = 1,
 } TCPViewerWiresharkFollowPacketStatus;
 
+typedef enum TCPViewerWiresharkFollowDirection {
+    TCPViewerWiresharkFollowBothDirections = 0,
+    TCPViewerWiresharkFollowClientToServer = 1,
+    TCPViewerWiresharkFollowServerToClient = 2,
+} TCPViewerWiresharkFollowDirection;
+
 typedef struct TCPViewerWiresharkExceptionReport {
     bool isCriticalException;
     unsigned long exceptionGroup;
@@ -157,16 +163,22 @@ bool TCPViewerWiresharkSessionTCPStreamIdentifier(
 );
 TCPViewerWiresharkSummaryResult *TCPViewerWiresharkSessionSummarizePacket(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *context);
 TCPViewerWiresharkInspectionResult *TCPViewerWiresharkSessionInspectPacket(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *context);
-bool TCPViewerWiresharkSessionBeginFollowTCPStream(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *selectedContext);
+bool TCPViewerWiresharkSessionBeginFollowTCPStream(
+    TCPViewerWiresharkSession *session,
+    const TCPViewerWiresharkPacketContext *selectedContext,
+    TCPViewerWiresharkFollowDirection direction
+);
 TCPViewerWiresharkFollowPacketStatus TCPViewerWiresharkSessionProcessFollowPacket(
     TCPViewerWiresharkSession *session,
     const TCPViewerWiresharkPacketContext *context,
-    size_t maximumPayloadBytes
+    size_t maximumPayloadBytes,
+    TCPViewerWiresharkFollowDirection direction
 );
 TCPViewerWiresharkFollowResult *TCPViewerWiresharkSessionFinishFollowTCPStream(
     TCPViewerWiresharkSession *session,
     size_t maximumPayloadBytes,
-    size_t maximumRecordCount
+    size_t maximumRecordCount,
+    TCPViewerWiresharkFollowDirection direction
 );
 void TCPViewerWiresharkSessionCancelFollowTCPStream(TCPViewerWiresharkSession *session);
 TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyLastCriticalException(TCPViewerWiresharkSession *session);

--- a/PcapPlusPlusCore/Models/TCPFollowStream.swift
+++ b/PcapPlusPlusCore/Models/TCPFollowStream.swift
@@ -69,15 +69,18 @@ public struct TCPFollowLimits: Sendable, Equatable, Hashable {
     public let maximumCandidatePacketCount: Int
     public let maximumPayloadBytes: Int
     public let maximumRecordCount: Int
+    public let includedDirection: TCPFollowDirection?
 
     public init(
         maximumCandidatePacketCount: Int = 250_000,
         maximumPayloadBytes: Int = 64 * 1_024 * 1_024,
-        maximumRecordCount: Int = 100_000
+        maximumRecordCount: Int = 100_000,
+        includedDirection: TCPFollowDirection? = nil
     ) {
         self.maximumCandidatePacketCount = max(maximumCandidatePacketCount, 1)
         self.maximumPayloadBytes = max(maximumPayloadBytes, 1)
         self.maximumRecordCount = max(maximumRecordCount, 1)
+        self.includedDirection = includedDirection
     }
 
     public static let `default` = TCPFollowLimits()

--- a/PcapPlusPlusCoreTests/Dissection/WiresharkTCPFollowTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/WiresharkTCPFollowTests.swift
@@ -73,6 +73,28 @@ struct WiresharkTCPFollowTests {
         #expect(!result.isTruncated)
     }
 
+    @Test func unrequestedDirectionDoesNotConsumeFollowLimits() throws {
+        let records = makeConversation()
+        let result = try followTCPStream(
+            containing: records[3],
+            records: records,
+            limits: TCPFollowLimits(
+                maximumCandidatePacketCount: records.count,
+                maximumPayloadBytes: 5,
+                maximumRecordCount: 1,
+                includedDirection: .serverToClient
+            ),
+            progress: nil,
+            shouldCancel: nil
+        )
+
+        #expect(payload(in: result, direction: .serverToClient) == Data("reply".utf8))
+        #expect(result.records.allSatisfy { $0.direction == .serverToClient })
+        #expect(result.clientByteCount == 0)
+        #expect(result.serverByteCount == 5)
+        #expect(!result.isTruncated)
+    }
+
     @Test func candidateIndexSeparatesReusedEndpointTupleConnections() throws {
         let firstConnection = makeConversation()
         let firstReset = makeTCPPacket(

--- a/TCPViewer/App/AppDelegate.swift
+++ b/TCPViewer/App/AppDelegate.swift
@@ -167,9 +167,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         presentsErrors: Bool = true,
         completion: ((Bool) -> Void)? = nil
     ) {
+        importCaptureURLsWithResult(
+            urls,
+            focusesWindow: focusesWindow,
+            presentsErrors: presentsErrors
+        ) { result in
+            completion?(result.error == nil)
+        }
+    }
+
+    private func importCaptureURLsWithResult(
+        _ urls: [URL],
+        focusesWindow: Bool,
+        presentsErrors: Bool,
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
+    ) {
         let supportedURLs = urls.filter(TCPViewerCaptureFileImportPolicy.isSupportedCaptureFileURL)
         guard !supportedURLs.isEmpty else {
-            completion?(false)
+            completion(TCPViewerCaptureImportResult(
+                importedURLs: [],
+                error: TCPViewerCoreError(
+                    code: .offlineFileOpenFailed,
+                    message: "No supported capture files were selected."
+                )
+            ))
             return
         }
 
@@ -178,7 +199,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if presentsErrors {
                 presentInvalidSessionOpenSelectionAlert()
             }
-            completion?(false)
+            completion(TCPViewerCaptureImportResult(
+                importedURLs: [],
+                error: TCPViewerCoreError(
+                    code: .offlineFileOpenFailed,
+                    message: "Open one TCPViewer session at a time. Sessions cannot be merged with other capture files."
+                )
+            ))
             return
         }
 
@@ -187,14 +214,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if focusesWindow {
                 focusWindowController(windowController)
             }
-            windowController.rootViewController.importDocuments(at: supportedURLs) {
-                completion?(true)
-            }
+            windowController.rootViewController.importDocumentsWithResult(at: supportedURLs, completion: completion)
         } catch {
             if presentsErrors {
                 NSDocumentController.shared.presentError(error)
             }
-            completion?(false)
+            completion(TCPViewerCaptureImportResult(importedURLs: [], error: error))
         }
     }
 
@@ -203,8 +228,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         try frontmostOrNewTCPViewerWindowController().rootViewController.viewModel
     }
 
-    func cliImportCaptureURLs(_ urls: [URL], completion: @escaping (Bool) -> Void) {
-        importCaptureURLs(urls, focusesWindow: false, presentsErrors: false, completion: completion)
+    func cliImportCaptureURLs(_ urls: [URL], completion: @escaping (TCPViewerCaptureImportResult) -> Void) {
+        importCaptureURLsWithResult(urls, focusesWindow: false, presentsErrors: false, completion: completion)
     }
 
     func cliRefreshSettings() {

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -926,6 +926,11 @@ enum TCPViewerCaptureFileImportPolicy {
     }
 }
 
+struct TCPViewerCaptureImportResult {
+    let importedURLs: [URL]
+    let error: Error?
+}
+
 private extension PacketInspection {
     func tcpviewerRemapping(packetID: PacketSummary.ID) -> PacketInspection {
         PacketInspection(
@@ -1652,10 +1657,25 @@ final class TCPViewerWorkspaceController {
     }
 
     private func openSessionDocument(at fileURL: URL, completion: (() -> Void)? = nil) {
+        openSessionDocumentWithResult(at: fileURL) { _ in
+            completion?()
+        }
+    }
+
+    private func openSessionDocumentWithResult(
+        at fileURL: URL,
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
+    ) {
         stopLiveCaptureIfNeeded { [weak self] stopResult in
             DispatchQueue.main.async {
                 guard let self else {
-                    completion?()
+                    completion(TCPViewerCaptureImportResult(
+                        importedURLs: [],
+                        error: TCPViewerCoreError(
+                            code: .offlineFileOpenFailed,
+                            message: "TCP Viewer closed before the session import completed."
+                        )
+                    ))
                     return
                 }
 
@@ -1664,11 +1684,33 @@ final class TCPViewerWorkspaceController {
                     self.snapshot.sessionState.phase = .failed
                     self.snapshot.sessionState.lastError = tcpviewerError
                     self.snapshot.sessionState.statusMessage = tcpviewerError.message
-                    completion?()
+                    completion(TCPViewerCaptureImportResult(importedURLs: [], error: tcpviewerError))
                     return
                 }
 
-                self.beginSessionImport(at: fileURL, completion: completion)
+                self.beginSessionImport(at: fileURL) { [weak self] in
+                    guard let self else {
+                        completion(TCPViewerCaptureImportResult(
+                            importedURLs: [],
+                            error: TCPViewerCoreError(
+                                code: .offlineFileOpenFailed,
+                                message: "TCP Viewer closed before the session import completed."
+                            )
+                        ))
+                        return
+                    }
+                    let error = self.lastSessionImportSucceeded
+                        ? nil
+                        : self.snapshot.sessionImportState.lastError
+                            ?? TCPViewerCoreError(
+                                code: .offlineFileOpenFailed,
+                                message: "TCP Viewer could not import \(fileURL.lastPathComponent)."
+                            )
+                    completion(TCPViewerCaptureImportResult(
+                        importedURLs: self.lastSessionImportSucceeded ? [fileURL] : [],
+                        error: error
+                    ))
+                }
             }
         }
     }
@@ -1837,9 +1879,27 @@ final class TCPViewerWorkspaceController {
     }
 
     func openDocuments(at fileURLs: [URL], replacingCurrent: Bool, completion: (() -> Void)? = nil) {
+        openDocumentsWithResult(at: fileURLs, replacingCurrent: replacingCurrent) { _ in
+            completion?()
+        }
+    }
+
+    func importDocumentsWithResult(
+        at fileURLs: [URL],
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
+    ) {
+        openDocumentsWithResult(at: fileURLs, replacingCurrent: false, completion: completion)
+    }
+
+    // Report the files that actually opened because batch imports may partially fail or skip duplicates.
+    private func openDocumentsWithResult(
+        at fileURLs: [URL],
+        replacingCurrent: Bool,
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
+    ) {
         let requestedURLs = uniqueSupportedCaptureURLs(fileURLs)
         guard !requestedURLs.isEmpty else {
-            completion?()
+            completion(TCPViewerCaptureImportResult(importedURLs: [], error: nil))
             return
         }
 
@@ -1852,11 +1912,11 @@ final class TCPViewerWorkspaceController {
                 )
                 snapshot.documentState.lastError = error
                 snapshot.documentState.statusMessage = error.message
-                completion?()
+                completion(TCPViewerCaptureImportResult(importedURLs: [], error: error))
                 return
             }
 
-            openSessionDocument(at: sessionURL, completion: completion)
+            openSessionDocumentWithResult(at: sessionURL, completion: completion)
             return
         }
 
@@ -1864,7 +1924,13 @@ final class TCPViewerWorkspaceController {
         stopLiveCaptureIfNeeded { [weak self] stopResult in
             DispatchQueue.main.async {
                 guard let self else {
-                    completion?()
+                    completion(TCPViewerCaptureImportResult(
+                        importedURLs: [],
+                        error: TCPViewerCoreError(
+                            code: .offlineFileOpenFailed,
+                            message: "TCP Viewer closed before the capture import completed."
+                        )
+                    ))
                     return
                 }
 
@@ -1873,7 +1939,7 @@ final class TCPViewerWorkspaceController {
                     self.snapshot.sessionState.phase = .failed
                     self.snapshot.sessionState.lastError = tcpviewerError
                     self.snapshot.sessionState.statusMessage = tcpviewerError.message
-                    completion?()
+                    completion(TCPViewerCaptureImportResult(importedURLs: [], error: tcpviewerError))
                     return
                 }
 
@@ -1910,14 +1976,14 @@ final class TCPViewerWorkspaceController {
                 let urlsToImport = self.urlsToImport(requestedURLs, replacingCurrent: replacingCurrent)
                 guard !urlsToImport.isEmpty else {
                     self.finishDocumentImports(importedCount: 0, skippedDuplicateCount: requestedURLs.count)
-                    completion?()
+                    completion(TCPViewerCaptureImportResult(importedURLs: [], error: nil))
                     return
                 }
 
                 self.importDocumentsSequentially(
                     urlsToImport,
                     index: 0,
-                    importedCount: 0,
+                    importedURLs: [],
                     skippedDuplicateCount: requestedURLs.count - urlsToImport.count,
                     completion: completion
                 )
@@ -3504,20 +3570,20 @@ final class TCPViewerWorkspaceController {
     private func importDocumentsSequentially(
         _ urls: [URL],
         index: Int,
-        importedCount: Int,
+        importedURLs: [URL],
         skippedDuplicateCount: Int,
         failureCount: Int = 0,
         firstError: TCPViewerCoreError? = nil,
-        completion: (() -> Void)?
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
     ) {
         guard index < urls.count else {
             finishDocumentImports(
-                importedCount: importedCount,
+                importedCount: importedURLs.count,
                 skippedDuplicateCount: skippedDuplicateCount,
                 failureCount: failureCount,
                 firstError: firstError
             )
-            completion?()
+            completion(TCPViewerCaptureImportResult(importedURLs: importedURLs, error: firstError))
             return
         }
 
@@ -3533,7 +3599,13 @@ final class TCPViewerWorkspaceController {
         services.core.openOfflineCaptureDocument(at: url) { [weak self] result in
             DispatchQueue.main.async {
                 guard let self else {
-                    completion?()
+                    completion(TCPViewerCaptureImportResult(
+                        importedURLs: importedURLs,
+                        error: firstError ?? TCPViewerCoreError(
+                            code: .offlineFileOpenFailed,
+                            message: "TCP Viewer closed before the capture import completed."
+                        )
+                    ))
                     return
                 }
 
@@ -3542,7 +3614,13 @@ final class TCPViewerWorkspaceController {
                     document.open { [weak self] openResult in
                         DispatchQueue.main.async {
                             guard let self else {
-                                completion?()
+                                completion(TCPViewerCaptureImportResult(
+                                    importedURLs: importedURLs,
+                                    error: firstError ?? TCPViewerCoreError(
+                                        code: .offlineFileOpenFailed,
+                                        message: "TCP Viewer closed before the capture import completed."
+                                    )
+                                ))
                                 return
                             }
 
@@ -3552,7 +3630,7 @@ final class TCPViewerWorkspaceController {
                                 self.importDocumentsSequentially(
                                     urls,
                                     index: index + 1,
-                                    importedCount: importedCount + 1,
+                                    importedURLs: importedURLs + [url],
                                     skippedDuplicateCount: skippedDuplicateCount,
                                     failureCount: failureCount,
                                     firstError: firstError,
@@ -3563,7 +3641,7 @@ final class TCPViewerWorkspaceController {
                                 self.importDocumentsSequentially(
                                     urls,
                                     index: index + 1,
-                                    importedCount: importedCount,
+                                    importedURLs: importedURLs,
                                     skippedDuplicateCount: skippedDuplicateCount,
                                     failureCount: failureCount + 1,
                                     firstError: firstError ?? tcpviewerError,
@@ -3577,7 +3655,7 @@ final class TCPViewerWorkspaceController {
                     self.importDocumentsSequentially(
                         urls,
                         index: index + 1,
-                        importedCount: importedCount,
+                        importedURLs: importedURLs,
                         skippedDuplicateCount: skippedDuplicateCount,
                         failureCount: failureCount + 1,
                         firstError: firstError ?? tcpviewerError,

--- a/TCPViewer/Features/CLI/TCPViewerCLICommandRouter.swift
+++ b/TCPViewer/Features/CLI/TCPViewerCLICommandRouter.swift
@@ -155,17 +155,18 @@ final class TCPViewerCLICommandRouter: TCPViewerCLICommandRouting {
             guard sessionCount == 0 || (sessionCount == 1 && urls.count == 1) else {
                 throw CLIError(code: "invalid_parameter", message: "A tcpviewsession must be imported by itself.")
             }
-            appDelegate.cliImportCaptureURLs(urls) { succeeded in
-                guard succeeded else {
-                    completion(self.failure(request, code: "import_failed", message: "TCP Viewer could not import the selected file."))
-                    return
-                }
+            appDelegate.cliImportCaptureURLs(urls) { result in
                 let packetCount = (try? appDelegate.cliWorkspaceViewModel().mcpWorkspaceSnapshot().totalPacketCount) ?? 0
-                completion(self.success(request, data: [
-                    "imported_files": .array(urls.map { .string($0.path) }),
-                    "imported_file_count": .int(urls.count),
+                let data: [String: TCPViewerCLIValue] = [
+                    "imported_files": .array(result.importedURLs.map { .string($0.path) }),
+                    "imported_file_count": .int(result.importedURLs.count),
                     "packet_count": .int(packetCount),
-                ]))
+                ]
+                if let error = result.error {
+                    completion(self.failure(request, code: "import_failed", error: error, data: data))
+                } else {
+                    completion(self.success(request, data: data))
+                }
             }
         } catch let error as CLIError {
             completion(failure(request, code: error.code, message: error.message))
@@ -225,11 +226,17 @@ final class TCPViewerCLICommandRouter: TCPViewerCLICommandRouting {
             guard ["text", "hex", "base64"].contains(encoding) else {
                 throw CLIError(code: "invalid_parameter", message: "encoding is invalid.")
             }
+            let includedDirection: TCPFollowDirection? = switch direction {
+            case "client-to-server": .clientToServer
+            case "server-to-client": .serverToClient
+            default: nil
+            }
             let viewModel = try appDelegate.cliWorkspaceViewModel()
             let limits = TCPFollowLimits(
                 maximumCandidatePacketCount: Limit.maximumFollowCandidates,
                 maximumPayloadBytes: maximumBytes,
-                maximumRecordCount: maximumRecords
+                maximumRecordCount: maximumRecords,
+                includedDirection: includedDirection
             )
             viewModel.followTCPStream(
                 containing: packetID,
@@ -566,12 +573,28 @@ final class TCPViewerCLICommandRouter: TCPViewerCLICommandRouting {
         .success(requestID: request.requestID, command: request.command, data: data)
     }
 
-    private func failure(_ request: TCPViewerCLIRequest, code: String, error: Error) -> TCPViewerCLIResponse {
-        failure(request, code: code, message: error.localizedDescription)
+    private func failure(
+        _ request: TCPViewerCLIRequest,
+        code: String,
+        error: Error,
+        data: [String: TCPViewerCLIValue]? = nil
+    ) -> TCPViewerCLIResponse {
+        failure(request, code: code, message: error.localizedDescription, data: data)
     }
 
-    private func failure(_ request: TCPViewerCLIRequest, code: String, message: String) -> TCPViewerCLIResponse {
-        .failure(requestID: request.requestID, command: request.command, code: code, message: message)
+    private func failure(
+        _ request: TCPViewerCLIRequest,
+        code: String,
+        message: String,
+        data: [String: TCPViewerCLIValue]? = nil
+    ) -> TCPViewerCLIResponse {
+        .failure(
+            requestID: request.requestID,
+            command: request.command,
+            code: code,
+            message: message,
+            data: data
+        )
     }
 
     private struct CLIError: Error {

--- a/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
+++ b/TCPViewer/Features/MCP/TCPViewerMCPCommandRouter.swift
@@ -764,9 +764,9 @@ final class TCPViewerMCPCommandRouter: TCPViewerMCPCommandRouting {
         appliesResultPagination: Bool
     ) -> (ids: [PacketSummary.ID], isTruncated: Bool, nextOffset: Int?, nextScanOffset: Int?) {
         let scannedCount = min(packets.count, query.scanLimit)
-        let candidates: ArraySlice<PacketSummary> = query.order == .recent
-            ? packets.suffix(scannedCount)
-            : packets.prefix(scannedCount)
+        let candidates = query.order == .recent && appliesResultPagination
+            ? Array(packets.suffix(scannedCount).reversed())
+            : Array(packets.prefix(scannedCount))
         var ids: [PacketSummary.ID] = []
         ids.reserveCapacity(min(scannedCount, Limit.maximumExportPacketCount))
         let maximumSelectedCount = appliesResultPagination

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1836,12 +1836,21 @@ final class NetworkInspectorViewModel {
     }
 
     func importDocuments(at fileURLs: [URL], completion: (() -> Void)? = nil) {
+        importDocumentsWithResult(at: fileURLs) { _ in
+            completion?()
+        }
+    }
+
+    func importDocumentsWithResult(
+        at fileURLs: [URL],
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
+    ) {
         let hasSessionFile = fileURLs
             .map(TCPViewerCaptureFileImportPolicy.standardizedFileURL)
             .contains(where: TCPViewerCaptureFileImportPolicy.isSessionFileURL)
-        controller.importDocuments(at: fileURLs) { [weak self] in
+        controller.importDocumentsWithResult(at: fileURLs) { [weak self] result in
             guard let self else {
-                completion?()
+                completion(result)
                 return
             }
 
@@ -1850,15 +1859,17 @@ final class NetworkInspectorViewModel {
                 self.applySessionDocumentState(sessionState)
                 self.pendingSessionImportReport = self.controller.currentDocumentSessionImportReport
                 self.rebuildSnapshot()
-                completion?()
+                completion(result)
             } else if hasSessionFile {
                 self.pendingSessionImportReport = nil
                 self.rebuildSnapshot()
-                completion?()
+                completion(result)
             } else {
                 self.pendingSessionImportReport = nil
                 self.restorePersistentDocumentState()
-                self.finishImportedDocuments(fileURLs: fileURLs, completion: completion)
+                self.finishImportedDocuments(fileURLs: fileURLs) {
+                    completion(result)
+                }
             }
         }
     }

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -295,10 +295,19 @@ final class TCPViewerRootViewController: NSViewController {
     }
 
     func importDocuments(at urls: [URL], completion: (() -> Void)? = nil) {
-        viewModel.importDocuments(at: urls) { [weak self] in
+        importDocumentsWithResult(at: urls) { _ in
+            completion?()
+        }
+    }
+
+    func importDocumentsWithResult(
+        at urls: [URL],
+        completion: @escaping (TCPViewerCaptureImportResult) -> Void
+    ) {
+        viewModel.importDocumentsWithResult(at: urls) { [weak self] result in
             self?.sidebarViewController.revealSelectedImportedFileIfNeeded()
             self?.presentSessionImportReportIfNeeded()
-            completion?()
+            completion(result)
         }
     }
 

--- a/TCPViewerCLIShared/TCPViewerCLIModels.swift
+++ b/TCPViewerCLIShared/TCPViewerCLIModels.swift
@@ -204,15 +204,23 @@ struct TCPViewerCLIResponse: Codable, Equatable {
         requestID: String,
         command: TCPViewerCLICommand,
         code: String,
-        message: String
+        message: String,
+        data: [String: TCPViewerCLIValue]? = nil
     ) -> TCPViewerCLIResponse {
         TCPViewerCLIResponse(
             schemaVersion: schemaVersion,
             requestID: requestID,
             ok: false,
             command: command,
-            data: nil,
+            data: data,
             error: TCPViewerCLIErrorPayload(code: code, message: message)
         )
+    }
+}
+
+extension TCPViewerCLIValue {
+    // Keep filter input lexical because the app applies numeric conversion only for numeric operators.
+    static func lexicalFilterValue(_ value: String) -> TCPViewerCLIValue {
+        .string(value)
     }
 }

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -804,6 +804,45 @@ struct WindowControllerTests {
         await tearDown(controller)
     }
 
+    @Test func captureImportResultReportsOnlyOpenedFilesAndTheFirstFailure() async throws {
+        let openedURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(URL(fileURLWithPath: "/tmp/import-opened.pcap"))
+        let failedURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(URL(fileURLWithPath: "/tmp/import-failed.pcapng"))
+        let openedDocument = FakeOfflineDocument(
+            url: openedURL,
+            metadata: CaptureDocumentMetadata(format: .pcap),
+            openPlan: .completed([makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)])
+        )
+        let importError = TCPViewerCoreError(code: .offlineFileOpenFailed, message: "Corrupt capture fixture.")
+        let failedDocument = FakeOfflineDocument(
+            url: failedURL,
+            metadata: CaptureDocumentMetadata(format: .pcapng),
+            openPlan: FakeOfflineDocument.LoadPlan(
+                batches: [],
+                progress: [],
+                error: importError
+            )
+        )
+        let controller = TCPViewerWorkspaceController(
+            services: TCPViewerServiceRegistry(core: FakeTCPViewerCore(
+                interfaceInventories: [[makeInterface(id: "en0", displayName: "Wi-Fi")]],
+                documentFactory: { url in url == failedURL ? failedDocument : openedDocument }
+            ))
+        )
+
+        let result = await controller.importDocumentsWithResult(at: [openedURL, failedURL])
+        let reportedError = try #require(result.error as? TCPViewerCoreError)
+
+        #expect(result.importedURLs == [openedURL])
+        #expect(reportedError == importError)
+        #expect(controller.snapshot.packetIngestState.importedFiles.map(\.url) == [openedURL])
+
+        let duplicateResult = await controller.importDocumentsWithResult(at: [openedURL])
+        #expect(duplicateResult.importedURLs.isEmpty)
+        #expect(duplicateResult.error == nil)
+
+        await tearDown(controller)
+    }
+
     @Test func captureFileImportPolicyAcceptsOnlyPcapAndPcapNgExtensions() {
         #expect(TCPViewerCaptureFileImportPolicy.isSupportedCaptureFileURL(URL(fileURLWithPath: "/tmp/sample.pcap")))
         #expect(TCPViewerCaptureFileImportPolicy.isSupportedCaptureFileURL(URL(fileURLWithPath: "/tmp/sample.PCAPNG")))

--- a/TCPViewerTests/Features/CLI/TCPViewerCLIModelsTests.swift
+++ b/TCPViewerTests/Features/CLI/TCPViewerCLIModelsTests.swift
@@ -67,4 +67,27 @@ struct TCPViewerCLIModelsTests {
         #expect(decoded.params == request.params)
         #expect(decoded.array("filters")?.first?.objectValue?["value"] == .string("2001:db8::1"))
     }
+
+    @Test func advancedFilterValuesRemainLexical() {
+        #expect(TCPViewerCLIValue.lexicalFilterValue("001") == .string("001"))
+        #expect(TCPViewerCLIValue.lexicalFilterValue("1e3") == .string("1e3"))
+        #expect(TCPViewerCLIValue.lexicalFilterValue("true") == .string("true"))
+    }
+
+    @Test func failedImportCanReportFilesThatOpenedBeforeTheFailure() {
+        let response = TCPViewerCLIResponse.failure(
+            requestID: UUID().uuidString.lowercased(),
+            command: .fileImport,
+            code: "import_failed",
+            message: "One capture could not be imported.",
+            data: [
+                "imported_files": .array([.string("/tmp/opened.pcap")]),
+                "imported_file_count": .int(1),
+            ]
+        )
+
+        #expect(!response.ok)
+        #expect(response.data?["imported_files"] == .array([.string("/tmp/opened.pcap")]))
+        #expect(response.data?["imported_file_count"] == .int(1))
+    }
 }

--- a/TCPViewerTests/Features/MCP/TCPViewerMCPCommandRouterTests.swift
+++ b/TCPViewerTests/Features/MCP/TCPViewerMCPCommandRouterTests.swift
@@ -183,11 +183,23 @@ struct TCPViewerMCPCommandRouterTests {
                 "operator": .string("exists"),
             ])]),
             "apply_result_pagination": .bool(true),
-            "offset": .int(1),
             "limit": .int(1),
         ])
         #expect(selectedPage.success)
         #expect(source.exportedIDs == [2])
+
+        let nextSelectedPage = await routeMCP(router, command: .exportPackets, params: [
+            "path": .string(directory.appendingPathComponent("next-selected-page.pcapng").path),
+            "filters": .array([.object([
+                "field": .string("packet_id"),
+                "operator": .string("exists"),
+            ])]),
+            "apply_result_pagination": .bool(true),
+            "offset": .int(1),
+            "limit": .int(1),
+        ])
+        #expect(nextSelectedPage.success)
+        #expect(source.exportedIDs == [1])
 
         let start = await routeMCP(router, command: .startCapture, params: [
             "interface_id": .string("en0"),

--- a/TCPViewerTests/Support/CallbackTestSupport.swift
+++ b/TCPViewerTests/Support/CallbackTestSupport.swift
@@ -42,6 +42,14 @@ extension TCPViewerWorkspaceController {
         await waitForCompletion { importDocuments(at: fileURLs, completion: $0) }
     }
 
+    func importDocumentsWithResult(at fileURLs: [URL]) async -> TCPViewerCaptureImportResult {
+        await withCheckedContinuation { continuation in
+            importDocumentsWithResult(at: fileURLs) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
     func cancelSessionImport() async {
         await waitForCompletion { cancelSessionImport(completion: $0) }
     }

--- a/tcpviewer-cli/Commands/PacketQueryOptions.swift
+++ b/tcpviewer-cli/Commands/PacketQueryOptions.swift
@@ -152,7 +152,7 @@ struct TCPViewerCLIPacketQueryOptions: ParsableArguments {
             guard value.utf8.count <= 4_096 else {
                 throw ValidationError("A filter value cannot exceed 4096 UTF-8 bytes.")
             }
-            return filter(field: field, operation: operation, value: scalar(value))
+            return filter(field: field, operation: operation, value: .lexicalFilterValue(value))
         }
     }
 
@@ -163,14 +163,6 @@ struct TCPViewerCLIPacketQueryOptions: ParsableArguments {
             "value": value,
             "case_sensitive": .bool(caseSensitive),
         ])
-    }
-
-    private func scalar(_ value: String) -> TCPViewerCLIValue {
-        if value == "true" { return .bool(true) }
-        if value == "false" { return .bool(false) }
-        if let integer = Int(value) { return .int(integer) }
-        if let double = Double(value), double.isFinite { return .double(double) }
-        return .string(value)
     }
 
     private static let fields: Set<String> = [


### PR DESCRIPTION
## Summary

- report actual capture import results, including partial failures and duplicate-only imports
- preserve newest-first pagination for recent selector exports while keeping full exports in capture order
- keep advanced filter values lexical
- apply follow limits only to the selected stream direction

## Testing

- `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build -quiet`
- `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS' -quiet`
- 645 tests passed, 0 failed, 0 skipped
- `git diff --check`

## AI disclosure

This pull request was substantially assisted by OpenAI Codex. The changes were reviewed against the reported issues and verified with the full local test suite.