### PR TITLE
Add Wireshark display filter support

### DIFF
--- a/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
@@ -716,6 +716,18 @@ final class WiresharkEpanSession {
 
 #if DEBUG
 extension WiresharkEpanSession {
+    static func testResetDisplayFilterCompilationCount() {
+        TCPViewerWiresharkTestResetDisplayFilterCompilationCount()
+    }
+
+    static var testDisplayFilterCompilationCount: Int {
+        Int(TCPViewerWiresharkTestDisplayFilterCompilationCount())
+    }
+
+    var testHasActiveDisplayFilter: Bool {
+        TCPViewerWiresharkSessionTestHasActiveDisplayFilter(handle)
+    }
+
     func testInjectCriticalException() throws {
         guard TCPViewerWiresharkSessionTestInjectCriticalException(handle) else {
             if let criticalError = criticalExceptionErrorIfNeeded() {

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanSession.swift
@@ -116,6 +116,68 @@ final class WiresharkEpanSession {
         TCPViewerWiresharkSessionDestroy(handle)
     }
 
+    static func validateDisplayFilter(
+        _ expression: String,
+        runtimeConfiguration: WiresharkRuntimeConfiguration = WiresharkRuntimeConfiguration()
+    ) -> DisplayFilterValidation {
+        do {
+            let directory = try runtimeConfiguration.createPersonalConfigurationDirectoryIfNeeded()
+            return expression.withCString { expressionPointer in
+                directory.path.withCString { directoryPointer in
+                    guard let resultPointer = TCPViewerWiresharkValidateDisplayFilter(
+                        expressionPointer,
+                        directoryPointer
+                    ) else {
+                        return unavailableDisplayFilterValidation(expression)
+                    }
+                    defer { TCPViewerDisplayFilterValidationResultDestroy(resultPointer) }
+                    return displayFilterValidation(resultPointer.pointee)
+                }
+            }
+        } catch {
+            return unavailableDisplayFilterValidation(expression, message: error.localizedDescription)
+        }
+    }
+
+    func activateDisplayFilter(_ expression: String, generation: UInt64) -> DisplayFilterValidation {
+        expression.withCString { expressionPointer in
+            guard let resultPointer = TCPViewerWiresharkSessionActivateDisplayFilter(
+                handle,
+                expressionPointer,
+                generation
+            ) else {
+                return Self.unavailableDisplayFilterValidation(expression)
+            }
+            defer { TCPViewerDisplayFilterValidationResultDestroy(resultPointer) }
+            return Self.displayFilterValidation(resultPointer.pointee)
+        }
+    }
+
+    func evaluateDisplayFilter(_ record: NativePacketRecord, generation: UInt64) throws -> Bool {
+        try withContext(for: record) { context in
+            guard let resultPointer = TCPViewerWiresharkSessionEvaluateDisplayFilter(
+                handle,
+                context,
+                generation
+            ) else {
+                throw unavailableError("Wireshark returned no display-filter result.")
+            }
+            defer { TCPViewerDisplayFilterMatchResultDestroy(resultPointer) }
+            let result = resultPointer.pointee
+            guard result.succeeded else {
+                if let criticalError = criticalExceptionErrorIfNeeded() {
+                    throw criticalError
+                }
+                throw unavailableError(Self.string(result.errorMessage))
+            }
+            return result.matched
+        }
+    }
+
+    func clearDisplayFilter() {
+        TCPViewerWiresharkSessionClearDisplayFilter(handle)
+    }
+
     @discardableResult
     func observe(_ record: NativePacketRecord) throws -> [WiresharkTCPStreamIndexEntry] {
         try withContext(for: record) { context in
@@ -598,6 +660,57 @@ final class WiresharkEpanSession {
         }
         let value = String(cString: pointer)
         return value.isEmpty ? nil : value
+    }
+
+    private static func displayFilterValidation(
+        _ result: TCPViewerDisplayFilterValidationResult
+    ) -> DisplayFilterValidation {
+        let status: DisplayFilterValidationStatus
+        switch result.status {
+        case TCPViewerDisplayFilterValidationValid:
+            status = .valid
+        case TCPViewerDisplayFilterValidationInvalid:
+            status = .invalid
+        default:
+            status = .unavailable
+        }
+        let normalizedExpression = result.normalizedExpression.map(String.init(cString:)) ?? ""
+        let diagnostics: [DisplayFilterDiagnostic]
+        if let diagnosticPointer = result.diagnostics, result.diagnosticCount > 0 {
+            diagnostics = UnsafeBufferPointer(
+                start: diagnosticPointer,
+                count: result.diagnosticCount
+            ).map { diagnostic in
+                DisplayFilterDiagnostic(
+                    severity: diagnostic.severity == TCPViewerDisplayFilterDiagnosticWarning ? .warning : .error,
+                    message: diagnostic.message.map(String.init(cString:)) ?? "Wireshark display-filter error.",
+                    range: diagnostic.hasRange
+                        ? DisplayFilterSourceRange(
+                            utf8StartOffset: Int(clamping: diagnostic.utf8StartOffset),
+                            utf8Length: Int(clamping: diagnostic.utf8Length)
+                        )
+                        : nil
+                )
+            }
+        } else {
+            diagnostics = []
+        }
+        return DisplayFilterValidation(
+            normalizedExpression: normalizedExpression,
+            status: status,
+            diagnostics: diagnostics
+        )
+    }
+
+    private static func unavailableDisplayFilterValidation(
+        _ expression: String,
+        message: String = "Wireshark display-filter validation is unavailable."
+    ) -> DisplayFilterValidation {
+        DisplayFilterValidation(
+            normalizedExpression: expression.trimmingCharacters(in: .whitespacesAndNewlines),
+            status: .unavailable,
+            diagnostics: [DisplayFilterDiagnostic(severity: .error, message: message)]
+        )
     }
 }
 

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
@@ -23,6 +23,7 @@
 #include <epan/column-info.h>
 #include <epan/column-utils.h>
 #include <epan/dissectors/packet-tcp.h>
+#include <epan/dfilter/dfilter.h>
 #include <epan/epan.h>
 #include <epan/epan_dissect.h>
 #include <epan/exceptions.h>
@@ -43,6 +44,8 @@
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
 #endif
+
+extern "C" void TCPViewerWiresharkIPDisplayFilterPluginRegister(void);
 
 struct packet_provider_data {
     wtap *wth = nullptr;
@@ -120,6 +123,24 @@ struct WiresharkDissectionResult {
     std::vector<WiresharkByteSource> byteSources;
     std::vector<DetailNode> nodes;
     std::string sniDomainName;
+    bool hasDisplayFilterMatch = false;
+    bool displayFilterMatched = false;
+    uint64_t displayFilterGeneration = 0;
+};
+
+struct DisplayFilterDiagnosticCopy {
+    TCPViewerDisplayFilterDiagnosticSeverity severity = TCPViewerDisplayFilterDiagnosticError;
+    std::string message;
+    size_t utf8StartOffset = 0;
+    size_t utf8Length = 0;
+    bool hasRange = false;
+};
+
+struct DisplayFilterValidationCopy {
+    TCPViewerDisplayFilterValidationStatus status = TCPViewerDisplayFilterValidationUnavailable;
+    std::string normalizedExpression;
+    std::vector<DisplayFilterDiagnosticCopy> diagnostics;
+    dfilter_t *compiledFilter = nullptr;
 };
 
 struct PacketContextView {
@@ -204,6 +225,201 @@ char *CopyCString(const std::string &value, bool allowNull = true)
         return nullptr;
     }
     return strdup(value.c_str());
+}
+
+std::string TrimASCIIWhitespace(const char *expression)
+{
+    if (expression == nullptr) {
+        return "";
+    }
+    std::string value(expression);
+    const auto first = value.find_first_not_of(" \t\r\n\f\v");
+    if (first == std::string::npos) {
+        return "";
+    }
+    const auto last = value.find_last_not_of(" \t\r\n\f\v");
+    return value.substr(first, last - first + 1);
+}
+
+std::optional<std::pair<size_t, size_t>> UnsupportedDollarTokenRange(const std::string &expression)
+{
+    enum class LiteralState { None, Quoted, Raw, Character };
+    LiteralState state = LiteralState::None;
+    bool escaped = false;
+
+    for (size_t index = 0; index < expression.size(); index += 1) {
+        const char character = expression[index];
+        switch (state) {
+            case LiteralState::Quoted:
+            case LiteralState::Character:
+                if (escaped) {
+                    escaped = false;
+                } else if (character == '\\') {
+                    escaped = true;
+                } else if ((state == LiteralState::Quoted && character == '"')
+                           || (state == LiteralState::Character && character == '\'')) {
+                    state = LiteralState::None;
+                }
+                continue;
+            case LiteralState::Raw:
+                if (character == '"') {
+                    state = LiteralState::None;
+                }
+                continue;
+            case LiteralState::None:
+                break;
+        }
+
+        if ((character == 'r' || character == 'R')
+            && index + 1 < expression.size() && expression[index + 1] == '"') {
+            state = LiteralState::Raw;
+            index += 1;
+            continue;
+        }
+        if (character == '"') {
+            state = LiteralState::Quoted;
+            continue;
+        }
+        if (character == '\'') {
+            state = LiteralState::Character;
+            continue;
+        }
+        if (character != '$') {
+            continue;
+        }
+
+        size_t end = index + 1;
+        if (end < expression.size() && expression[end] == '{') {
+            end += 1;
+            while (end < expression.size() && expression[end] != '}') {
+                end += 1;
+            }
+            if (end < expression.size()) {
+                end += 1;
+            }
+        } else {
+            while (end < expression.size()) {
+                const unsigned char next = static_cast<unsigned char>(expression[end]);
+                if (!(std::isalnum(next) || next == '_' || next == '.')) {
+                    break;
+                }
+                end += 1;
+            }
+        }
+        return std::pair<size_t, size_t>{index, end - index};
+    }
+    return std::nullopt;
+}
+
+DisplayFilterValidationCopy CompileDisplayFilter(const char *expression)
+{
+    DisplayFilterValidationCopy validation;
+    const std::string sourceExpression = expression == nullptr ? "" : expression;
+    validation.normalizedExpression = TrimASCIIWhitespace(expression);
+    if (validation.normalizedExpression.empty()) {
+        validation.status = TCPViewerDisplayFilterValidationValid;
+        return validation;
+    }
+
+    if (auto range = UnsupportedDollarTokenRange(sourceExpression)) {
+        validation.status = TCPViewerDisplayFilterValidationInvalid;
+        validation.diagnostics.push_back(DisplayFilterDiagnosticCopy{
+            TCPViewerDisplayFilterDiagnosticError,
+            "Macros and selected-frame $field references are not supported.",
+            range->first,
+            range->second,
+            true,
+        });
+        return validation;
+    }
+
+    dfilter_t *compiled = nullptr;
+    df_error_t *error = nullptr;
+    const bool succeeded = dfilter_compile_full(
+        sourceExpression.c_str(),
+        &compiled,
+        &error,
+        DF_OPTIMIZE,
+        "TCPViewerDisplayFilter"
+    );
+    if (!succeeded) {
+        validation.status = TCPViewerDisplayFilterValidationInvalid;
+        DisplayFilterDiagnosticCopy diagnostic;
+        diagnostic.message = error != nullptr && error->msg != nullptr
+            ? error->msg
+            : "Wireshark could not compile this display filter.";
+        if (error != nullptr && error->loc.col_start >= 0) {
+            diagnostic.hasRange = true;
+            diagnostic.utf8StartOffset = static_cast<size_t>(error->loc.col_start);
+            diagnostic.utf8Length = error->loc.col_len;
+        }
+        validation.diagnostics.push_back(std::move(diagnostic));
+        df_error_free(&error);
+        dfilter_free(compiled);
+        return validation;
+    }
+
+    validation.status = TCPViewerDisplayFilterValidationValid;
+    validation.compiledFilter = compiled;
+    if (compiled != nullptr) {
+        for (GSList *item = dfilter_get_warnings(compiled); item != nullptr; item = item->next) {
+            const auto *message = static_cast<const char *>(item->data);
+            if (message != nullptr && message[0] != '\0') {
+                validation.diagnostics.push_back(DisplayFilterDiagnosticCopy{
+                    TCPViewerDisplayFilterDiagnosticWarning,
+                    message,
+                    0,
+                    0,
+                    false,
+                });
+            }
+        }
+        if (GPtrArray *deprecated = dfilter_deprecated_tokens(compiled)) {
+            for (guint index = 0; index < deprecated->len; index += 1) {
+                const auto *token = static_cast<const char *>(g_ptr_array_index(deprecated, index));
+                if (token != nullptr && token[0] != '\0') {
+                    validation.diagnostics.push_back(DisplayFilterDiagnosticCopy{
+                        TCPViewerDisplayFilterDiagnosticWarning,
+                        std::string("Deprecated display-filter token: ") + token,
+                        0,
+                        0,
+                        false,
+                    });
+                }
+            }
+        }
+    }
+    return validation;
+}
+
+TCPViewerDisplayFilterValidationResult *CopyDisplayFilterValidation(const DisplayFilterValidationCopy &source)
+{
+    auto *result = static_cast<TCPViewerDisplayFilterValidationResult *>(std::calloc(1, sizeof(TCPViewerDisplayFilterValidationResult)));
+    if (result == nullptr) {
+        return nullptr;
+    }
+    result->status = source.status;
+    result->normalizedExpression = CopyCString(source.normalizedExpression, false);
+    result->diagnosticCount = source.diagnostics.size();
+    if (result->diagnosticCount == 0) {
+        return result;
+    }
+    result->diagnostics = static_cast<TCPViewerDisplayFilterDiagnostic *>(
+        std::calloc(result->diagnosticCount, sizeof(TCPViewerDisplayFilterDiagnostic))
+    );
+    if (result->diagnostics == nullptr) {
+        result->diagnosticCount = 0;
+        return result;
+    }
+    for (size_t index = 0; index < result->diagnosticCount; index += 1) {
+        const auto &diagnostic = source.diagnostics[index];
+        result->diagnostics[index].severity = diagnostic.severity;
+        result->diagnostics[index].message = CopyCString(diagnostic.message, false);
+        result->diagnostics[index].utf8StartOffset = diagnostic.utf8StartOffset;
+        result->diagnostics[index].utf8Length = diagnostic.utf8Length;
+        result->diagnostics[index].hasRange = diagnostic.hasRange;
+    }
+    return result;
 }
 
 const char *WiresharkExceptionName(unsigned long code)
@@ -516,16 +732,18 @@ private:
 
 class WiresharkColumnInfo {
 public:
-    WiresharkColumnInfo()
+    WiresharkColumnInfo(bool isNeeded, bool includesAllRegisteredColumns)
     {
-        // TCP Viewer only needs packet-list protocol and info columns from Wireshark.
-        col_setup(&info_, 2);
-        info_.columns[0].col_fmt = COL_PROTOCOL;
-        info_.columns[0].col_title = nullptr;
-        info_.columns[0].col_fence = 0;
-        info_.columns[1].col_fmt = COL_INFO;
-        info_.columns[1].col_title = nullptr;
-        info_.columns[1].col_fence = 0;
+        if (!isNeeded) {
+            return;
+        }
+        const int columnCount = includesAllRegisteredColumns ? NUM_COL_FMTS : 2;
+        col_setup(&info_, columnCount);
+        for (int index = 0; index < columnCount; index += 1) {
+            info_.columns[index].col_fmt = includesAllRegisteredColumns ? index : (index == 0 ? COL_PROTOCOL : COL_INFO);
+            info_.columns[index].col_title = nullptr;
+            info_.columns[index].col_fence = 0;
+        }
         col_finalize(&info_);
         initialized_ = true;
     }
@@ -1091,6 +1309,7 @@ private:
             return;
         }
         initializedWiretap_ = true;
+        TCPViewerWiresharkIPDisplayFilterPluginRegister();
         bool didInitializeEpan = false;
         if (auto report = CatchWiresharkException("initializing Wireshark protocol registry", std::nullopt, [&didInitializeEpan] {
                 didInitializeEpan = epan_init(nullptr, nullptr, false);
@@ -1184,6 +1403,10 @@ struct TCPViewerWiresharkSession {
     std::vector<std::pair<uint32_t, uint32_t>> pendingTCPStreamFrames;
     std::vector<std::pair<uint64_t, uint32_t>> pendingTCPStreamIndexUpdates;
     std::deque<WiresharkCriticalException> pendingCriticalExceptions;
+    dfilter_t *activeDisplayFilter = nullptr;
+    std::string activeDisplayFilterExpression;
+    uint64_t activeDisplayFilterGeneration = 0;
+    std::unordered_map<uint64_t, std::pair<uint64_t, bool>> displayFilterMatchByPacketIdentifier;
     follow_info_t *followInfo = nullptr;
     TCPFollowTapContext *followTapContext = nullptr;
     register_follow_t *tcpFollower = nullptr;
@@ -1391,9 +1614,21 @@ struct TCPViewerWiresharkSession {
         }
     }
 
+    void clearActiveDisplayFilterLocked()
+    {
+        if (activeDisplayFilter != nullptr) {
+            dfilter_free(activeDisplayFilter);
+            activeDisplayFilter = nullptr;
+        }
+        activeDisplayFilterExpression.clear();
+        activeDisplayFilterGeneration = 0;
+        displayFilterMatchByPacketIdentifier.clear();
+    }
+
     void releaseWiresharkResourcesLocked(const std::string &reason, bool finishSession)
     {
         cancelFollowLocked();
+        clearActiveDisplayFilterLocked();
         if (tcpIndexTapRegistered) {
             if (auto report = CatchWiresharkException("removing Wireshark TCP stream index listener", std::nullopt, [&] {
                     remove_tap_listener(this);
@@ -1418,6 +1653,43 @@ struct TCPViewerWiresharkSession {
         if (finishSession) {
             firstPassFinished = true;
         }
+    }
+
+    DisplayFilterValidationCopy activateDisplayFilterLocked(const char *expression, uint64_t generation)
+    {
+        DisplayFilterValidationCopy validation;
+        if (!ensureActiveSessionLocked()) {
+            validation.normalizedExpression = TrimASCIIWhitespace(expression);
+            validation.status = TCPViewerDisplayFilterValidationUnavailable;
+            validation.diagnostics.push_back(DisplayFilterDiagnosticCopy{
+                TCPViewerDisplayFilterDiagnosticError,
+                unavailableReason.empty() ? kBackendUnavailableReason : unavailableReason,
+                0,
+                0,
+                false,
+            });
+            return validation;
+        }
+
+        const std::string normalizedExpression = TrimASCIIWhitespace(expression);
+        if (activeDisplayFilter != nullptr
+            && activeDisplayFilterExpression == normalizedExpression
+            && activeDisplayFilterGeneration == generation) {
+            validation.normalizedExpression = normalizedExpression;
+            validation.status = TCPViewerDisplayFilterValidationValid;
+            return validation;
+        }
+
+        validation = CompileDisplayFilter(expression);
+        if (validation.status != TCPViewerDisplayFilterValidationValid) {
+            return validation;
+        }
+        clearActiveDisplayFilterLocked();
+        activeDisplayFilter = validation.compiledFilter;
+        validation.compiledFilter = nullptr;
+        activeDisplayFilterExpression = validation.normalizedExpression;
+        activeDisplayFilterGeneration = generation;
+        return validation;
     }
 
     bool initializeWiresharkResourcesLocked()
@@ -2031,7 +2303,11 @@ struct TCPViewerWiresharkSession {
         return result;
     }
 
-    WiresharkDissectionResult runSecondPassLocked(const PacketContextView &context, bool buildTree)
+    WiresharkDissectionResult runSecondPassLocked(
+        const PacketContextView &context,
+        bool buildTree,
+        bool includesSummaryColumns = true
+    )
     {
         WiresharkDissectionResult result;
         if (!ensureActiveSessionLocked()) {
@@ -2060,11 +2336,14 @@ struct TCPViewerWiresharkSession {
             return result;
         }
 
-        WiresharkColumnInfo columnInfo;
+        const bool evaluatesDisplayFilter = activeDisplayFilter != nullptr;
+        const bool filterRequiresColumns = evaluatesDisplayFilter && dfilter_requires_columns(activeDisplayFilter);
+        WiresharkColumnInfo columnInfo(includesSummaryColumns || filterRequiresColumns, filterRequiresColumns);
+        const bool createsProtocolTree = buildTree || evaluatesDisplayFilter;
         epan_dissect_t *rawDissect = nullptr;
         auto *currentEpan = epan;
-        if (auto report = CatchWiresharkException("creating Wireshark second-pass dissector", context.packetIdentifier, [&rawDissect, currentEpan, buildTree] {
-                rawDissect = epan_dissect_new(currentEpan, buildTree, buildTree);
+        if (auto report = CatchWiresharkException("creating Wireshark second-pass dissector", context.packetIdentifier, [&rawDissect, currentEpan, createsProtocolTree, buildTree] {
+                rawDissect = epan_dissect_new(currentEpan, createsProtocolTree, buildTree);
             })) {
             failWithCriticalExceptionLocked(std::move(*report));
             result.fallbackReason = unavailableReason;
@@ -2103,6 +2382,15 @@ struct TCPViewerWiresharkSession {
             }
         }
 
+        if (evaluatesDisplayFilter) {
+            if (auto report = CatchWiresharkException("priming Wireshark display filter", context.packetIdentifier, [&] {
+                    epan_dissect_prime_with_dfilter(rawDissect, activeDisplayFilter);
+                })) {
+                failWithLocalCriticalException(std::move(*report));
+                return result;
+            }
+        }
+
         wtap_block_t block = record.get()->block != nullptr ? wtap_block_ref(record.get()->block) : nullptr;
         if (auto report = CatchWiresharkException("running Wireshark second-pass dissection", context.packetIdentifier, [&] {
                 frame_data_set_before_dissect(frame, &elapsedTime, &provider->ref, provider->prev_dis);
@@ -2124,6 +2412,22 @@ struct TCPViewerWiresharkSession {
         }
 
         result.columns = ColumnsFromInfo(columnInfo.get());
+        if (evaluatesDisplayFilter) {
+            bool matched = false;
+            if (auto report = CatchWiresharkException("applying Wireshark display filter", context.packetIdentifier, [&] {
+                    matched = dfilter_apply_edt(activeDisplayFilter, rawDissect);
+                })) {
+                failWithLocalCriticalException(std::move(*report));
+                return result;
+            }
+            result.hasDisplayFilterMatch = true;
+            result.displayFilterMatched = matched;
+            result.displayFilterGeneration = activeDisplayFilterGeneration;
+            displayFilterMatchByPacketIdentifier[context.packetIdentifier] = {
+                activeDisplayFilterGeneration,
+                matched,
+            };
+        }
         if (buildTree) {
             auto sourceSet = ExtractByteSources(rawDissect->pi.data_src);
             result.nodes = MapProtoTree(rawDissect->tree, sourceSet);
@@ -2147,6 +2451,38 @@ struct TCPViewerWiresharkSession {
         if (!freeSecondPassDissector()) {
             return result;
         }
+        return result;
+    }
+
+    TCPViewerDisplayFilterMatchResult *evaluateDisplayFilterLocked(
+        const PacketContextView &context,
+        uint64_t generation
+    ) {
+        auto *result = static_cast<TCPViewerDisplayFilterMatchResult *>(std::calloc(1, sizeof(TCPViewerDisplayFilterMatchResult)));
+        if (result == nullptr) {
+            return nullptr;
+        }
+        if (generation != activeDisplayFilterGeneration || activeDisplayFilter == nullptr) {
+            result->errorMessage = CopyCString("The Wireshark display-filter generation is no longer active.", false);
+            return result;
+        }
+        const auto cached = displayFilterMatchByPacketIdentifier.find(context.packetIdentifier);
+        if (cached != displayFilterMatchByPacketIdentifier.end() && cached->second.first == generation) {
+            result->succeeded = true;
+            result->matched = cached->second.second;
+            return result;
+        }
+
+        const auto dissection = runSecondPassLocked(context, false, false);
+        if (!dissection.hasDisplayFilterMatch || dissection.displayFilterGeneration != generation) {
+            result->errorMessage = CopyCString(
+                dissection.fallbackReason.empty() ? "Wireshark could not evaluate this packet." : dissection.fallbackReason,
+                false
+            );
+            return result;
+        }
+        result->succeeded = true;
+        result->matched = dissection.displayFilterMatched;
         return result;
     }
 
@@ -2207,6 +2543,115 @@ const char *TCPViewerWiresharkSessionUnavailableReason(TCPViewerWiresharkSession
     }
     std::lock_guard<std::mutex> lock(session->mutex);
     return session->unavailableReason.empty() ? kBackendUnavailableReason : session->unavailableReason.c_str();
+}
+
+TCPViewerDisplayFilterValidationResult *TCPViewerWiresharkValidateDisplayFilter(
+    const char *expression,
+    const char *personalConfigurationDirectory
+) {
+    auto &runtime = WiresharkRuntime::shared(personalConfigurationDirectory);
+    if (!runtime.isAvailable()) {
+        DisplayFilterValidationCopy validation;
+        validation.normalizedExpression = TrimASCIIWhitespace(expression);
+        validation.status = TCPViewerDisplayFilterValidationUnavailable;
+        validation.diagnostics.push_back(DisplayFilterDiagnosticCopy{
+            TCPViewerDisplayFilterDiagnosticError,
+            runtime.unavailableReason(),
+            0,
+            0,
+            false,
+        });
+        return CopyDisplayFilterValidation(validation);
+    }
+
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    DisplayFilterValidationCopy validation;
+    if (auto report = CatchWiresharkException("compiling Wireshark display filter", std::nullopt, [&] {
+            validation = CompileDisplayFilter(expression);
+        })) {
+        validation.status = TCPViewerDisplayFilterValidationUnavailable;
+        validation.normalizedExpression = TrimASCIIWhitespace(expression);
+        validation.diagnostics = {DisplayFilterDiagnosticCopy{
+            TCPViewerDisplayFilterDiagnosticError,
+            report->reason,
+            0,
+            0,
+            false,
+        }};
+    }
+    auto *result = CopyDisplayFilterValidation(validation);
+    dfilter_free(validation.compiledFilter);
+    return result;
+}
+
+TCPViewerDisplayFilterValidationResult *TCPViewerWiresharkSessionActivateDisplayFilter(
+    TCPViewerWiresharkSession *session,
+    const char *expression,
+    uint64_t generation
+) {
+    if (session == nullptr) {
+        DisplayFilterValidationCopy validation;
+        validation.normalizedExpression = TrimASCIIWhitespace(expression);
+        validation.status = TCPViewerDisplayFilterValidationUnavailable;
+        validation.diagnostics.push_back(DisplayFilterDiagnosticCopy{
+            TCPViewerDisplayFilterDiagnosticError,
+            kBackendUnavailableReason,
+            0,
+            0,
+            false,
+        });
+        return CopyDisplayFilterValidation(validation);
+    }
+
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
+    DisplayFilterValidationCopy validation;
+    if (auto report = CatchWiresharkException("activating Wireshark display filter", std::nullopt, [&] {
+            validation = session->activateDisplayFilterLocked(expression, generation);
+        })) {
+        session->failWithCriticalExceptionLocked(*report);
+        validation.status = TCPViewerDisplayFilterValidationUnavailable;
+        validation.normalizedExpression = TrimASCIIWhitespace(expression);
+        validation.diagnostics = {DisplayFilterDiagnosticCopy{
+            TCPViewerDisplayFilterDiagnosticError,
+            report->reason,
+            0,
+            0,
+            false,
+        }};
+    }
+    auto *result = CopyDisplayFilterValidation(validation);
+    dfilter_free(validation.compiledFilter);
+    return result;
+}
+
+TCPViewerDisplayFilterMatchResult *TCPViewerWiresharkSessionEvaluateDisplayFilter(
+    TCPViewerWiresharkSession *session,
+    const TCPViewerWiresharkPacketContext *context,
+    uint64_t generation
+) {
+    if (session == nullptr || context == nullptr) {
+        auto *result = static_cast<TCPViewerDisplayFilterMatchResult *>(std::calloc(1, sizeof(TCPViewerDisplayFilterMatchResult)));
+        if (result != nullptr) {
+            result->errorMessage = CopyCString("The Wireshark display-filter request is invalid.", false);
+        }
+        return result;
+    }
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearCriticalExceptionsLocked();
+    return session->evaluateDisplayFilterLocked(ContextViewFromC(context), generation);
+}
+
+void TCPViewerWiresharkSessionClearDisplayFilter(TCPViewerWiresharkSession *session)
+{
+    if (session == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    session->clearActiveDisplayFilterLocked();
 }
 
 bool TCPViewerWiresharkSessionObservePacket(TCPViewerWiresharkSession *session, const TCPViewerWiresharkPacketContext *context)
@@ -2575,6 +3020,28 @@ void TCPViewerWiresharkExceptionReportDestroy(TCPViewerWiresharkExceptionReport 
     std::free(const_cast<char *>(report->exceptionName));
     std::free(const_cast<char *>(report->reason));
     std::free(report);
+}
+
+void TCPViewerDisplayFilterValidationResultDestroy(TCPViewerDisplayFilterValidationResult *result)
+{
+    if (result == nullptr) {
+        return;
+    }
+    std::free(const_cast<char *>(result->normalizedExpression));
+    for (size_t index = 0; index < result->diagnosticCount; index += 1) {
+        std::free(const_cast<char *>(result->diagnostics[index].message));
+    }
+    std::free(result->diagnostics);
+    std::free(result);
+}
+
+void TCPViewerDisplayFilterMatchResultDestroy(TCPViewerDisplayFilterMatchResult *result)
+{
+    if (result == nullptr) {
+        return;
+    }
+    std::free(const_cast<char *>(result->errorMessage));
+    std::free(result);
 }
 
 #if DEBUG

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
@@ -360,6 +360,11 @@ DisplayFilterValidationCopy CompileDisplayFilter(const char *expression)
             diagnostic.hasRange = true;
             diagnostic.utf8StartOffset = static_cast<size_t>(error->loc.col_start);
             diagnostic.utf8Length = error->loc.col_len;
+        } else {
+            // Wireshark omits locations for incomplete trailing grammar, so place the caret at the end.
+            diagnostic.hasRange = true;
+            diagnostic.utf8StartOffset = sourceExpression.size();
+            diagnostic.utf8Length = 0;
         }
         validation.diagnostics.push_back(std::move(diagnostic));
         df_error_free(&error);
@@ -1426,7 +1431,6 @@ struct TCPViewerWiresharkSession {
     dfilter_t *activeDisplayFilter = nullptr;
     std::string activeDisplayFilterExpression;
     uint64_t activeDisplayFilterGeneration = 0;
-    std::unordered_map<uint64_t, std::pair<uint64_t, bool>> displayFilterMatchByPacketIdentifier;
     follow_info_t *followInfo = nullptr;
     TCPFollowTapContext *followTapContext = nullptr;
     register_follow_t *tcpFollower = nullptr;
@@ -1642,7 +1646,6 @@ struct TCPViewerWiresharkSession {
         }
         activeDisplayFilterExpression.clear();
         activeDisplayFilterGeneration = 0;
-        displayFilterMatchByPacketIdentifier.clear();
     }
 
     void releaseWiresharkResourcesLocked(const std::string &reason, bool finishSession)
@@ -2443,10 +2446,6 @@ struct TCPViewerWiresharkSession {
             result.hasDisplayFilterMatch = true;
             result.displayFilterMatched = matched;
             result.displayFilterGeneration = activeDisplayFilterGeneration;
-            displayFilterMatchByPacketIdentifier[context.packetIdentifier] = {
-                activeDisplayFilterGeneration,
-                matched,
-            };
         }
         if (buildTree) {
             auto sourceSet = ExtractByteSources(rawDissect->pi.data_src);
@@ -2486,13 +2485,6 @@ struct TCPViewerWiresharkSession {
             result->errorMessage = CopyCString("The Wireshark display-filter generation is no longer active.", false);
             return result;
         }
-        const auto cached = displayFilterMatchByPacketIdentifier.find(context.packetIdentifier);
-        if (cached != displayFilterMatchByPacketIdentifier.end() && cached->second.first == generation) {
-            result->succeeded = true;
-            result->matched = cached->second.second;
-            return result;
-        }
-
         const auto dissection = runSecondPassLocked(context, false, false);
         if (!dissection.hasDisplayFilterMatch || dissection.displayFilterGeneration != generation) {
             result->errorMessage = CopyCString(

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.cpp
@@ -33,6 +33,7 @@
 #include <epan/prefs.h>
 #include <epan/proto.h>
 #include <epan/tap.h>
+#include <epan/timestamp.h>
 #include <epan/to_str.h>
 #include <epan/tvbuff.h>
 #include <wiretap/pcap-encap.h>
@@ -175,6 +176,10 @@ std::mutex &WiresharkAPIMutex()
     static auto *mutex = new std::mutex();
     return *mutex;
 }
+
+#if DEBUG
+size_t gDisplayFilterCompilationCount = 0;
+#endif
 
 std::string CurrentExecutablePath()
 {
@@ -333,6 +338,9 @@ DisplayFilterValidationCopy CompileDisplayFilter(const char *expression)
         return validation;
     }
 
+#if DEBUG
+    gDisplayFilterCompilationCount += 1;
+#endif
     dfilter_t *compiled = nullptr;
     df_error_t *error = nullptr;
     const bool succeeded = dfilter_compile_full(
@@ -737,10 +745,18 @@ public:
         if (!isNeeded) {
             return;
         }
-        const int columnCount = includesAllRegisteredColumns ? NUM_COL_FMTS : 2;
+        if (includesAllRegisteredColumns) {
+            // Mirror Wireshark's registered preference columns so _ws.col.* fields use valid column metadata.
+            build_column_format_array(&info_, prefs.num_cols, true);
+            initialized_ = true;
+            return;
+        }
+
+        const int formats[] = {COL_PROTOCOL, COL_INFO};
+        const int columnCount = 2;
         col_setup(&info_, columnCount);
         for (int index = 0; index < columnCount; index += 1) {
-            info_.columns[index].col_fmt = includesAllRegisteredColumns ? index : (index == 0 ? COL_PROTOCOL : COL_INFO);
+            info_.columns[index].col_fmt = formats[index];
             info_.columns[index].col_title = nullptr;
             info_.columns[index].col_fence = 0;
         }
@@ -1300,6 +1316,10 @@ private:
             return;
         }
         initializedExceptions_ = true;
+        // Column-backed filters need the same timestamp defaults as Wireshark's command-line tools.
+        timestamp_set_type(TS_RELATIVE);
+        timestamp_set_precision(TS_PREC_AUTO);
+        timestamp_set_seconds_type(TS_SECONDS_DEFAULT);
         if (auto report = CatchWiresharkException("initializing Wireshark Wiretap", std::nullopt, [] {
                 wtap_init(false);
             })) {
@@ -3076,5 +3096,27 @@ bool TCPViewerWiresharkSessionTestInjectCriticalException(TCPViewerWiresharkSess
         return session->failWithCriticalExceptionLocked(std::move(*report));
     }
     return true;
+}
+
+void TCPViewerWiresharkTestResetDisplayFilterCompilationCount(void)
+{
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    gDisplayFilterCompilationCount = 0;
+}
+
+size_t TCPViewerWiresharkTestDisplayFilterCompilationCount(void)
+{
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    return gDisplayFilterCompilationCount;
+}
+
+bool TCPViewerWiresharkSessionTestHasActiveDisplayFilter(TCPViewerWiresharkSession *session)
+{
+    if (session == nullptr) {
+        return false;
+    }
+    std::lock_guard<std::mutex> apiLock(WiresharkAPIMutex());
+    std::lock_guard<std::mutex> sessionLock(session->mutex);
+    return session->activeDisplayFilter != nullptr;
 }
 #endif

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
@@ -131,6 +131,38 @@ typedef struct TCPViewerWiresharkExceptionReport {
     const char *reason;
 } TCPViewerWiresharkExceptionReport;
 
+typedef enum TCPViewerDisplayFilterValidationStatus {
+    TCPViewerDisplayFilterValidationValid = 0,
+    TCPViewerDisplayFilterValidationInvalid = 1,
+    TCPViewerDisplayFilterValidationUnavailable = 2,
+} TCPViewerDisplayFilterValidationStatus;
+
+typedef enum TCPViewerDisplayFilterDiagnosticSeverity {
+    TCPViewerDisplayFilterDiagnosticWarning = 0,
+    TCPViewerDisplayFilterDiagnosticError = 1,
+} TCPViewerDisplayFilterDiagnosticSeverity;
+
+typedef struct TCPViewerDisplayFilterDiagnostic {
+    TCPViewerDisplayFilterDiagnosticSeverity severity;
+    const char *message;
+    size_t utf8StartOffset;
+    size_t utf8Length;
+    bool hasRange;
+} TCPViewerDisplayFilterDiagnostic;
+
+typedef struct TCPViewerDisplayFilterValidationResult {
+    TCPViewerDisplayFilterValidationStatus status;
+    const char *normalizedExpression;
+    TCPViewerDisplayFilterDiagnostic *diagnostics;
+    size_t diagnosticCount;
+} TCPViewerDisplayFilterValidationResult;
+
+typedef struct TCPViewerDisplayFilterMatchResult {
+    bool succeeded;
+    bool matched;
+    const char *errorMessage;
+} TCPViewerDisplayFilterMatchResult;
+
 TCPViewerWiresharkSession *TCPViewerWiresharkSessionCreate(bool disabled, bool livePriority, const char *personalConfigurationDirectory);
 void TCPViewerWiresharkSessionDestroy(TCPViewerWiresharkSession *session);
 void TCPViewerWiresharkSessionReleaseResources(TCPViewerWiresharkSession *session);
@@ -171,12 +203,29 @@ TCPViewerWiresharkFollowResult *TCPViewerWiresharkSessionFinishFollowTCPStream(
 void TCPViewerWiresharkSessionCancelFollowTCPStream(TCPViewerWiresharkSession *session);
 TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyLastCriticalException(TCPViewerWiresharkSession *session);
 TCPViewerWiresharkExceptionReport *TCPViewerWiresharkSessionCopyNextCriticalException(TCPViewerWiresharkSession *session);
+TCPViewerDisplayFilterValidationResult *TCPViewerWiresharkValidateDisplayFilter(
+    const char *expression,
+    const char *personalConfigurationDirectory
+);
+TCPViewerDisplayFilterValidationResult *TCPViewerWiresharkSessionActivateDisplayFilter(
+    TCPViewerWiresharkSession *session,
+    const char *expression,
+    uint64_t generation
+);
+TCPViewerDisplayFilterMatchResult *TCPViewerWiresharkSessionEvaluateDisplayFilter(
+    TCPViewerWiresharkSession *session,
+    const TCPViewerWiresharkPacketContext *context,
+    uint64_t generation
+);
+void TCPViewerWiresharkSessionClearDisplayFilter(TCPViewerWiresharkSession *session);
 void TCPViewerWiresharkSummaryResultDestroy(TCPViewerWiresharkSummaryResult *result);
 void TCPViewerWiresharkInspectionResultDestroy(TCPViewerWiresharkInspectionResult *result);
 void TCPViewerWiresharkTCPStreamIndexResultDestroy(TCPViewerWiresharkTCPStreamIndexResult *result);
 void TCPViewerWiresharkFollowCandidateResultDestroy(TCPViewerWiresharkFollowCandidateResult *result);
 void TCPViewerWiresharkFollowResultDestroy(TCPViewerWiresharkFollowResult *result);
 void TCPViewerWiresharkExceptionReportDestroy(TCPViewerWiresharkExceptionReport *report);
+void TCPViewerDisplayFilterValidationResultDestroy(TCPViewerDisplayFilterValidationResult *result);
+void TCPViewerDisplayFilterMatchResultDestroy(TCPViewerDisplayFilterMatchResult *result);
 
 #if DEBUG
 TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(const char *personalConfigurationDirectory);

--- a/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
+++ b/PcapPlusPlusCore/Dissection/WiresharkEpanShim.h
@@ -230,6 +230,9 @@ void TCPViewerDisplayFilterMatchResultDestroy(TCPViewerDisplayFilterMatchResult 
 #if DEBUG
 TCPViewerWiresharkExceptionReport *TCPViewerWiresharkTestCopyCaughtExceptionReport(const char *personalConfigurationDirectory);
 bool TCPViewerWiresharkSessionTestInjectCriticalException(TCPViewerWiresharkSession *session);
+void TCPViewerWiresharkTestResetDisplayFilterCompilationCount(void);
+size_t TCPViewerWiresharkTestDisplayFilterCompilationCount(void);
+bool TCPViewerWiresharkSessionTestHasActiveDisplayFilter(TCPViewerWiresharkSession *session);
 #endif
 
 #ifdef __cplusplus

--- a/PcapPlusPlusCore/Dissection/WiresharkIPDisplayFilterPlugin.c
+++ b/PcapPlusPlusCore/Dissection/WiresharkIPDisplayFilterPlugin.c
@@ -1,0 +1,14 @@
+//
+//  WiresharkIPDisplayFilterPlugin.c
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+// Keep Wireshark's official IP display-filter functions available in the plugin-free embedded build.
+#define plugin_register TCPViewerWiresharkIPDisplayFilterPluginRegister
+#define plugin_describe TCPViewerWiresharkIPDisplayFilterPluginDescribe
+#define plugin_version TCPViewerWiresharkIPDisplayFilterPluginVersion
+#define plugin_want_major TCPViewerWiresharkIPDisplayFilterPluginWantMajor
+#define plugin_want_minor TCPViewerWiresharkIPDisplayFilterPluginWantMinor
+#include "../../Vendor/Wireshark/plugins/epan/dfilter/ipaddr/ipaddr.c"

--- a/PcapPlusPlusCore/Models/CoreProtocols.swift
+++ b/PcapPlusPlusCore/Models/CoreProtocols.swift
@@ -56,7 +56,67 @@ public protocol CaptureFilterValidating {
     func validateCaptureFilter(_ expression: String, completion: @escaping (CaptureFilterValidation) -> Void)
 }
 
-public protocol LiveCaptureSessionProviding: TCPStreamFollowing {
+public protocol DisplayFilterValidating {
+    func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void)
+}
+
+public protocol DisplayFilterEvaluating: DisplayFilterValidating {
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    )
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    )
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion)
+}
+
+public extension DisplayFilterValidating {
+    func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        let normalized = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        completion(DisplayFilterValidation(
+            normalizedExpression: normalized,
+            status: normalized.isEmpty ? .valid : .unavailable,
+            diagnostics: normalized.isEmpty ? [] : [DisplayFilterDiagnostic(
+                severity: .error,
+                message: "Wireshark display-filter validation is unavailable."
+            )]
+        ))
+    }
+}
+
+public extension DisplayFilterEvaluating {
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        _ = generation
+        validateDisplayFilter(expression, completion: completion)
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        _ = packetIDs
+        _ = generation
+        completion(.failure(TCPViewerCoreError(
+            code: .unavailableFeature,
+            message: "Wireshark display-filter evaluation is unavailable."
+        )))
+    }
+
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+}
+
+public protocol LiveCaptureSessionProviding: TCPStreamFollowing, DisplayFilterEvaluating {
     var eventHandler: PacketIngestEventHandler? { get set }
 
     func start(completion: @escaping TCPViewerVoidCompletion)
@@ -96,7 +156,7 @@ public extension LiveCaptureSessionProviding {
 }
 #endif
 
-public protocol OfflineCaptureDocumentProviding: TCPStreamFollowing {
+public protocol OfflineCaptureDocumentProviding: TCPStreamFollowing, DisplayFilterEvaluating {
     var eventHandler: PacketIngestEventHandler? { get set }
 
     func open(completion: @escaping TCPViewerCompletion<[PacketSummary]>)
@@ -192,6 +252,7 @@ public protocol OfflineCaptureProviding {
 public protocol TCPViewerCoreProviding:
     CaptureInterfaceProviding,
     CaptureFilterValidating,
+    DisplayFilterValidating,
     LiveCaptureProviding,
     OfflineCaptureProviding {}
 
@@ -221,6 +282,22 @@ public struct UnconfiguredTCPViewerCore: TCPViewerCoreProviding {
             disposition: .unavailable,
             normalizedExpression: trimmed,
             message: "Native capture-filter validation is not available in the unconfigured core."
+        ))
+    }
+
+    public func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        let normalized = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty {
+            completion(DisplayFilterValidation(normalizedExpression: "", status: .valid))
+            return
+        }
+        completion(DisplayFilterValidation(
+            normalizedExpression: normalized,
+            status: .unavailable,
+            diagnostics: [DisplayFilterDiagnostic(
+                severity: .error,
+                message: "Wireshark display-filter validation is unavailable in the unconfigured core."
+            )]
         ))
     }
 
@@ -293,6 +370,36 @@ public final class UnconfiguredLiveCaptureSession: LiveCaptureSessionProviding {
         completion(.failure(TCPViewerCoreError(code: .integrationMisconfigured, message: "Packet inspection is not wired into PcapPlusPlusCore yet.")))
     }
 
+    public func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        UnconfiguredTCPViewerCore().validateDisplayFilter(expression, completion: completion)
+    }
+
+    public func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        _ = generation
+        validateDisplayFilter(expression, completion: completion)
+    }
+
+    public func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        _ = packetIDs
+        _ = generation
+        completion(.failure(TCPViewerCoreError(
+            code: .integrationMisconfigured,
+            message: "Wireshark display-filter evaluation is unavailable in the unconfigured session."
+        )))
+    }
+
+    public func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
     public func exportPackets(
         withIDs identifiers: [PacketSummary.ID],
         to url: URL,
@@ -337,6 +444,36 @@ public final class UnconfiguredOfflineCaptureDocument: OfflineCaptureDocumentPro
     public func inspectPacket(id: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>) {
         _ = id
         completion(.failure(TCPViewerCoreError(code: .integrationMisconfigured, message: "Packet inspection is not wired into PcapPlusPlusCore yet.")))
+    }
+
+    public func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        UnconfiguredTCPViewerCore().validateDisplayFilter(expression, completion: completion)
+    }
+
+    public func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        _ = generation
+        validateDisplayFilter(expression, completion: completion)
+    }
+
+    public func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        _ = packetIDs
+        _ = generation
+        completion(.failure(TCPViewerCoreError(
+            code: .integrationMisconfigured,
+            message: "Wireshark display-filter evaluation is unavailable in the unconfigured document."
+        )))
+    }
+
+    public func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
     }
 
     public func save(completion: @escaping TCPViewerVoidCompletion) {

--- a/PcapPlusPlusCore/Models/DisplayFilterModels.swift
+++ b/PcapPlusPlusCore/Models/DisplayFilterModels.swift
@@ -1,0 +1,81 @@
+//
+//  DisplayFilterModels.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+
+public struct DisplayFilterSourceRange: Equatable, Sendable {
+    public let utf8StartOffset: Int
+    public let utf8Length: Int
+
+    public init(utf8StartOffset: Int, utf8Length: Int) {
+        self.utf8StartOffset = max(0, utf8StartOffset)
+        self.utf8Length = max(0, utf8Length)
+    }
+}
+
+public enum DisplayFilterDiagnosticSeverity: String, Equatable, Sendable {
+    case warning
+    case error
+}
+
+public struct DisplayFilterDiagnostic: Equatable, Sendable {
+    public let severity: DisplayFilterDiagnosticSeverity
+    public let message: String
+    public let range: DisplayFilterSourceRange?
+
+    public init(
+        severity: DisplayFilterDiagnosticSeverity,
+        message: String,
+        range: DisplayFilterSourceRange? = nil
+    ) {
+        self.severity = severity
+        self.message = message
+        self.range = range
+    }
+}
+
+public enum DisplayFilterValidationStatus: String, Equatable, Sendable {
+    case valid
+    case invalid
+    case unavailable
+}
+
+public struct DisplayFilterValidation: Equatable, Sendable {
+    public let normalizedExpression: String
+    public let status: DisplayFilterValidationStatus
+    public let diagnostics: [DisplayFilterDiagnostic]
+
+    public init(
+        normalizedExpression: String,
+        status: DisplayFilterValidationStatus,
+        diagnostics: [DisplayFilterDiagnostic] = []
+    ) {
+        self.normalizedExpression = normalizedExpression
+        self.status = status
+        self.diagnostics = diagnostics
+    }
+
+    public var isApplicable: Bool {
+        status == .valid
+    }
+}
+
+public struct DisplayFilterMatchBatch: Equatable, Sendable {
+    public let generation: UInt64
+    public let evaluatedPacketIDs: [PacketSummary.ID]
+    public let matchingPacketIDs: [PacketSummary.ID]
+
+    public init(
+        generation: UInt64,
+        evaluatedPacketIDs: [PacketSummary.ID],
+        matchingPacketIDs: [PacketSummary.ID]
+    ) {
+        self.generation = generation
+        self.evaluatedPacketIDs = evaluatedPacketIDs
+        self.matchingPacketIDs = matchingPacketIDs
+    }
+}

--- a/PcapPlusPlusCore/Services/Core/NativeTCPViewerCore.swift
+++ b/PcapPlusPlusCore/Services/Core/NativeTCPViewerCore.swift
@@ -55,6 +55,12 @@ public final class NativeTCPViewerCore: TCPViewerCoreProviding, @unchecked Senda
         }
     }
 
+    public func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        workerQueue.async {
+            completion(WiresharkEpanSession.validateDisplayFilter(expression))
+        }
+    }
+
     public func validateCaptureOptions(_ options: CaptureOptions, for interface: CaptureInterfaceSummary?) throws -> CaptureOptions {
         let normalized = options.normalizedForLiveCapture()
         return try normalized.validated(for: interface)

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -138,6 +138,7 @@ private struct InterfaceBuilder {
 
 private struct PCPPNativeOfflineDocumentState {
     var file: NativeCaptureFile
+    var recordIndexByIdentifier: [UInt64: Int]
     var partiallyLoaded = false
     var dissectionSession: WiresharkEpanSession?
     var currentURL: URL
@@ -182,6 +183,7 @@ final class PCPPNativeOfflineDocument {
         }
         self.state = Protected(PCPPNativeOfflineDocumentState(
             file: loadedFile,
+            recordIndexByIdentifier: Self.recordIndex(in: loadedFile),
             partiallyLoaded: loadedFile.isPartialResult,
             currentURL: url,
             currentFormat: loadedFormat
@@ -204,6 +206,7 @@ final class PCPPNativeOfflineDocument {
         }
         self.state = Protected(PCPPNativeOfflineDocumentState(
             file: loadedFile,
+            recordIndexByIdentifier: Self.recordIndex(in: loadedFile),
             partiallyLoaded: loadedFile.isPartialResult,
             currentURL: url,
             currentFormat: loadedFormat
@@ -241,13 +244,57 @@ final class PCPPNativeOfflineDocument {
 
     func inspectPacket(withIdentifier identifier: UInt64) throws -> PCPPNativePacketInspectionDescriptor {
         try state.write { state in
-            guard let record = state.file.records.first(where: { $0.identifier == identifier }) else {
+            guard let index = state.recordIndexByIdentifier[identifier],
+                  state.file.records.indices.contains(index) else {
                 throw NativeNSError(.fileReadFailed, "Packet \(identifier) is not available in the backing store.")
             }
+            let record = state.file.records[index]
             return try autoreleasepool {
                 try self.makePacketInspectionDescriptorSafely(record: record, state: &state)
             }
         }
+    }
+
+    func activateDisplayFilter(_ expression: String, generation: UInt64) throws -> DisplayFilterValidation {
+        try state.write { state in
+            let session = try prepareDisplayFilterSession(in: &state)
+            return session.activateDisplayFilter(expression, generation: generation)
+        }
+    }
+
+    func evaluateDisplayFilter(packetIDs: [UInt64], generation: UInt64) throws -> DisplayFilterMatchBatch {
+        guard packetIDs.count <= 128 else {
+            throw NativeNSError(.unavailableFeature, "Display-filter batches are limited to 128 packets.")
+        }
+        return try state.write { state in
+            guard let session = state.dissectionSession else {
+                throw NativeNSError(.unavailableFeature, "Wireshark display-filter evaluation is unavailable for this capture.")
+            }
+            var evaluatedPacketIDs: [UInt64] = []
+            var matchingPacketIDs: [UInt64] = []
+            evaluatedPacketIDs.reserveCapacity(packetIDs.count)
+            matchingPacketIDs.reserveCapacity(packetIDs.count)
+            for packetID in packetIDs {
+                guard let index = state.recordIndexByIdentifier[packetID],
+                      state.file.records.indices.contains(index) else {
+                    continue
+                }
+                let record = state.file.records[index]
+                if try session.evaluateDisplayFilter(record, generation: generation) {
+                    matchingPacketIDs.append(packetID)
+                }
+                evaluatedPacketIDs.append(packetID)
+            }
+            return DisplayFilterMatchBatch(
+                generation: generation,
+                evaluatedPacketIDs: evaluatedPacketIDs,
+                matchingPacketIDs: matchingPacketIDs
+            )
+        }
+    }
+
+    func clearDisplayFilter() {
+        state.write { $0.dissectionSession?.clearDisplayFilter() }
     }
 
     // Copy the selected conversation before retapping the document's loaded Wireshark session.
@@ -359,6 +406,7 @@ final class PCPPNativeOfflineDocument {
                 let loaded = try NativeCaptureFile.load(from: sourceURL)
                 try state.write {
                     $0.file = loaded
+                    $0.recordIndexByIdentifier = Self.recordIndex(in: loaded)
                     $0.currentFormat = loaded.format.rawValue
                     $0.partiallyLoaded = loaded.isPartialResult
                     $0.dissectionSession = try WiresharkEpanSession(disabled: disablesWireshark)
@@ -459,6 +507,29 @@ final class PCPPNativeOfflineDocument {
             throw NativeNSError(.unavailableFeature, "Wireshark libwireshark backend is unavailable.")
         }
         return dissectionSession
+    }
+
+    // Rebuild a complete first pass when another document previously owned process-global EPAN state.
+    private func prepareDisplayFilterSession(
+        in state: inout PCPPNativeOfflineDocumentState
+    ) throws -> WiresharkEpanSession {
+        let identifiers = state.file.records.map(\.identifier)
+        if let session = state.dissectionSession,
+           identifiers.isEmpty || session.canFollowObservedPackets(withIdentifiers: identifiers) {
+            return session
+        }
+
+        let session = try WiresharkEpanSession(disabled: disablesWireshark)
+        for record in state.file.records {
+            try session.observe(record)
+        }
+        try session.finishFirstPass()
+        state.dissectionSession = session
+        return session
+    }
+
+    private static func recordIndex(in file: NativeCaptureFile) -> [UInt64: Int] {
+        Dictionary(uniqueKeysWithValues: file.records.enumerated().map { ($0.element.identifier, $0.offset) })
     }
 
     private func makePacketSummaryDescriptorSafely(
@@ -805,6 +876,44 @@ final class PCPPNativeLiveSession {
         }
     }
 
+    func activateDisplayFilter(_ expression: String, generation: UInt64) throws -> DisplayFilterValidation {
+        try state.write { state in
+            let session = try prepareDisplayFilterSession(in: &state)
+            return session.activateDisplayFilter(expression, generation: generation)
+        }
+    }
+
+    func evaluateDisplayFilter(packetIDs: [UInt64], generation: UInt64) throws -> DisplayFilterMatchBatch {
+        guard packetIDs.count <= 128 else {
+            throw NativeNSError(.unavailableFeature, "Display-filter batches are limited to 128 packets.")
+        }
+        return try state.write { state in
+            guard let session = state.dissectionSession else {
+                throw NativeNSError(.unavailableFeature, "Wireshark display-filter evaluation is unavailable for this capture.")
+            }
+            let records = try state.packetStore.records(withIdentifiers: packetIDs)
+            var evaluatedPacketIDs: [UInt64] = []
+            var matchingPacketIDs: [UInt64] = []
+            evaluatedPacketIDs.reserveCapacity(records.count)
+            matchingPacketIDs.reserveCapacity(records.count)
+            for record in records {
+                if try session.evaluateDisplayFilter(record, generation: generation) {
+                    matchingPacketIDs.append(record.identifier)
+                }
+                evaluatedPacketIDs.append(record.identifier)
+            }
+            return DisplayFilterMatchBatch(
+                generation: generation,
+                evaluatedPacketIDs: evaluatedPacketIDs,
+                matchingPacketIDs: matchingPacketIDs
+            )
+        }
+    }
+
+    func clearDisplayFilter() {
+        state.write { $0.dissectionSession?.clearDisplayFilter() }
+    }
+
     // Follow a duplicated disk snapshot without blocking live packet storage during the retap.
     func followTCPStream(
         containing identifier: UInt64,
@@ -1084,6 +1193,32 @@ final class PCPPNativeLiveSession {
         state.dissectionSession = nil
         state.hadWorkingDissectionSession = false
         state.statusMessage = "Wireshark details are unavailable; capture continues with the Swift dissector. \(message)"
+    }
+
+    // Rehydrate stopped live captures once, while active captures keep their incremental first pass.
+    private func prepareDisplayFilterSession(
+        in state: inout PCPPNativeLiveSessionState
+    ) throws -> WiresharkEpanSession {
+        if let session = state.dissectionSession,
+           state.phase == .running || state.phase == .paused {
+            return session
+        }
+
+        let records = try state.packetStore.records(withIdentifiers: nil)
+        let identifiers = records.map(\.identifier)
+        if let session = state.dissectionSession,
+           identifiers.isEmpty || session.canFollowObservedPackets(withIdentifiers: identifiers) {
+            return session
+        }
+
+        let session = try WiresharkEpanSession()
+        for record in records {
+            try session.observe(record)
+        }
+        try session.finishFirstPass()
+        state.dissectionSession = session
+        state.hadWorkingDissectionSession = true
+        return session
     }
 
     private func healthDescriptor(status: String?, state: PCPPNativeLiveSessionState) -> PCPPNativeCaptureHealthDescriptor {

--- a/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
+++ b/PcapPlusPlusCore/Services/Core/SwiftNativeCore.swift
@@ -1199,20 +1199,12 @@ final class PCPPNativeLiveSession {
     private func prepareDisplayFilterSession(
         in state: inout PCPPNativeLiveSessionState
     ) throws -> WiresharkEpanSession {
-        if let session = state.dissectionSession,
-           state.phase == .running || state.phase == .paused {
-            return session
-        }
-
-        let records = try state.packetStore.records(withIdentifiers: nil)
-        let identifiers = records.map(\.identifier)
-        if let session = state.dissectionSession,
-           identifiers.isEmpty || session.canFollowObservedPackets(withIdentifiers: identifiers) {
+        if let session = state.dissectionSession {
             return session
         }
 
         let session = try WiresharkEpanSession()
-        for record in records {
+        try state.packetStore.forEachRecord { record in
             try session.observe(record)
         }
         try session.finishFirstPass()

--- a/PcapPlusPlusCore/Services/DisplayFilterEvaluationCoordinator.swift
+++ b/PcapPlusPlusCore/Services/DisplayFilterEvaluationCoordinator.swift
@@ -1,0 +1,18 @@
+//
+//  DisplayFilterEvaluationCoordinator.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+
+enum DisplayFilterEvaluationCoordinator {
+    private static let lock = NSLock()
+
+    static func perform<Value>(_ work: () throws -> Value) rethrows -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return try work()
+    }
+}

--- a/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
+++ b/PcapPlusPlusCore/Services/LiveCapture/NativeLiveCaptureSession.swift
@@ -49,6 +49,30 @@ public final class NativeLiveCaptureSession: LiveCaptureSessionProviding, @unche
         state.inspectPacket(id: id, completion: completion)
     }
 
+    public func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        state.validateDisplayFilter(expression, completion: completion)
+    }
+
+    public func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        state.activateDisplayFilter(expression, generation: generation, completion: completion)
+    }
+
+    public func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        state.evaluateDisplayFilter(packetIDs: packetIDs, generation: generation, completion: completion)
+    }
+
+    public func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        state.clearDisplayFilter(completion: completion)
+    }
+
     public func followTCPStream(
         containing packetID: PacketSummary.ID,
         limits: TCPFollowLimits,
@@ -465,6 +489,65 @@ private final class NativeLiveCaptureSessionState: @unchecked Sendable {
             completion(Result {
                 try self.inspectPacketOnQueue(id: id)
             })
+        }
+    }
+
+    func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        queue.async {
+            completion(WiresharkEpanSession.validateDisplayFilter(expression))
+        }
+    }
+
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        queue.async {
+            do {
+                completion(try DisplayFilterEvaluationCoordinator.perform {
+                    try self.nativeSession.activateDisplayFilter(expression, generation: generation)
+                })
+            } catch {
+                completion(DisplayFilterValidation(
+                    normalizedExpression: expression.trimmingCharacters(in: .whitespacesAndNewlines),
+                    status: .unavailable,
+                    diagnostics: [DisplayFilterDiagnostic(
+                        severity: .error,
+                        message: NativeBridgeMapper.coreError(error, defaultCode: .unavailableFeature).message
+                    )]
+                ))
+            }
+        }
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        queue.async {
+            completion(Result {
+                do {
+                    return try DisplayFilterEvaluationCoordinator.perform {
+                        try self.nativeSession.evaluateDisplayFilter(
+                            packetIDs: packetIDs,
+                            generation: generation
+                        )
+                    }
+                } catch {
+                    throw NativeBridgeMapper.coreError(error, defaultCode: .unavailableFeature)
+                }
+            })
+        }
+    }
+
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        queue.async {
+            DisplayFilterEvaluationCoordinator.perform {
+                self.nativeSession.clearDisplayFilter()
+            }
+            completion(.success(()))
         }
     }
 

--- a/PcapPlusPlusCore/Services/LiveCapture/NativeLivePacketDiskStore.swift
+++ b/PcapPlusPlusCore/Services/LiveCapture/NativeLivePacketDiskStore.swift
@@ -273,6 +273,15 @@ final class NativeLivePacketDiskStore {
         }
     }
 
+    // Read and release one packet payload at a time while rebuilding stateful dissector sessions.
+    func forEachRecord(_ body: (NativePacketRecord) throws -> Void) throws {
+        for entry in entries {
+            try autoreleasepool {
+                try body(record(for: entry))
+            }
+        }
+    }
+
     func records(matching identifiers: Set<UInt64>) throws -> [NativePacketRecord] {
         try entries.compactMap { entry in
             guard identifiers.contains(entry.identifier) else {

--- a/PcapPlusPlusCore/Services/OfflineCapture/NativeOfflineCaptureDocument.swift
+++ b/PcapPlusPlusCore/Services/OfflineCapture/NativeOfflineCaptureDocument.swift
@@ -36,6 +36,30 @@ public final class NativeOfflineCaptureDocument: OfflineCaptureDocumentProviding
         state.inspectPacket(id: id, completion: completion)
     }
 
+    public func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        state.validateDisplayFilter(expression, completion: completion)
+    }
+
+    public func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        state.activateDisplayFilter(expression, generation: generation, completion: completion)
+    }
+
+    public func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        state.evaluateDisplayFilter(packetIDs: packetIDs, generation: generation, completion: completion)
+    }
+
+    public func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        state.clearDisplayFilter(completion: completion)
+    }
+
     public func followTCPStream(
         containing packetID: PacketSummary.ID,
         limits: TCPFollowLimits,
@@ -241,6 +265,65 @@ private final class NativeOfflineCaptureDocumentState: @unchecked Sendable {
                     throw NativeBridgeMapper.coreError(error, defaultCode: .offlineFileOpenFailed)
                 }
             })
+        }
+    }
+
+    func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        stateQueue.async {
+            completion(WiresharkEpanSession.validateDisplayFilter(expression))
+        }
+    }
+
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        stateQueue.async {
+            do {
+                completion(try DisplayFilterEvaluationCoordinator.perform {
+                    try self.nativeDocument.activateDisplayFilter(expression, generation: generation)
+                })
+            } catch {
+                completion(DisplayFilterValidation(
+                    normalizedExpression: expression.trimmingCharacters(in: .whitespacesAndNewlines),
+                    status: .unavailable,
+                    diagnostics: [DisplayFilterDiagnostic(
+                        severity: .error,
+                        message: NativeBridgeMapper.coreError(error, defaultCode: .unavailableFeature).message
+                    )]
+                ))
+            }
+        }
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        stateQueue.async {
+            completion(Result {
+                do {
+                    return try DisplayFilterEvaluationCoordinator.perform {
+                        try self.nativeDocument.evaluateDisplayFilter(
+                            packetIDs: packetIDs,
+                            generation: generation
+                        )
+                    }
+                } catch {
+                    throw NativeBridgeMapper.coreError(error, defaultCode: .unavailableFeature)
+                }
+            })
+        }
+    }
+
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        stateQueue.async {
+            DisplayFilterEvaluationCoordinator.perform {
+                self.nativeDocument.clearDisplayFilter()
+            }
+            completion(.success(()))
         }
     }
 

--- a/PcapPlusPlusCoreTests/Dissection/WiresharkDisplayFilterTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/WiresharkDisplayFilterTests.swift
@@ -32,24 +32,25 @@ struct WiresharkDisplayFilterTests {
     }
 
     @Test func invalidSyntaxReturnsNativeRangesAndMessages() {
-        var rangedDiagnosticCount = 0
-        for expression in [
-            "unknown.tcpviewer.field == 1",
-            "tcp.port ==",
-            "(tcp.port == 443",
-            "tcp.port in {80,",
-            "tcp.port == \"https\"",
-            "http.host matches \"[\"",
-        ] {
+        let cases: [(name: String, expression: String, expectedRange: DisplayFilterSourceRange?)] = [
+            ("unknown field", "unknown.tcpviewer.field == 1", DisplayFilterSourceRange(utf8StartOffset: 0, utf8Length: 23)),
+            ("missing operand", "tcp.port ==", nil),
+            ("unclosed parenthesis", "(tcp.port == 443", nil),
+            ("unclosed set", "tcp.port in {80,", nil),
+            ("missing quote", "http.host == \"unterminated", DisplayFilterSourceRange(utf8StartOffset: 26, utf8Length: 0)),
+            ("incompatible literal", "tcp.port == \"https\"", DisplayFilterSourceRange(utf8StartOffset: 12, utf8Length: 7)),
+            ("invalid regular expression", "http.host matches \"[\"", DisplayFilterSourceRange(utf8StartOffset: 18, utf8Length: 3)),
+            ("UTF-8 byte offset", "http.host == \"é\" and unknown.tcpviewer.field == 1", DisplayFilterSourceRange(utf8StartOffset: 22, utf8Length: 23)),
+        ]
+
+        for testCase in cases {
+            let expression = testCase.expression
             let validation = WiresharkEpanSession.validateDisplayFilter(expression)
-            #expect(validation.status == .invalid)
-            #expect(validation.diagnostics.first?.severity == .error)
-            #expect(validation.diagnostics.first?.message.isEmpty == false)
-            if validation.diagnostics.first?.range != nil {
-                rangedDiagnosticCount += 1
-            }
+            #expect(validation.status == .invalid, "\(testCase.name) unexpectedly compiled")
+            #expect(validation.diagnostics.first?.severity == .error, "\(testCase.name) lacked an error")
+            #expect(validation.diagnostics.first?.message.isEmpty == false, "\(testCase.name) lacked a message")
+            #expect(validation.diagnostics.first?.range == testCase.expectedRange, "\(testCase.name) range drifted")
         }
-        #expect(rangedDiagnosticCount >= 3)
     }
 
     @Test func dollarTokensAreRejectedOnlyOutsideStringLiterals() {
@@ -79,6 +80,23 @@ struct WiresharkDisplayFilterTests {
         #expect(validation.diagnostics.contains { diagnostic in
             diagnostic.severity == .warning && diagnostic.message.localizedCaseInsensitiveContains("deprecated")
         })
+    }
+
+    @Test func activationCompilesOncePerGenerationAndClearReleasesTheFilter() throws {
+        let session = try WiresharkEpanSession()
+        WiresharkEpanSession.testResetDisplayFilterCompilationCount()
+
+        #expect(session.activateDisplayFilter("tcp", generation: 7).status == .valid)
+        #expect(session.activateDisplayFilter("tcp", generation: 7).status == .valid)
+        #expect(WiresharkEpanSession.testDisplayFilterCompilationCount == 1)
+        #expect(session.testHasActiveDisplayFilter)
+
+        #expect(session.activateDisplayFilter("tcp.port ==", generation: 8).status == .invalid)
+        #expect(WiresharkEpanSession.testDisplayFilterCompilationCount == 2)
+        #expect(session.testHasActiveDisplayFilter)
+
+        session.clearDisplayFilter()
+        #expect(!session.testHasActiveDisplayFilter)
     }
 
     private static let syntaxCategories: [SyntaxCategory] = [

--- a/PcapPlusPlusCoreTests/Dissection/WiresharkDisplayFilterTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/WiresharkDisplayFilterTests.swift
@@ -34,9 +34,9 @@ struct WiresharkDisplayFilterTests {
     @Test func invalidSyntaxReturnsNativeRangesAndMessages() {
         let cases: [(name: String, expression: String, expectedRange: DisplayFilterSourceRange?)] = [
             ("unknown field", "unknown.tcpviewer.field == 1", DisplayFilterSourceRange(utf8StartOffset: 0, utf8Length: 23)),
-            ("missing operand", "tcp.port ==", nil),
-            ("unclosed parenthesis", "(tcp.port == 443", nil),
-            ("unclosed set", "tcp.port in {80,", nil),
+            ("missing operand", "tcp.port ==", DisplayFilterSourceRange(utf8StartOffset: 11, utf8Length: 0)),
+            ("unclosed parenthesis", "(tcp.port == 443", DisplayFilterSourceRange(utf8StartOffset: 16, utf8Length: 0)),
+            ("unclosed set", "tcp.port in {80,", DisplayFilterSourceRange(utf8StartOffset: 16, utf8Length: 0)),
             ("missing quote", "http.host == \"unterminated", DisplayFilterSourceRange(utf8StartOffset: 26, utf8Length: 0)),
             ("incompatible literal", "tcp.port == \"https\"", DisplayFilterSourceRange(utf8StartOffset: 12, utf8Length: 7)),
             ("invalid regular expression", "http.host matches \"[\"", DisplayFilterSourceRange(utf8StartOffset: 18, utf8Length: 3)),

--- a/PcapPlusPlusCoreTests/Dissection/WiresharkDisplayFilterTests.swift
+++ b/PcapPlusPlusCoreTests/Dissection/WiresharkDisplayFilterTests.swift
@@ -1,0 +1,169 @@
+//
+//  WiresharkDisplayFilterTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+import Testing
+@testable import PcapPlusPlusCore
+
+@Suite(.serialized)
+struct WiresharkDisplayFilterTests {
+    private struct SyntaxCategory {
+        let name: String
+        let expressions: [String]
+    }
+
+    @Test func stableSyntaxChecklistCompilesEverySupportedCategory() {
+        let categories = Self.syntaxCategories
+        #expect(categories.count == 18)
+
+        for category in categories {
+            for expression in category.expressions {
+                let validation = WiresharkEpanSession.validateDisplayFilter(expression)
+                #expect(
+                    validation.status == .valid,
+                    "\(category.name) rejected `\(expression)`: \(validation.diagnostics.map(\.message))"
+                )
+            }
+        }
+    }
+
+    @Test func invalidSyntaxReturnsNativeRangesAndMessages() {
+        var rangedDiagnosticCount = 0
+        for expression in [
+            "unknown.tcpviewer.field == 1",
+            "tcp.port ==",
+            "(tcp.port == 443",
+            "tcp.port in {80,",
+            "tcp.port == \"https\"",
+            "http.host matches \"[\"",
+        ] {
+            let validation = WiresharkEpanSession.validateDisplayFilter(expression)
+            #expect(validation.status == .invalid)
+            #expect(validation.diagnostics.first?.severity == .error)
+            #expect(validation.diagnostics.first?.message.isEmpty == false)
+            if validation.diagnostics.first?.range != nil {
+                rangedDiagnosticCount += 1
+            }
+        }
+        #expect(rangedDiagnosticCount >= 3)
+    }
+
+    @Test func dollarTokensAreRejectedOnlyOutsideStringLiterals() {
+        let macro = WiresharkEpanSession.validateDisplayFilter("$private_ipv4(ip.src)")
+        #expect(macro.status == .invalid)
+        #expect(macro.diagnostics.first?.range == DisplayFilterSourceRange(utf8StartOffset: 0, utf8Length: 13))
+
+        let selectedField = WiresharkEpanSession.validateDisplayFilter("frame.number < $frame.number")
+        #expect(selectedField.status == .invalid)
+        #expect(selectedField.diagnostics.first?.range == DisplayFilterSourceRange(utf8StartOffset: 15, utf8Length: 13))
+
+        #expect(WiresharkEpanSession.validateDisplayFilter("http.host == \"$value\"").status == .valid)
+        #expect(WiresharkEpanSession.validateDisplayFilter("http.host == r\"$value\"").status == .valid)
+    }
+
+    @Test func blankInputIsAValidClearOperation() {
+        let validation = WiresharkEpanSession.validateDisplayFilter("  \n\t ")
+        #expect(validation.status == .valid)
+        #expect(validation.normalizedExpression.isEmpty)
+        #expect(validation.diagnostics.isEmpty)
+    }
+
+    @Test func deprecatedTokenRemainsApplicableAndReportsAWarning() {
+        let validation = WiresharkEpanSession.validateDisplayFilter("bootp")
+
+        #expect(validation.status == .valid)
+        #expect(validation.diagnostics.contains { diagnostic in
+            diagnostic.severity == .warning && diagnostic.message.localizedCaseInsensitiveContains("deprecated")
+        })
+    }
+
+    private static let syntaxCategories: [SyntaxCategory] = [
+        SyntaxCategory(name: "field existence and columns", expressions: [
+            "frame",
+            "tcp.port",
+            "_ws.col.info",
+            "len(_ws.col.protocol) >= 0",
+        ]),
+        SyntaxCategory(name: "comparison operands", expressions: [
+            "ip.proto == 6",
+            "tcp.srcport == tcp.dstport",
+            "len(frame) > 0",
+        ]),
+        SyntaxCategory(name: "comparison aliases", expressions: [
+            "ip.version eq 4", "ip.version ne 6", "ip.version gt 1", "ip.version lt 7",
+            "ip.version ge 4", "ip.version le 4", "ip.version == 4", "ip.version != 6",
+            "ip.version > 1", "ip.version < 7", "ip.version >= 4", "ip.version <= 4",
+        ]),
+        SyntaxCategory(name: "multi occurrence", expressions: [
+            "udp.port === 53", "udp.port !== 53", "any ip.addr > 1.1.1.1", "all ip.addr > 1.1.1.1",
+            "tcp.port any_eq 443", "tcp.port all_eq 443", "tcp.port any_ne 443", "tcp.port all_ne 443",
+        ]),
+        SyntaxCategory(name: "contains and regex", expressions: [
+            "tcp.payload contains \"GET\"",
+            "http.request.method matches \"(?i)^get$\"",
+            "http.request.method ~ r\"^GET$\"",
+        ]),
+        SyntaxCategory(name: "logical operators", expressions: [
+            "not tcp", "!udp", "tcp and ip", "tcp && ip", "tcp xor udp", "tcp ^^ udp",
+            "tcp or udp", "tcp || udp", "tcp or udp and ip", "(tcp or udp) and ip",
+        ]),
+        SyntaxCategory(name: "numeric boolean and time literals", expressions: [
+            "frame.len > 10", "frame.len > 012", "frame.len > 0xa", "frame.len > 0b1010",
+            "frame.len > 'P'", "frame.ignored == true", "icmp.resptime > 1.25",
+            "frame.time > \"2002-12-31 13:54:31.3 UTC\"",
+        ]),
+        SyntaxCategory(name: "typed literals", expressions: [
+            "http.request.method == \"\\u00e9\"",
+            "smb.path contains r\"\\SERVER\\SHARE\"",
+            "tcp.payload contains 47:45:54",
+            "eth.addr == 00:11:22:33:44:55",
+            "thread_bcn.epid == 00:11:22:33:44:55:66:77",
+            "ip.addr == 192.168.1.1", "ipv6.addr == 2001:db8::1",
+            "ip.addr == 192.168.0.0/16", "typeinfo.guid == 00000000-0000-0000-0000-000000000000",
+            "snmp.name == 1.3.6.1",
+        ]),
+        SyntaxCategory(name: "slices", expressions: [
+            "frame[5:5] == 11:22:33:44:55", "frame[5-10] == 11:22:33:44:55:66",
+            "frame[5] == 11", "frame[:20] contains be:ef", "frame[20:] contains 12:34",
+            "frame[-4:] contains 12:34", "frame[0:2,4:2] contains 00:01",
+        ]),
+        SyntaxCategory(name: "layer and raw field", expressions: [
+            "ip.addr#2 == 4.4.4.4", "ip.dst#[-1] == 8.8.8.8", "@tcp.port[1] == 0xc3",
+        ]),
+        SyntaxCategory(name: "membership", expressions: [
+            "tcp.port in {80, 443, 8080}", "tcp.port in {4430..4434}",
+            "ip.addr in {10.0.0.5 .. 10.0.0.9}", "frame.time_delta in {10 .. 10.5}",
+        ]),
+        SyntaxCategory(name: "implicit conversions", expressions: [
+            "tcp.payload contains \"GET\"", "frame[60:2] gt \"PQ\"", "tcp.checksum.status == \"Unverified\"",
+        ]),
+        SyntaxCategory(name: "bitwise aliases", expressions: [
+            "tcp.flags & 0x8", "tcp.flags bitand 0x8", "tcp.flags bitwise_and 0x8",
+        ]),
+        SyntaxCategory(name: "arithmetic", expressions: [
+            "udp.dstport == udp.srcport + 1", "udp.srcport == udp.dstport - 1",
+            "udp.port * {10 / {5 - 4}} >= 0", "frame.len % 2 == 0",
+        ]),
+        SyntaxCategory(name: "built in functions", expressions: [
+            "upper(http.host) contains \"EXAMPLE\"", "lower(http.host) contains \"example\"",
+            "len(frame) > 0", "count(ip.addr) >= 0", "string(frame.number) matches \"[0-9]+\"",
+            "vals(tls.handshake.type) contains \"Client\"", "dec(frame.number) == \"1\"",
+            "hex(frame.number) == \"1\"", "float(frame.number) >= 0", "double(frame.number) >= 0",
+            "max(tcp.srcport, tcp.dstport) >= 0", "min(tcp.srcport, tcp.dstport) >= 0", "udp.dstport == abs(-67)",
+        ]),
+        SyntaxCategory(name: "IP functions", expressions: [
+            "ip_special_name(ip.addr) contains \"\"", "ip_special_mask(ip.addr) >= 0",
+            "ip_linklocal(ip.addr)", "ip_multicast(ip.addr)", "ip_rfc1918(ip.addr)", "ip_ula(ipv6.addr)",
+        ]),
+        SyntaxCategory(name: "warnings and deprecated forms", expressions: [
+            "bootp", "tcp.checksum.status == Unverified",
+        ]),
+        SyntaxCategory(name: "explicit unsupported tokens", expressions: [
+            "http.host == \"$literal\"", "http.host == r\"$literal\"",
+        ]),
+    ]
+}

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -509,6 +509,77 @@ struct InspectorPipelineTests {
         #expect(preservedBatch.matchingPacketIDs == [clientHello.id])
     }
 
+    @Test func wiresharkDisplayFilterSemanticsMatchAcrossPcapAndPcapNg() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let httpConversation = makeIPv4HTTPConversationPackets()
+        let rawPackets = [
+            makeIPv4TCPPayloadPacket(),
+            makeIPv4UDPPayloadPacket(),
+            makeIPv4DNSResponsePacket(),
+            httpConversation[0],
+            httpConversation[1],
+            httpConversation[2],
+            makeIPv4TLSClientHelloPacket(hostName: "api.example.com"),
+            makeIPv6UDPPayloadPacket(),
+            makeUnknownEtherTypePacket(etherType: 0xb681, byteCount: 66),
+        ]
+        let pcapURL = directory.appendingPathComponent("display-filter-semantics.pcap")
+        let pcapNGURL = directory.appendingPathComponent("display-filter-semantics.pcapng")
+        try writePCAP(to: pcapURL, packets: rawPackets)
+        try writePCAPNG(
+            to: pcapNGURL,
+            interfaces: ["test0"],
+            packets: rawPackets.map { (packet: $0, interfaceID: 0) }
+        )
+
+        let expectedPacketNumbersByExpression: [(String, [UInt64])] = [
+            ("tcp", [1, 4, 5, 6, 7]),
+            ("udp", [2, 3, 8]),
+            ("dns", [3]),
+            ("http.request.method == \"GET\"", [6]),
+            ("tls.handshake.extensions_server_name == \"api.example.com\"", [7]),
+            ("ip.version == 4", [1, 2, 3, 4, 5, 6, 7]),
+            ("ipv6 && udp", [8]),
+            ("tcp.port any_eq 443", [7]),
+            ("tcp.payload[0:3] == 47:45:54", [6]),
+            ("http.host matches r\"(?i)^example\\.com$\"", [6]),
+            ("upper(http.host) == \"EXAMPLE.COM\"", [6]),
+            ("_ws.col.protocol == \"HTTP\"", [6]),
+            ("udp.dstport == udp.srcport + 1000", [2]),
+            ("frame[0:2] == 66:77", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            ("eth.type#1 == 0x0800", [1, 2, 3, 4, 5, 6, 7]),
+            ("@tcp.srcport == d4:31", [4, 6, 7]),
+            ("count(ip.addr) == 2", [1, 2, 3, 4, 5, 6, 7]),
+            ("any ip.addr == 192.168.0.1", [1, 2, 3, 4, 5, 6, 7]),
+        ]
+
+        for captureURL in [pcapURL, pcapNGURL] {
+            let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: captureURL)
+            let packets = try await document.open()
+
+            for (offset, expectation) in expectedPacketNumbersByExpression.enumerated() {
+                let generation = UInt64(offset + 1)
+                let validation = await document.activateDisplayFilter(expectation.0, generation: generation)
+                #expect(validation.status == .valid, "Rejected `\(expectation.0)` in \(captureURL.lastPathComponent)")
+                guard validation.isApplicable else {
+                    continue
+                }
+                let batch = try await document.evaluateDisplayFilter(
+                    packetIDs: packets.map(\.id),
+                    generation: generation
+                )
+                let matches = Set(batch.matchingPacketIDs)
+                let matchingPacketNumbers = packets.filter { matches.contains($0.id) }.map(\.packetNumber)
+                #expect(
+                    matchingPacketNumbers == expectation.1,
+                    "`\(expectation.0)` drifted in \(captureURL.lastPathComponent)"
+                )
+            }
+        }
+    }
+
     @Test func splitTCPTLSClientHelloProducesSNIFromWiresharkState() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -1577,6 +1648,41 @@ Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
     )
 }
 
+private func makeIPv4HTTPConversationPackets() -> [Data] {
+    let request = Array("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".utf8)
+    return [
+        makeIPv4TCPPacket(
+            sourcePort: 54_321,
+            destinationPort: 80,
+            identification: 0x2240,
+            sequenceNumber: 100,
+            acknowledgementNumber: 0,
+            flags: 0x02,
+            payload: []
+        ),
+        makeIPv4TCPPacket(
+            sourcePort: 80,
+            destinationPort: 54_321,
+            identification: 0x2241,
+            sequenceNumber: 200,
+            acknowledgementNumber: 101,
+            sourceIPv4: [0xc0, 0xa8, 0x00, 0x02],
+            destinationIPv4: [0xc0, 0xa8, 0x00, 0x01],
+            flags: 0x12,
+            payload: []
+        ),
+        makeIPv4TCPPacket(
+            sourcePort: 54_321,
+            destinationPort: 80,
+            identification: 0x2242,
+            sequenceNumber: 101,
+            acknowledgementNumber: 201,
+            flags: 0x18,
+            payload: request
+        ),
+    ]
+}
+
 private func makeIPv4WebSocketTextFramePacket() -> Data {
     makeIPv4TCPPacket(
         sourcePort: 54_321,
@@ -1598,6 +1704,7 @@ private func makeIPv4TCPPacket(
     acknowledgementNumber: UInt32 = 1,
     sourceIPv4: [UInt8] = [0xc0, 0xa8, 0x00, 0x01],
     destinationIPv4: [UInt8] = [0xc0, 0xa8, 0x00, 0x02],
+    flags: UInt8 = 0x18,
     payload: [UInt8]
 ) -> Data {
     let ipv4TotalLength = UInt16(20 + 20 + payload.count)
@@ -1619,7 +1726,7 @@ private func makeIPv4TCPPacket(
     packet.appendBigEndian(sequenceNumber)
     packet.appendBigEndian(acknowledgementNumber)
     packet.append(contentsOf: [
-        0x50, 0x18, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x50, flags, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
     ])
     packet.append(contentsOf: payload)
     return packet

--- a/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
+++ b/PcapPlusPlusCoreTests/Services/Core/InspectorPipelineTests.swift
@@ -476,6 +476,39 @@ struct InspectorPipelineTests {
         #expect(findNode(in: tlsNode.children, fieldName: "tls.handshake.extensions_server_name")?.value == "www.google.com")
     }
 
+    @Test func wiresharkDisplayFilterMatchesSNIAndKeepsPreviousFilterAfterInvalidApply() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let captureURL = directory.appendingPathComponent("display-filter-sni.pcap")
+        let hostName = "display-filter.example"
+        try writePCAP(
+            to: captureURL,
+            packets: [
+                makeIPv4TLSClientHelloPacket(hostName: hostName),
+                makeIPv4TLSServerHelloPacket(),
+            ]
+        )
+
+        let document = try await NativeTCPViewerCore().openOfflineCaptureDocument(at: captureURL)
+        let packets = try await document.open()
+        let clientHello = try #require(packets.first)
+        let expression = "tls.handshake.extensions_server_name == \"\(hostName)\""
+
+        let validation = await document.activateDisplayFilter(expression, generation: 41)
+        #expect(validation.status == .valid)
+
+        let firstBatch = try await document.evaluateDisplayFilter(packetIDs: packets.map(\.id), generation: 41)
+        #expect(firstBatch.evaluatedPacketIDs == packets.map(\.id))
+        #expect(firstBatch.matchingPacketIDs == [clientHello.id])
+
+        let invalid = await document.activateDisplayFilter("tcp.port ==", generation: 42)
+        #expect(invalid.status == .invalid)
+
+        let preservedBatch = try await document.evaluateDisplayFilter(packetIDs: packets.map(\.id), generation: 41)
+        #expect(preservedBatch.matchingPacketIDs == [clientHello.id])
+    }
+
     @Test func splitTCPTLSClientHelloProducesSNIFromWiresharkState() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/PcapPlusPlusCoreTests/Services/LiveCapture/LiveCaptureLifecycleTests.swift
+++ b/PcapPlusPlusCoreTests/Services/LiveCapture/LiveCaptureLifecycleTests.swift
@@ -184,6 +184,55 @@ struct LiveCaptureLifecycleTests {
         #expect(try offlineSession.summarize(record).infoSummary.isEmpty == false)
     }
 
+    @Test func displayFilterSemanticsMatchRunningAndStoppedLivePackets() throws {
+        let udpPacket = makeUDPPacketRecord().rawBytes
+        let tcpPacket = makeLiveTCPPacket(
+            identifier: 2,
+            sourceIsClient: true,
+            sequence: 100,
+            acknowledgment: 0,
+            flags: 0x02
+        )
+        let reads = [udpPacket, tcpPacket].enumerated().map { index, packet in
+            let header = pcap_pkthdr(
+                ts: timeval(tv_sec: index + 1, tv_usec: 0),
+                caplen: UInt32(packet.count),
+                len: UInt32(packet.count)
+            )
+            return LibpcapPacketReadResult.packet(header: header, bytes: packet)
+        }
+        let backend = TestLiveCaptureBackend(queuedReads: reads)
+        let session = PCPPNativeLiveSession(
+            interfaceIdentifier: "test0",
+            options: makeOptions(),
+            captureBackend: backend,
+            dissectionSessionFactory: { try WiresharkEpanSession(purpose: .live) }
+        )
+        defer { session.shutdown() }
+        let packetDelivered = DispatchSemaphore(value: 0)
+        session.packetHandler = { _ in packetDelivered.signal() }
+
+        try session.start()
+        #expect(packetDelivered.wait(timeout: .now() + 2) == .success)
+        #expect(packetDelivered.wait(timeout: .now() + 2) == .success)
+
+        #expect(try session.activateDisplayFilter("udp", generation: 1).status == .valid)
+        let runningUDP = try session.evaluateDisplayFilter(packetIDs: [1, 2], generation: 1)
+        #expect(runningUDP.evaluatedPacketIDs == [1, 2])
+        #expect(runningUDP.matchingPacketIDs == [1])
+
+        #expect(try session.activateDisplayFilter("tcp", generation: 2).status == .valid)
+        let runningTCP = try session.evaluateDisplayFilter(packetIDs: [1, 2], generation: 2)
+        #expect(runningTCP.matchingPacketIDs == [2])
+
+        try session.stop()
+
+        #expect(try session.activateDisplayFilter("udp", generation: 3).status == .valid)
+        let stoppedUDP = try session.evaluateDisplayFilter(packetIDs: [1, 2], generation: 3)
+        #expect(stoppedUDP.evaluatedPacketIDs == [1, 2])
+        #expect(stoppedUDP.matchingPacketIDs == [1])
+    }
+
     @Test func stoppedLiveCaptureCanFollowRetainedTCPStream() throws {
         let packets = [
             makeLiveTCPPacket(identifier: 1, sourceIsClient: true, sequence: 100, acknowledgment: 0, flags: 0x02),

--- a/PcapPlusPlusCoreTests/Services/LiveCapture/NativeLivePacketDiskSnapshotTests.swift
+++ b/PcapPlusPlusCoreTests/Services/LiveCapture/NativeLivePacketDiskSnapshotTests.swift
@@ -78,6 +78,21 @@ struct NativeLivePacketDiskSnapshotTests {
         #expect(try snapshot.records(maximumBytes: 3).map(\.identifier) == [1, 2, 3])
     }
 
+    @Test func recordReplayVisitsDiskPayloadsOneAtATimeInCaptureOrder() throws {
+        let store = NativeLivePacketDiskStore()
+        try store.append(makeRecord(identifier: 1, byte: 0x11))
+        try store.append(makeRecord(identifier: 2, byte: 0x22))
+        try store.append(makeRecord(identifier: 3, byte: 0x33))
+        var visited: [(UInt64, Data)] = []
+
+        try store.forEachRecord { record in
+            visited.append((record.identifier, record.rawBytes))
+        }
+
+        #expect(visited.map(\.0) == [1, 2, 3])
+        #expect(visited.map(\.1) == [Data([0x11]), Data([0x22]), Data([0x33])])
+    }
+
     private func makeRecord(identifier: UInt64, byte: UInt8) -> NativePacketRecord {
         NativePacketRecord(
             identifier: identifier,

--- a/PcapPlusPlusCoreTests/Support/CallbackTestSupport.swift
+++ b/PcapPlusPlusCoreTests/Support/CallbackTestSupport.swift
@@ -142,6 +142,23 @@ extension OfflineCaptureDocumentProviding {
         }
     }
 
+    func activateDisplayFilter(_ expression: String, generation: UInt64) async -> DisplayFilterValidation {
+        await withCheckedContinuation { continuation in
+            activateDisplayFilter(expression, generation: generation) { validation in
+                continuation.resume(returning: validation)
+            }
+        }
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64
+    ) async throws -> DisplayFilterMatchBatch {
+        try await waitForResult { completion in
+            evaluateDisplayFilter(packetIDs: packetIDs, generation: generation, completion: completion)
+        }
+    }
+
     func save() async throws {
         try await waitForResult { completion in
             save(completion: completion)

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -1071,6 +1071,16 @@ struct TCPViewerWorkspaceMemoryDebugSnapshot: Equatable {
 #endif
 
 final class TCPViewerWorkspaceController {
+    private struct DisplayFilterRoute {
+        let evaluator: any DisplayFilterEvaluating
+        let packetIDPairs: [(workspace: PacketSummary.ID, backing: PacketSummary.ID)]
+    }
+
+    private final class DisplayFilterAccumulator {
+        var evaluatedPacketIDs: [PacketSummary.ID] = []
+        var matchingPacketIDs: [PacketSummary.ID] = []
+    }
+
     private struct ImportedSessionCaptureExportGroup {
         let fileID: ImportedCaptureFileID
         var originalPacketIDs: [PacketSummary.ID]
@@ -1366,6 +1376,57 @@ final class TCPViewerWorkspaceController {
                 }
                 completion?()
             }
+        }
+    }
+
+    func validateDisplayFilter(
+        _ expression: String,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        services.core.validateDisplayFilter(expression, completion: completion)
+    }
+
+    // Evaluate one backing capture at a time because Wireshark owns process-global dissection state.
+    func evaluateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        packetIDs: [PacketSummary.ID],
+        progress: ((DisplayFilterMatchBatch) -> Void)? = nil,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        do {
+            let routes = try displayFilterRoutes(for: packetIDs)
+            let accumulator = DisplayFilterAccumulator()
+            accumulator.evaluatedPacketIDs.reserveCapacity(packetIDs.count)
+            accumulator.matchingPacketIDs.reserveCapacity(packetIDs.count)
+
+            evaluateDisplayFilterRoutes(
+                routes,
+                routeIndex: 0,
+                expression: expression,
+                generation: generation,
+                accumulator: accumulator,
+                progress: progress,
+                completion: completion
+            )
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
+    func clearDisplayFilters() {
+        var evaluators: [any DisplayFilterEvaluating] = []
+        if let liveSession {
+            evaluators.append(liveSession)
+        }
+        if let document {
+            evaluators.append(document)
+        }
+        for importedDocument in importedDocumentsByFileID.values {
+            evaluators.append(importedDocument)
+        }
+        for evaluator in evaluators {
+            evaluator.clearDisplayFilter { _ in }
         }
     }
 
@@ -2957,6 +3018,187 @@ final class TCPViewerWorkspaceController {
     // Check both lineage and membership before navigating from a detached follow window.
     func canRevealTCPFollowPacket(_ identifier: PacketSummary.ID, from identity: TCPFollowCaptureIdentity) -> Bool {
         identity.canReveal(packetID: identifier, in: snapshot.packetIngestState)
+    }
+
+    private func displayFilterRoutes(for packetIDs: [PacketSummary.ID]) throws -> [DisplayFilterRoute] {
+        var livePairs: [(workspace: PacketSummary.ID, backing: PacketSummary.ID)] = []
+        var documentPairs: [(workspace: PacketSummary.ID, backing: PacketSummary.ID)] = []
+        var importedPairsByFileID: [ImportedCaptureFileID: [(workspace: PacketSummary.ID, backing: PacketSummary.ID)]] = [:]
+        var importedFileOrder: [ImportedCaptureFileID] = []
+
+        for packetID in packetIDs {
+            guard let packet = snapshot.packetIngestState.packet(withID: packetID) else {
+                throw TCPViewerCoreError(
+                    code: .unavailableFeature,
+                    message: "Packet \(packetID) is no longer available for display-filter evaluation."
+                )
+            }
+
+            switch packet.source {
+            case .live:
+                livePairs.append((workspace: packetID, backing: packetID))
+            case .offline:
+                if let reference = snapshot.packetIngestState.importedPacketReference(for: packetID) {
+                    if importedPairsByFileID[reference.fileID] == nil {
+                        importedFileOrder.append(reference.fileID)
+                    }
+                    importedPairsByFileID[reference.fileID, default: []].append((
+                        workspace: packetID,
+                        backing: reference.originalPacketID
+                    ))
+                } else {
+                    documentPairs.append((workspace: packetID, backing: packetID))
+                }
+            @unknown default:
+                throw TCPViewerCoreError(
+                    code: .unavailableFeature,
+                    message: "Packet \(packetID) cannot be evaluated by Wireshark."
+                )
+            }
+        }
+
+        var routes: [DisplayFilterRoute] = []
+        if !livePairs.isEmpty {
+            guard let liveSession else {
+                throw TCPViewerCoreError(
+                    code: .unavailableFeature,
+                    message: "The live capture is no longer available for display-filter evaluation."
+                )
+            }
+            routes.append(DisplayFilterRoute(evaluator: liveSession, packetIDPairs: livePairs))
+        }
+        if !documentPairs.isEmpty {
+            guard let document else {
+                throw TCPViewerCoreError(
+                    code: .unavailableFeature,
+                    message: "The capture document is no longer available for display-filter evaluation."
+                )
+            }
+            routes.append(DisplayFilterRoute(evaluator: document, packetIDPairs: documentPairs))
+        }
+        for fileID in importedFileOrder {
+            guard let importedDocument = importedDocumentsByFileID[fileID],
+                  let pairs = importedPairsByFileID[fileID] else {
+                throw TCPViewerCoreError(
+                    code: .unavailableFeature,
+                    message: "An imported capture is no longer available for display-filter evaluation."
+                )
+            }
+            routes.append(DisplayFilterRoute(evaluator: importedDocument, packetIDPairs: pairs))
+        }
+        return routes
+    }
+
+    private func evaluateDisplayFilterRoutes(
+        _ routes: [DisplayFilterRoute],
+        routeIndex: Int,
+        expression: String,
+        generation: UInt64,
+        accumulator: DisplayFilterAccumulator,
+        progress: ((DisplayFilterMatchBatch) -> Void)?,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        guard routes.indices.contains(routeIndex) else {
+            completion(.success(DisplayFilterMatchBatch(
+                generation: generation,
+                evaluatedPacketIDs: accumulator.evaluatedPacketIDs,
+                matchingPacketIDs: accumulator.matchingPacketIDs
+            )))
+            return
+        }
+
+        let route = routes[routeIndex]
+        route.evaluator.activateDisplayFilter(expression, generation: generation) { [weak self] validation in
+            guard let self else {
+                completion(.failure(TCPViewerCoreError(
+                    code: .operationCancelled,
+                    message: "Display-filter evaluation was cancelled."
+                )))
+                return
+            }
+            guard validation.isApplicable else {
+                completion(.failure(TCPViewerCoreError(
+                    code: .invalidCaptureFilter,
+                    message: validation.diagnostics.first?.message ?? "Wireshark could not compile this display filter."
+                )))
+                return
+            }
+
+            self.evaluateDisplayFilterBatches(
+                route,
+                nextIndex: 0,
+                generation: generation,
+                accumulator: accumulator,
+                progress: progress
+            ) { result in
+                switch result {
+                case .success:
+                    self.evaluateDisplayFilterRoutes(
+                        routes,
+                        routeIndex: routeIndex + 1,
+                        expression: expression,
+                        generation: generation,
+                        accumulator: accumulator,
+                        progress: progress,
+                        completion: completion
+                    )
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    private func evaluateDisplayFilterBatches(
+        _ route: DisplayFilterRoute,
+        nextIndex: Int,
+        generation: UInt64,
+        accumulator: DisplayFilterAccumulator,
+        progress: ((DisplayFilterMatchBatch) -> Void)?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        guard nextIndex < route.packetIDPairs.count else {
+            completion(.success(()))
+            return
+        }
+
+        let endIndex = min(nextIndex + 128, route.packetIDPairs.count)
+        let pairs = Array(route.packetIDPairs[nextIndex..<endIndex])
+        route.evaluator.evaluateDisplayFilter(
+            packetIDs: pairs.map(\.backing),
+            generation: generation
+        ) { [weak self] result in
+            guard let self else {
+                completion(.failure(TCPViewerCoreError(
+                    code: .operationCancelled,
+                    message: "Display-filter evaluation was cancelled."
+                )))
+                return
+            }
+
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let backingBatch):
+                let workspaceIDByBackingID = Dictionary(uniqueKeysWithValues: pairs.map { ($0.backing, $0.workspace) })
+                let mappedBatch = DisplayFilterMatchBatch(
+                    generation: generation,
+                    evaluatedPacketIDs: backingBatch.evaluatedPacketIDs.compactMap { workspaceIDByBackingID[$0] },
+                    matchingPacketIDs: backingBatch.matchingPacketIDs.compactMap { workspaceIDByBackingID[$0] }
+                )
+                accumulator.evaluatedPacketIDs.append(contentsOf: mappedBatch.evaluatedPacketIDs)
+                accumulator.matchingPacketIDs.append(contentsOf: mappedBatch.matchingPacketIDs)
+                progress?(mappedBatch)
+                self.evaluateDisplayFilterBatches(
+                    route,
+                    nextIndex: endIndex,
+                    generation: generation,
+                    accumulator: accumulator,
+                    progress: progress,
+                    completion: completion
+                )
+            }
+        }
     }
 
     func inspectPacket(id identifier: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>) {

--- a/TCPViewer/Core/WorkspaceFoundation.swift
+++ b/TCPViewer/Core/WorkspaceFoundation.swift
@@ -1070,6 +1070,23 @@ struct TCPViewerWorkspaceMemoryDebugSnapshot: Equatable {
 }
 #endif
 
+final class DisplayFilterEvaluationCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    func isCancelled() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
 final class TCPViewerWorkspaceController {
     private struct DisplayFilterRoute {
         let evaluator: any DisplayFilterEvaluating
@@ -1391,9 +1408,17 @@ final class TCPViewerWorkspaceController {
         _ expression: String,
         generation: UInt64,
         packetIDs: [PacketSummary.ID],
+        cancellationToken: DisplayFilterEvaluationCancellationToken,
         progress: ((DisplayFilterMatchBatch) -> Void)? = nil,
         completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
     ) {
+        guard !cancellationToken.isCancelled() else {
+            completion(.failure(TCPViewerCoreError(
+                code: .operationCancelled,
+                message: "Display-filter evaluation was cancelled."
+            )))
+            return
+        }
         do {
             let routes = try displayFilterRoutes(for: packetIDs)
             let accumulator = DisplayFilterAccumulator()
@@ -1406,6 +1431,7 @@ final class TCPViewerWorkspaceController {
                 expression: expression,
                 generation: generation,
                 accumulator: accumulator,
+                cancellationToken: cancellationToken,
                 progress: progress,
                 completion: completion
             )
@@ -3095,9 +3121,17 @@ final class TCPViewerWorkspaceController {
         expression: String,
         generation: UInt64,
         accumulator: DisplayFilterAccumulator,
+        cancellationToken: DisplayFilterEvaluationCancellationToken,
         progress: ((DisplayFilterMatchBatch) -> Void)?,
         completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
     ) {
+        guard !cancellationToken.isCancelled() else {
+            completion(.failure(TCPViewerCoreError(
+                code: .operationCancelled,
+                message: "Display-filter evaluation was cancelled."
+            )))
+            return
+        }
         guard routes.indices.contains(routeIndex) else {
             completion(.success(DisplayFilterMatchBatch(
                 generation: generation,
@@ -3109,7 +3143,7 @@ final class TCPViewerWorkspaceController {
 
         let route = routes[routeIndex]
         route.evaluator.activateDisplayFilter(expression, generation: generation) { [weak self] validation in
-            guard let self else {
+            guard let self, !cancellationToken.isCancelled() else {
                 completion(.failure(TCPViewerCoreError(
                     code: .operationCancelled,
                     message: "Display-filter evaluation was cancelled."
@@ -3129,6 +3163,7 @@ final class TCPViewerWorkspaceController {
                 nextIndex: 0,
                 generation: generation,
                 accumulator: accumulator,
+                cancellationToken: cancellationToken,
                 progress: progress
             ) { result in
                 switch result {
@@ -3139,6 +3174,7 @@ final class TCPViewerWorkspaceController {
                         expression: expression,
                         generation: generation,
                         accumulator: accumulator,
+                        cancellationToken: cancellationToken,
                         progress: progress,
                         completion: completion
                     )
@@ -3154,9 +3190,17 @@ final class TCPViewerWorkspaceController {
         nextIndex: Int,
         generation: UInt64,
         accumulator: DisplayFilterAccumulator,
+        cancellationToken: DisplayFilterEvaluationCancellationToken,
         progress: ((DisplayFilterMatchBatch) -> Void)?,
         completion: @escaping TCPViewerVoidCompletion
     ) {
+        guard !cancellationToken.isCancelled() else {
+            completion(.failure(TCPViewerCoreError(
+                code: .operationCancelled,
+                message: "Display-filter evaluation was cancelled."
+            )))
+            return
+        }
         guard nextIndex < route.packetIDPairs.count else {
             completion(.success(()))
             return
@@ -3168,7 +3212,7 @@ final class TCPViewerWorkspaceController {
             packetIDs: pairs.map(\.backing),
             generation: generation
         ) { [weak self] result in
-            guard let self else {
+            guard let self, !cancellationToken.isCancelled() else {
                 completion(.failure(TCPViewerCoreError(
                     code: .operationCancelled,
                     message: "Display-filter evaluation was cancelled."
@@ -3194,6 +3238,7 @@ final class TCPViewerWorkspaceController {
                     nextIndex: endIndex,
                     generation: generation,
                     accumulator: accumulator,
+                    cancellationToken: cancellationToken,
                     progress: progress,
                     completion: completion
                 )

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -537,6 +537,8 @@ struct NetworkInspectorSnapshot: Equatable {
     var inspectorPlacement: NetworkInspectorPlacement
     var isInspectorVisible: Bool
     var isStructuredFilterVisible: Bool
+    var filterMode: PacketFilterMode
+    var wiresharkFilterState: PacketWiresharkFilterState
     var displayFilterText: String
     var displayFilter: PacketDisplayFilter
     var displayFilterChips: [PacketFilterChip]
@@ -565,6 +567,8 @@ struct NetworkInspectorSnapshot: Equatable {
         inspectorPlacement: NetworkInspectorPlacement = .trailing,
         isInspectorVisible: Bool,
         isStructuredFilterVisible: Bool = false,
+        filterMode: PacketFilterMode = .builder,
+        wiresharkFilterState: PacketWiresharkFilterState = PacketWiresharkFilterState(),
         displayFilterText: String,
         structuredFilterGroup: PacketStructuredFilterGroup = .default,
         isPacketTableFiltering: Bool = false,
@@ -584,6 +588,8 @@ struct NetworkInspectorSnapshot: Equatable {
             inspectorPlacement: inspectorPlacement,
             isInspectorVisible: isInspectorVisible,
             isStructuredFilterVisible: isStructuredFilterVisible,
+            filterMode: filterMode,
+            wiresharkFilterState: wiresharkFilterState,
             displayFilterText: displayFilterText,
             displayFilter: packetTableContent.displayFilter,
             displayFilterChips: packetTableContent.displayFilterChips,
@@ -617,6 +623,8 @@ struct NetworkInspectorSnapshot: Equatable {
             lhs.inspectorPlacement == rhs.inspectorPlacement &&
             lhs.isInspectorVisible == rhs.isInspectorVisible &&
             lhs.isStructuredFilterVisible == rhs.isStructuredFilterVisible &&
+            lhs.filterMode == rhs.filterMode &&
+            lhs.wiresharkFilterState == rhs.wiresharkFilterState &&
             lhs.displayFilterText == rhs.displayFilterText &&
             lhs.displayFilter == rhs.displayFilter &&
             lhs.displayFilterChips == rhs.displayFilterChips &&
@@ -682,7 +690,15 @@ struct NetworkInspectorSnapshot: Equatable {
             return false
         }
 
-        return !isStructuredFilterVisible || structuredFilterGroup.activeFilters.isEmpty
+        guard isStructuredFilterVisible else {
+            return true
+        }
+        switch filterMode {
+        case .builder:
+            return structuredFilterGroup.activeFilters.isEmpty
+        case .wireshark:
+            return wiresharkFilterState.appliedExpression.isEmpty
+        }
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Models/PacketQuickFilterModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketQuickFilterModels.swift
@@ -82,7 +82,20 @@ struct PacketQuickFilterItem: Identifiable, Equatable, Sendable {
 struct PacketCustomFilterItem: Identifiable, Equatable, Sendable {
     let id: PacketCustomFilter.ID
     let title: String
+    let mode: PacketFilterMode
     let isSelected: Bool
+
+    init(
+        id: PacketCustomFilter.ID,
+        title: String,
+        mode: PacketFilterMode = .builder,
+        isSelected: Bool
+    ) {
+        self.id = id
+        self.title = title
+        self.mode = mode
+        self.isSelected = isSelected
+    }
 }
 
 struct PacketQuickFilterSelection: Codable, Equatable, Sendable, Hashable {

--- a/TCPViewer/Features/NetworkInspector/Models/PacketWiresharkFilterModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketWiresharkFilterModels.swift
@@ -17,7 +17,7 @@ enum PacketFilterMode: String, Codable, Sendable, CaseIterable {
         case .builder:
             return "Filter Builder"
         case .wireshark:
-            return "Wireshark Filter..."
+            return "Wireshark Filter…"
         }
     }
 }
@@ -116,6 +116,7 @@ struct PacketDisplayFilterCacheKey: Hashable, Sendable {
 struct PacketDisplayFilterCacheEntry: Equatable, Sendable {
     var evaluatedPacketIndexes = PacketIndexBitSet()
     var matchingPacketIndexes = PacketIndexBitSet()
+    private(set) var evaluatedPrefixCount = 0
 
     mutating func record(
         batch: DisplayFilterMatchBatch,
@@ -131,6 +132,9 @@ struct PacketDisplayFilterCacheEntry: Equatable, Sendable {
                 matchingPacketIndexes.insert(index)
             }
         }
+        while evaluatedPacketIndexes.contains(evaluatedPrefixCount) {
+            evaluatedPrefixCount += 1
+        }
     }
 
     func unknownPacketIDs(in ingestState: PacketIngestState, limit: Int? = nil) -> [PacketSummary.ID] {
@@ -138,7 +142,9 @@ struct PacketDisplayFilterCacheEntry: Equatable, Sendable {
         if let limit {
             identifiers.reserveCapacity(min(limit, ingestState.packets.count))
         }
-        for (index, packet) in ingestState.packets.enumerated() where !evaluatedPacketIndexes.contains(index) {
+        let startIndex = min(evaluatedPrefixCount, ingestState.packets.count)
+        for index in startIndex..<ingestState.packets.count where !evaluatedPacketIndexes.contains(index) {
+            let packet = ingestState.packets[index]
             identifiers.append(packet.id)
             if let limit, identifiers.count >= limit {
                 break

--- a/TCPViewer/Features/NetworkInspector/Models/PacketWiresharkFilterModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketWiresharkFilterModels.swift
@@ -1,0 +1,193 @@
+//
+//  PacketWiresharkFilterModels.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+
+enum PacketFilterMode: String, Codable, Sendable, CaseIterable {
+    case builder
+    case wireshark
+
+    var title: String {
+        switch self {
+        case .builder:
+            return "Filter Builder"
+        case .wireshark:
+            return "Wireshark Filter..."
+        }
+    }
+}
+
+struct PacketWiresharkFilterState: Equatable, Sendable {
+    var draftExpression = ""
+    var validation = DisplayFilterValidation(
+        normalizedExpression: "",
+        status: .valid
+    )
+    var appliedExpression = ""
+    var isValidating = false
+    var isApplying = false
+    var evaluatedPacketCount = 0
+    var totalPacketCount = 0
+
+    var diagnostic: DisplayFilterDiagnostic? {
+        validation.diagnostics.first
+    }
+
+    var progressText: String? {
+        guard isApplying else {
+            return nil
+        }
+        return "Filtering \(evaluatedPacketCount.formatted()) of \(totalPacketCount.formatted()) packets..."
+    }
+}
+
+struct PacketIndexBitSet: Equatable, Sendable {
+    private(set) var words: [UInt64] = []
+
+    mutating func insert(_ index: Int) {
+        guard index >= 0 else {
+            return
+        }
+        let wordIndex = index / UInt64.bitWidth
+        if words.count <= wordIndex {
+            words.append(contentsOf: repeatElement(0, count: wordIndex - words.count + 1))
+        }
+        words[wordIndex] |= UInt64(1) << UInt64(index % UInt64.bitWidth)
+    }
+
+    func contains(_ index: Int) -> Bool {
+        guard index >= 0 else {
+            return false
+        }
+        let wordIndex = index / UInt64.bitWidth
+        guard words.indices.contains(wordIndex) else {
+            return false
+        }
+        return words[wordIndex] & (UInt64(1) << UInt64(index % UInt64.bitWidth)) != 0
+    }
+
+    func setBitCount(upTo packetCount: Int) -> Int {
+        guard packetCount > 0 else {
+            return 0
+        }
+        let fullWordCount = packetCount / UInt64.bitWidth
+        let remainder = packetCount % UInt64.bitWidth
+        var count = words.prefix(fullWordCount).reduce(0) { $0 + $1.nonzeroBitCount }
+        if remainder > 0, words.indices.contains(fullWordCount) {
+            let mask = (UInt64(1) << UInt64(remainder)) - 1
+            count += (words[fullWordCount] & mask).nonzeroBitCount
+        }
+        return count
+    }
+
+    var setBitCount: Int {
+        words.reduce(0) { $0 + $1.nonzeroBitCount }
+    }
+}
+
+struct PacketWiresharkFilterMembership: Equatable, Sendable {
+    let generation: UInt64
+    let expression: String
+    let evaluatedPacketCount: Int
+    let matchingPacketIndexes: PacketIndexBitSet
+
+    func matches(_ packet: PacketSummary, in ingestState: PacketIngestState) -> Bool {
+        guard let index = ingestState.packetIndexByID[packet.id] else {
+            return false
+        }
+        return matchingPacketIndexes.contains(index)
+    }
+}
+
+struct PacketDisplayFilterCacheKey: Hashable, Sendable {
+    static let dissectionRevision = "wireshark-4.6.6-display-filter-v1"
+
+    let backingIdentity: String
+    let packetLineageRevision: UInt64
+    let expression: String
+    let dissectionRevision: String
+}
+
+struct PacketDisplayFilterCacheEntry: Equatable, Sendable {
+    var evaluatedPacketIndexes = PacketIndexBitSet()
+    var matchingPacketIndexes = PacketIndexBitSet()
+
+    mutating func record(
+        batch: DisplayFilterMatchBatch,
+        packetIndexByID: [PacketSummary.ID: Int]
+    ) {
+        let matchingIDs = Set(batch.matchingPacketIDs)
+        for packetID in batch.evaluatedPacketIDs {
+            guard let index = packetIndexByID[packetID] else {
+                continue
+            }
+            evaluatedPacketIndexes.insert(index)
+            if matchingIDs.contains(packetID) {
+                matchingPacketIndexes.insert(index)
+            }
+        }
+    }
+
+    func unknownPacketIDs(in ingestState: PacketIngestState, limit: Int? = nil) -> [PacketSummary.ID] {
+        var identifiers: [PacketSummary.ID] = []
+        if let limit {
+            identifiers.reserveCapacity(min(limit, ingestState.packets.count))
+        }
+        for (index, packet) in ingestState.packets.enumerated() where !evaluatedPacketIndexes.contains(index) {
+            identifiers.append(packet.id)
+            if let limit, identifiers.count >= limit {
+                break
+            }
+        }
+        return identifiers
+    }
+
+    func membership(generation: UInt64, expression: String) -> PacketWiresharkFilterMembership {
+        PacketWiresharkFilterMembership(
+            generation: generation,
+            expression: expression,
+            evaluatedPacketCount: evaluatedPacketIndexes.setBitCount,
+            matchingPacketIndexes: matchingPacketIndexes
+        )
+    }
+}
+
+struct PacketDisplayFilterResultCache {
+    private struct StoredEntry {
+        var entry: PacketDisplayFilterCacheEntry
+        var accessOrdinal: UInt64
+    }
+
+    private let capacity = 4
+    private var entries: [PacketDisplayFilterCacheKey: StoredEntry] = [:]
+    private var accessOrdinal: UInt64 = 0
+
+    mutating func entry(for key: PacketDisplayFilterCacheKey) -> PacketDisplayFilterCacheEntry? {
+        guard var stored = entries[key] else {
+            return nil
+        }
+        accessOrdinal &+= 1
+        stored.accessOrdinal = accessOrdinal
+        entries[key] = stored
+        return stored.entry
+    }
+
+    mutating func store(_ entry: PacketDisplayFilterCacheEntry, for key: PacketDisplayFilterCacheKey) {
+        accessOrdinal &+= 1
+        entries[key] = StoredEntry(entry: entry, accessOrdinal: accessOrdinal)
+        guard entries.count > capacity,
+              let oldestKey = entries.min(by: { $0.value.accessOrdinal < $1.value.accessOrdinal })?.key else {
+            return
+        }
+        entries.removeValue(forKey: oldestKey)
+    }
+
+    mutating func removeAll() {
+        entries.removeAll(keepingCapacity: false)
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
@@ -189,6 +189,9 @@ final class PacketCustomFilterService {
 
     // Replace a saved filter payload while keeping its user-facing name and identity.
     func updateGroup(id: PacketCustomFilter.ID, group: PacketStructuredFilterGroup, now: Date = Date()) throws {
+        guard filter(id: id)?.mode == .builder else {
+            return
+        }
         try update(
             id: id,
             mode: .builder,

--- a/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketCustomFilterService.swift
@@ -13,6 +13,58 @@ struct PacketCustomFilter: Identifiable, Codable, Hashable, Sendable {
     let createdAt: Date
     var updatedAt: Date
     var group: PacketStructuredFilterGroup
+    var mode: PacketFilterMode
+    var wiresharkExpression: String?
+
+    init(
+        id: String,
+        name: String,
+        createdAt: Date,
+        updatedAt: Date,
+        group: PacketStructuredFilterGroup,
+        mode: PacketFilterMode = .builder,
+        wiresharkExpression: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.group = group
+        self.mode = mode
+        self.wiresharkExpression = wiresharkExpression
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case createdAt
+        case updatedAt
+        case group
+        case mode
+        case wiresharkExpression
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        group = try container.decode(PacketStructuredFilterGroup.self, forKey: .group)
+        mode = try container.decodeIfPresent(PacketFilterMode.self, forKey: .mode) ?? .builder
+        wiresharkExpression = try container.decodeIfPresent(String.self, forKey: .wiresharkExpression)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encode(group, forKey: .group)
+        try container.encode(mode, forKey: .mode)
+        try container.encodeIfPresent(wiresharkExpression, forKey: .wiresharkExpression)
+    }
 }
 
 enum PacketCustomFilterValidationError: Error, Equatable, LocalizedError {
@@ -86,13 +138,26 @@ final class PacketCustomFilterService {
     // Append a new custom filter while allowing duplicate display names by design.
     @discardableResult
     func save(name: String, group: PacketStructuredFilterGroup, now: Date = Date()) throws -> PacketCustomFilter {
+        try save(name: name, mode: .builder, group: group, wiresharkExpression: nil, now: now)
+    }
+
+    @discardableResult
+    func save(
+        name: String,
+        mode: PacketFilterMode,
+        group: PacketStructuredFilterGroup,
+        wiresharkExpression: String?,
+        now: Date = Date()
+    ) throws -> PacketCustomFilter {
         let normalizedName = try Self.normalizedName(name)
         let filter = PacketCustomFilter(
             id: UUID().uuidString,
             name: normalizedName,
             createdAt: now,
             updatedAt: now,
-            group: PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
+            group: PacketStructuredFilterGroup(filters: group.filters, operator: group.operator),
+            mode: mode,
+            wiresharkExpression: wiresharkExpression
         )
         cachedFilters.append(filter)
         do {
@@ -124,12 +189,30 @@ final class PacketCustomFilterService {
 
     // Replace a saved filter payload while keeping its user-facing name and identity.
     func updateGroup(id: PacketCustomFilter.ID, group: PacketStructuredFilterGroup, now: Date = Date()) throws {
+        try update(
+            id: id,
+            mode: .builder,
+            group: group,
+            wiresharkExpression: nil,
+            now: now
+        )
+    }
+
+    func update(
+        id: PacketCustomFilter.ID,
+        mode: PacketFilterMode,
+        group: PacketStructuredFilterGroup,
+        wiresharkExpression: String?,
+        now: Date = Date()
+    ) throws {
         guard let index = cachedFilters.firstIndex(where: { $0.id == id }) else {
             return
         }
 
         let previousFilter = cachedFilters[index]
         cachedFilters[index].group = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
+        cachedFilters[index].mode = mode
+        cachedFilters[index].wiresharkExpression = wiresharkExpression
         cachedFilters[index].updatedAt = now
         do {
             try persist()
@@ -152,7 +235,9 @@ final class PacketCustomFilterService {
             name: sourceFilter.name,
             createdAt: now,
             updatedAt: now,
-            group: PacketStructuredFilterGroup(filters: sourceFilter.group.filters, operator: sourceFilter.group.operator)
+            group: PacketStructuredFilterGroup(filters: sourceFilter.group.filters, operator: sourceFilter.group.operator),
+            mode: sourceFilter.mode,
+            wiresharkExpression: sourceFilter.wiresharkExpression
         )
         cachedFilters.insert(duplicatedFilter, at: cachedFilters.index(after: index))
         do {

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionFormat.swift
@@ -348,6 +348,8 @@ struct TCPViewSessionState: Codable, Equatable {
     let inspectorPlacement: String
     let isInspectorVisible: Bool
     let isStructuredFilterVisible: Bool
+    var filterMode: PacketFilterMode? = nil
+    var wiresharkExpression: String? = nil
     let tableColumnLayout: PacketTableColumnLayout?
     let importedFileProvenance: String?
     let sourceMetadata: TCPViewSessionSourceMetadata?
@@ -393,6 +395,8 @@ struct TCPViewSessionExportSnapshot {
     let inspectorPlacement: NetworkInspectorPlacement
     let isInspectorVisible: Bool
     let isStructuredFilterVisible: Bool
+    var filterMode: PacketFilterMode? = nil
+    var wiresharkExpression: String? = nil
     let tableColumnLayout: PacketTableColumnLayout?
     let sourceMetadata: TCPViewSessionSourceMetadata?
 
@@ -418,6 +422,8 @@ struct TCPViewSessionExportSnapshot {
             inspectorPlacement: inspectorPlacement.rawValue,
             isInspectorVisible: isInspectorVisible,
             isStructuredFilterVisible: isStructuredFilterVisible,
+            filterMode: filterMode,
+            wiresharkExpression: wiresharkExpression,
             tableColumnLayout: tableColumnLayout,
             importedFileProvenance: importedFiles.isEmpty ? nil : "Imported capture grouping is preserved for TCPViewer source-list reconstruction.",
             sourceMetadata: sourceMetadata

--- a/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionImportService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/TCPViewSessionImportService.swift
@@ -357,6 +357,8 @@ final class TCPViewSessionImportService {
             inspectorPlacement: state.inspectorPlacement,
             isInspectorVisible: state.isInspectorVisible,
             isStructuredFilterVisible: state.isStructuredFilterVisible,
+            filterMode: state.filterMode,
+            wiresharkExpression: state.wiresharkExpression,
             tableColumnLayout: state.tableColumnLayout,
             importedFileProvenance: importedFiles.isEmpty ? nil : state.importedFileProvenance,
             sourceMetadata: state.sourceMetadata.map { metadata in
@@ -862,6 +864,8 @@ final class TCPViewSessionOfflineDocument: OfflineCaptureDocumentProviding {
             inspectorPlacement: state.inspectorPlacement,
             isInspectorVisible: state.isInspectorVisible,
             isStructuredFilterVisible: state.isStructuredFilterVisible,
+            filterMode: state.filterMode,
+            wiresharkExpression: state.wiresharkExpression,
             tableColumnLayout: state.tableColumnLayout,
             importedFileProvenance: importedFileRecords.isEmpty ? nil : state.importedFileProvenance,
             sourceMetadata: state.sourceMetadata.map { metadata in

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1053,6 +1053,7 @@ final class NetworkInspectorViewModel {
     private var pendingDisplayFilterValidationWorkItem: DispatchWorkItem?
     private var displayFilterValidationGeneration: UInt64 = 0
     private var displayFilterEvaluationGeneration: UInt64 = 0
+    private var displayFilterEvaluationCancellationToken: DisplayFilterEvaluationCancellationToken?
     private var displayFilterResultCache = PacketDisplayFilterResultCache()
 
     // Trailing-edge debounce for delegate-driven rebuilds. Live ingest fires the controller delegate
@@ -1150,7 +1151,7 @@ final class NetworkInspectorViewModel {
             packetTableContent = content
         }
         let initialCustomFilterItems = customFilterService.filters().map { filter in
-            PacketCustomFilterItem(id: filter.id, title: filter.name, isSelected: false)
+            PacketCustomFilterItem(id: filter.id, title: filter.name, mode: filter.mode, isSelected: false)
         }
         self.snapshot = NetworkInspectorSnapshot.make(
             base: controller.snapshot,
@@ -1399,9 +1400,7 @@ final class NetworkInspectorViewModel {
     }
 
     func applyWiresharkFilter(completion: ((Bool) -> Void)? = nil) {
-        pendingDisplayFilterValidationWorkItem?.cancel()
-        pendingDisplayFilterValidationWorkItem = nil
-        displayFilterValidationGeneration &+= 1
+        cancelWiresharkFilterEvaluation(clearMembership: false)
         let generation = displayFilterValidationGeneration
         let expression = wiresharkFilterState.draftExpression
         wiresharkFilterState.isValidating = true
@@ -1514,12 +1513,30 @@ final class NetworkInspectorViewModel {
 
     // Replace one saved custom filter with the current structured filter group.
     func overrideCustomFilter(id: PacketCustomFilter.ID, group: PacketStructuredFilterGroup) throws {
+        guard customFilterService.filter(id: id)?.mode == .builder else {
+            return
+        }
         let replacementGroup = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
         try customFilterService.updateGroup(id: id, group: replacementGroup)
         structuredFilterGroup = replacementGroup
         if !isUsingSessionDocumentState {
             structuredFilterStore.save(replacementGroup)
         }
+        selectedCustomFilterID = id
+        rebuildSnapshot()
+    }
+
+    // Replace only a Wireshark saved filter so builder payloads cannot be erased across modes.
+    func overrideWiresharkCustomFilter(id: PacketCustomFilter.ID) throws {
+        guard customFilterService.filter(id: id)?.mode == .wireshark else {
+            return
+        }
+        try customFilterService.update(
+            id: id,
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: wiresharkFilterState.appliedExpression
+        )
         selectedCustomFilterID = id
         rebuildSnapshot()
     }
@@ -1611,6 +1628,8 @@ final class NetworkInspectorViewModel {
 
         displayFilterEvaluationGeneration &+= 1
         let generation = displayFilterEvaluationGeneration
+        let cancellationToken = DisplayFilterEvaluationCancellationToken()
+        displayFilterEvaluationCancellationToken = cancellationToken
         wiresharkFilterState.validation = validation
         wiresharkFilterState.isApplying = true
         wiresharkFilterState.evaluatedPacketCount = 0
@@ -1621,6 +1640,7 @@ final class NetworkInspectorViewModel {
             expression,
             generation: generation,
             packetIDs: unknownPacketIDs,
+            cancellationToken: cancellationToken,
             progress: { [weak self] batch in
                 DispatchQueue.main.async {
                     guard let self,
@@ -1645,6 +1665,7 @@ final class NetworkInspectorViewModel {
                         completion?(false)
                         return
                     }
+                    self.displayFilterEvaluationCancellationToken = nil
                     self.wiresharkFilterState.isApplying = false
                     switch result {
                     case .failure(let error):
@@ -1715,6 +1736,8 @@ final class NetworkInspectorViewModel {
         pendingDisplayFilterValidationWorkItem = nil
         displayFilterValidationGeneration &+= 1
         displayFilterEvaluationGeneration &+= 1
+        displayFilterEvaluationCancellationToken?.cancel()
+        displayFilterEvaluationCancellationToken = nil
         wiresharkFilterState.isValidating = false
         wiresharkFilterState.isApplying = false
         wiresharkFilterState.evaluatedPacketCount = 0
@@ -1730,6 +1753,7 @@ final class NetworkInspectorViewModel {
         #if DEBUG
         logClearMemorySnapshot("before")
         #endif
+        cancelWiresharkFilterEvaluation(clearMembership: true)
         cancelActivePacketTableFilterJob()
         controller.clearPackets()
         packetTableContentCache.reset()
@@ -2173,6 +2197,7 @@ final class NetworkInspectorViewModel {
                 completion?()
             }
         } else {
+            cancelWiresharkFilterEvaluation(clearMembership: true)
             restorePersistentDocumentState()
             controller.startLiveCapture { [weak self] in
                 self?.rebuildSnapshot()
@@ -2203,6 +2228,7 @@ final class NetworkInspectorViewModel {
     }
 
     func openDocument(at fileURL: URL, completion: (() -> Void)? = nil) {
+        cancelWiresharkFilterEvaluation(clearMembership: true)
         let standardizedURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(fileURL)
         let isSessionFile = TCPViewerCaptureFileImportPolicy.isSessionFileURL(standardizedURL)
         controller.openDocument(at: fileURL) { [weak self] in
@@ -2230,6 +2256,7 @@ final class NetworkInspectorViewModel {
     }
 
     func importDocuments(at fileURLs: [URL], completion: (() -> Void)? = nil) {
+        cancelWiresharkFilterEvaluation(clearMembership: true)
         let hasSessionFile = fileURLs
             .map(TCPViewerCaptureFileImportPolicy.standardizedFileURL)
             .contains(where: TCPViewerCaptureFileImportPolicy.isSessionFileURL)
@@ -2838,6 +2865,7 @@ final class NetworkInspectorViewModel {
             PacketCustomFilterItem(
                 id: filter.id,
                 title: filter.name,
+                mode: filter.mode,
                 isSelected: isStructuredFilterVisible && selectedCustomFilterID == filter.id
             )
         }

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1626,6 +1626,7 @@ final class NetworkInspectorViewModel {
             return
         }
 
+        displayFilterEvaluationCancellationToken?.cancel()
         displayFilterEvaluationGeneration &+= 1
         let generation = displayFilterEvaluationGeneration
         let cancellationToken = DisplayFilterEvaluationCancellationToken()
@@ -2321,8 +2322,7 @@ final class NetworkInspectorViewModel {
             validation: DisplayFilterValidation(
                 normalizedExpression: wiresharkExpression,
                 status: .valid
-            ),
-            appliedExpression: wiresharkExpression
+            )
         )
         wiresharkFilterMembership = nil
         wiresharkFilterMembershipLineageRevision = nil
@@ -2335,7 +2335,7 @@ final class NetworkInspectorViewModel {
         }
         if isStructuredFilterVisible, filterMode == .wireshark {
             DispatchQueue.main.async { [weak self] in
-                self?.reapplyWiresharkFilterIfNeeded()
+                self?.applyWiresharkFilter()
             }
         }
     }

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -27,6 +27,8 @@ private struct NetworkInspectorPreferences {
         static let sidebarLeadingThickness = "TCPViewer.sidebarLeadingThickness"
         static let sidebarVisible = "TCPViewer.sidebarVisible"
         static let structuredFilterVisible = "TCPViewer.structuredFilterVisible"
+        static let filterMode = "TCPViewer.filterMode"
+        static let wiresharkFilterDraft = "TCPViewer.wiresharkFilterDraft"
     }
 
     let defaults: UserDefaults
@@ -69,6 +71,17 @@ private struct NetworkInspectorPreferences {
         }
 
         return defaults.bool(forKey: Key.structuredFilterVisible)
+    }
+
+    var filterMode: PacketFilterMode {
+        guard let value = defaults.string(forKey: Key.filterMode) else {
+            return .builder
+        }
+        return PacketFilterMode(rawValue: value) ?? .builder
+    }
+
+    var wiresharkFilterDraft: String {
+        defaults.string(forKey: Key.wiresharkFilterDraft) ?? ""
     }
 
     func inspectorThickness(for placement: NetworkInspectorPlacement) -> CGFloat? {
@@ -114,6 +127,14 @@ private struct NetworkInspectorPreferences {
 
     func persistStructuredFilterVisible(_ isVisible: Bool) {
         defaults.set(isVisible, forKey: Key.structuredFilterVisible)
+    }
+
+    func persistFilterMode(_ mode: PacketFilterMode) {
+        defaults.set(mode.rawValue, forKey: Key.filterMode)
+    }
+
+    func persistWiresharkFilterDraft(_ expression: String) {
+        defaults.set(expression, forKey: Key.wiresharkFilterDraft)
     }
 
     private func inspectorThicknessKey(for placement: NetworkInspectorPlacement) -> String {
@@ -168,6 +189,7 @@ private struct PacketTableFilterSignature: Equatable, Sendable {
     let sourceListSelection: PacketSourceListSelection
     let pinnedItems: [PacketPin]
     let savedRecords: [SavedPacketRecord]
+    let wiresharkFilterMembership: PacketWiresharkFilterMembership?
 }
 
 private struct PacketTableBuildInput: Sendable {
@@ -227,7 +249,8 @@ private enum PacketTableContentBuilder {
             guard matches(packet, selection: input.signature.sourceListSelection, pinnedItems: input.signature.pinnedItems, ingestState: input.ingestState),
                   displayFilter.isEmpty || displayFilter.matches(packet),
                   quickFilterService.matches(packet, selection: input.signature.quickFilterSelection),
-                  structuredFilterService.matches(packet, context: structuredFilterContext) else {
+                  structuredFilterService.matches(packet, context: structuredFilterContext),
+                  input.signature.wiresharkFilterMembership?.matches(packet, in: input.ingestState) != false else {
                 continue
             }
 
@@ -304,6 +327,7 @@ private struct PacketTableContentCache {
     private var sourceListSelection: PacketSourceListSelection?
     private var pinnedItems: [PacketPin] = []
     private var savedRecords: [SavedPacketRecord] = []
+    private var wiresharkFilterMembership: PacketWiresharkFilterMembership?
     private var generation: UInt64 = 0
     private var cachedContent = PacketTableContent.empty
     private var cachedRowTimingState = PacketTableRowTimingState()
@@ -319,6 +343,7 @@ private struct PacketTableContentCache {
         sourceListSelection = nil
         pinnedItems = []
         savedRecords = []
+        wiresharkFilterMembership = nil
         generation &+= 1
         cachedContent = .empty
         cachedRowTimingState = PacketTableRowTimingState()
@@ -344,6 +369,7 @@ private struct PacketTableContentCache {
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?,
         allowsAsyncRebuild: Bool,
         asyncRebuildThreshold: Int
     ) -> PacketTableContentResolution {
@@ -354,7 +380,8 @@ private struct PacketTableContentCache {
             structuredFilterGroup: structuredFilterGroup,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
-            savedRecords: savedRecords
+            savedRecords: savedRecords,
+            wiresharkFilterMembership: wiresharkFilterMembership
         ) else {
             requiresReloadForAsyncBaseline = false
             return .ready(cachedContent)
@@ -368,12 +395,34 @@ private struct PacketTableContentCache {
             self.sourceListSelection == sourceListSelection &&
             self.pinnedItems == pinnedItems &&
             self.savedRecords == savedRecords &&
+            hasSameWiresharkFilterIdentity(as: wiresharkFilterMembership) &&
             packetLineageRevision == ingestState.packetLineageRevision &&
             sourcePacketCount <= ingestState.packets.count
 
         if isStateStable {
             let forceReload = requiresReloadForAsyncBaseline
             requiresReloadForAsyncBaseline = false
+            if let previousMembership = self.wiresharkFilterMembership,
+               let wiresharkFilterMembership,
+               wiresharkFilterMembership.evaluatedPacketCount > previousMembership.evaluatedPacketCount {
+                let upperBound = min(wiresharkFilterMembership.evaluatedPacketCount, ingestState.packets.count)
+                let lowerBound = min(previousMembership.evaluatedPacketCount, upperBound)
+                return .ready(appendContent(
+                    from: ingestState.packets[lowerBound..<upperBound],
+                    ingestState: ingestState,
+                    displayFilter: displayFilter,
+                    displayFilterText: displayFilterText,
+                    quickFilterSelection: quickFilterSelection,
+                    quickFilterService: quickFilterService,
+                    structuredFilterGroup: structuredFilterGroup,
+                    structuredFilterService: structuredFilterService,
+                    sourceListSelection: sourceListSelection,
+                    pinnedItems: pinnedItems,
+                    savedRecords: savedRecords,
+                    wiresharkFilterMembership: wiresharkFilterMembership,
+                    forceReload: forceReload
+                ))
+            }
             switch ingestState.lastMutation {
             case .append:
                 return .ready(appendContent(
@@ -388,6 +437,7 @@ private struct PacketTableContentCache {
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
                     savedRecords: savedRecords,
+                    wiresharkFilterMembership: wiresharkFilterMembership,
                     forceReload: forceReload
                 ))
             case .appendWithMetadataUpdates(_, let updatedIDs):
@@ -404,6 +454,7 @@ private struct PacketTableContentCache {
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
                     savedRecords: savedRecords,
+                    wiresharkFilterMembership: wiresharkFilterMembership,
                     forceReload: forceReload
                 ) {
                     return .ready(content)
@@ -420,7 +471,8 @@ private struct PacketTableContentCache {
                     structuredFilterService: structuredFilterService,
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
-                    savedRecords: savedRecords
+                    savedRecords: savedRecords,
+                    wiresharkFilterMembership: wiresharkFilterMembership
                 ) {
                     return .ready(content)
                 }
@@ -435,7 +487,8 @@ private struct PacketTableContentCache {
             structuredFilterGroup: structuredFilterGroup,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
-            savedRecords: savedRecords
+            savedRecords: savedRecords,
+            wiresharkFilterMembership: wiresharkFilterMembership
         )
         let input = PacketTableBuildInput(ingestState: ingestState, signature: signature)
         if allowsAsyncRebuild, input.sourcePacketCount >= asyncRebuildThreshold {
@@ -456,7 +509,8 @@ private struct PacketTableContentCache {
         structuredFilterGroup: PacketStructuredFilterGroup,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
-        savedRecords: [SavedPacketRecord]
+        savedRecords: [SavedPacketRecord],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?
     ) -> Bool {
         let dependsOnIngestPackets = sourceListSelection != .saved
         return (dependsOnIngestPackets && packetRevision != ingestState.packetRevision) ||
@@ -465,7 +519,8 @@ private struct PacketTableContentCache {
             self.structuredFilterGroup != structuredFilterGroup ||
             self.sourceListSelection != sourceListSelection ||
             self.pinnedItems != pinnedItems ||
-            self.savedRecords != savedRecords
+            self.savedRecords != savedRecords ||
+            self.wiresharkFilterMembership != wiresharkFilterMembership
     }
 
     mutating func storeAsyncRebuild(_ output: PacketTableBuildOutput, input: PacketTableBuildInput) -> PacketTableContent {
@@ -523,6 +578,7 @@ private struct PacketTableContentCache {
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?,
         forceReload: Bool = false
     ) -> PacketTableContent {
         guard !newPackets.isEmpty else {
@@ -534,7 +590,8 @@ private struct PacketTableContentCache {
                 structuredFilterGroup: structuredFilterGroup,
                 sourceListSelection: sourceListSelection,
                 pinnedItems: pinnedItems,
-                savedRecords: savedRecords
+                savedRecords: savedRecords,
+                wiresharkFilterMembership: wiresharkFilterMembership
             )
         }
 
@@ -559,7 +616,8 @@ private struct PacketTableContentCache {
             guard matches(packet, selection: sourceListSelection, pinnedItems: pinnedItems, ingestState: ingestState),
                   displayFilter.isEmpty || displayFilter.matches(packet),
                   quickFilterService.matches(packet, selection: quickFilterSelection),
-                  structuredFilterService.matches(packet, context: structuredFilterContext) else {
+                  structuredFilterService.matches(packet, context: structuredFilterContext),
+                  wiresharkFilterMembership?.matches(packet, in: ingestState) != false else {
                 continue
             }
 
@@ -597,6 +655,7 @@ private struct PacketTableContentCache {
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
+            wiresharkFilterMembership: wiresharkFilterMembership,
             rowTimingState: rowTimingState
         )
     }
@@ -614,7 +673,8 @@ private struct PacketTableContentCache {
         structuredFilterService: PacketStructuredFilterService,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
-        savedRecords: [SavedPacketRecord]
+        savedRecords: [SavedPacketRecord],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?
     ) -> PacketTableContent? {
         guard let result = computeRowUpdates(
             updatedPacketIDs: updatedPacketIDs,
@@ -626,6 +686,7 @@ private struct PacketTableContentCache {
             structuredFilterService: structuredFilterService,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
+            wiresharkFilterMembership: wiresharkFilterMembership,
             store: cachedContent.store,
             existingTimingState: cachedRowTimingState
         ) else {
@@ -654,6 +715,7 @@ private struct PacketTableContentCache {
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
+            wiresharkFilterMembership: wiresharkFilterMembership,
             rowTimingState: result.rowTimingState
         )
     }
@@ -671,6 +733,7 @@ private struct PacketTableContentCache {
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?,
         forceReload: Bool = false
     ) -> PacketTableContent? {
         // Run the existing append path first so older-row updates apply on top of the new rows.
@@ -686,6 +749,7 @@ private struct PacketTableContentCache {
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
+            wiresharkFilterMembership: wiresharkFilterMembership,
             forceReload: forceReload
         )
 
@@ -703,6 +767,7 @@ private struct PacketTableContentCache {
             structuredFilterService: structuredFilterService,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
+            wiresharkFilterMembership: wiresharkFilterMembership,
             store: appendedContent.store,
             existingTimingState: cachedRowTimingState
         ) else {
@@ -750,6 +815,7 @@ private struct PacketTableContentCache {
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
+            wiresharkFilterMembership: wiresharkFilterMembership,
             rowTimingState: result.rowTimingState
         )
     }
@@ -773,6 +839,7 @@ private struct PacketTableContentCache {
         structuredFilterService: PacketStructuredFilterService,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?,
         store: PacketTableRowStore,
         existingTimingState: PacketTableRowTimingState
     ) -> RowUpdateResult? {
@@ -787,7 +854,8 @@ private struct PacketTableContentCache {
             let isVisibleNow = matches(packet, selection: sourceListSelection, pinnedItems: pinnedItems, ingestState: ingestState) &&
                 (displayFilter.isEmpty || displayFilter.matches(packet)) &&
                 quickFilterService.matches(packet, selection: quickFilterSelection) &&
-                structuredFilterService.matches(packet, context: structuredFilterContext)
+                structuredFilterService.matches(packet, context: structuredFilterContext) &&
+                wiresharkFilterMembership?.matches(packet, in: ingestState) != false
             let wasVisible = store.visiblePacketRowIndexByID[packetID] != nil
             guard wasVisible == isVisibleNow else {
                 return nil  // visibility flipped — caller falls back to rebuild
@@ -822,6 +890,7 @@ private struct PacketTableContentCache {
         sourceListSelection = input.signature.sourceListSelection
         pinnedItems = input.signature.pinnedItems
         savedRecords = input.signature.savedRecords
+        wiresharkFilterMembership = input.signature.wiresharkFilterMembership
         cachedContent = content
         cachedRowTimingState = rowTimingState
         return content
@@ -836,6 +905,7 @@ private struct PacketTableContentCache {
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
+        wiresharkFilterMembership: PacketWiresharkFilterMembership?,
         rowTimingState: PacketTableRowTimingState? = nil
     ) -> PacketTableContent {
         packetRevision = ingestState.packetRevision
@@ -847,11 +917,25 @@ private struct PacketTableContentCache {
         self.sourceListSelection = sourceListSelection
         self.pinnedItems = pinnedItems
         self.savedRecords = savedRecords
+        self.wiresharkFilterMembership = wiresharkFilterMembership
         cachedContent = content
         if let rowTimingState {
             cachedRowTimingState = rowTimingState
         }
         return content
+    }
+
+    private func hasSameWiresharkFilterIdentity(
+        as membership: PacketWiresharkFilterMembership?
+    ) -> Bool {
+        switch (wiresharkFilterMembership, membership) {
+        case (nil, nil):
+            return true
+        case (let current?, let next?):
+            return current.expression == next.expression
+        default:
+            return false
+        }
     }
 
     private func packets(
@@ -966,6 +1050,10 @@ final class NetworkInspectorViewModel {
     private var isPacketTableFiltering = false
     private var selectsFirstVisiblePacketAfterFiltering = false
     private var pendingSessionImportReport: TCPViewSessionImportReport?
+    private var pendingDisplayFilterValidationWorkItem: DispatchWorkItem?
+    private var displayFilterValidationGeneration: UInt64 = 0
+    private var displayFilterEvaluationGeneration: UInt64 = 0
+    private var displayFilterResultCache = PacketDisplayFilterResultCache()
 
     // Trailing-edge debounce for delegate-driven rebuilds. Live ingest fires the controller delegate
     // up to ~10 Hz; coalescing to ~12 Hz keeps the UI feeling live without burning CPU on redundant
@@ -980,6 +1068,10 @@ final class NetworkInspectorViewModel {
     private var inspectorPlacement: NetworkInspectorPlacement
     private var isInspectorVisible: Bool
     private var isStructuredFilterVisible: Bool
+    private var filterMode: PacketFilterMode
+    private var wiresharkFilterState: PacketWiresharkFilterState
+    private var wiresharkFilterMembership: PacketWiresharkFilterMembership?
+    private var wiresharkFilterMembershipLineageRevision: UInt64?
     private var displayFilterText: String
     private var structuredFilterGroup: PacketStructuredFilterGroup
     private var selectedCustomFilterID: PacketCustomFilter.ID?
@@ -1026,6 +1118,10 @@ final class NetworkInspectorViewModel {
         self.inspectorPlacement = preferences.inspectorPlacement
         self.isInspectorVisible = preferences.isInspectorVisible
         self.isStructuredFilterVisible = preferences.isStructuredFilterVisible
+        self.filterMode = preferences.filterMode
+        self.wiresharkFilterState = PacketWiresharkFilterState(draftExpression: preferences.wiresharkFilterDraft)
+        self.wiresharkFilterMembership = nil
+        self.wiresharkFilterMembershipLineageRevision = nil
         self.displayFilterText = preferences.displayFilterText
         self.structuredFilterGroup = structuredFilterStore.load()
         let sourceListSnapshot = sourceListService.snapshot(
@@ -1033,7 +1129,7 @@ final class NetworkInspectorViewModel {
             pinnedItems: pinService.pins(),
             savedPacketCount: savedPacketService.records().count
         )
-        let activeStructuredFilterGroup = isStructuredFilterVisible ? structuredFilterGroup : .default
+        let activeStructuredFilterGroup = isStructuredFilterVisible && filterMode == .builder ? structuredFilterGroup : .default
         let packetTableResolution = packetTableContentCache.content(
             for: controller.snapshot.packetIngestState,
             displayFilterText: displayFilterText,
@@ -1044,6 +1140,7 @@ final class NetworkInspectorViewModel {
             sourceListSelection: selectedSourceListSelection,
             pinnedItems: pinService.pins(),
             savedRecords: savedPacketService.records(),
+            wiresharkFilterMembership: nil,
             allowsAsyncRebuild: false,
             asyncRebuildThreshold: self.packetTableAsyncRebuildThreshold
         )
@@ -1069,6 +1166,8 @@ final class NetworkInspectorViewModel {
             inspectorPlacement: inspectorPlacement,
             isInspectorVisible: isInspectorVisible,
             isStructuredFilterVisible: isStructuredFilterVisible,
+            filterMode: filterMode,
+            wiresharkFilterState: wiresharkFilterState,
             displayFilterText: displayFilterText,
             structuredFilterGroup: structuredFilterGroup,
             isPacketTableFiltering: isPacketTableFiltering,
@@ -1249,10 +1348,84 @@ final class NetworkInspectorViewModel {
         }
 
         isStructuredFilterVisible = isVisible
+        if !isVisible {
+            cancelWiresharkFilterEvaluation(clearMembership: true)
+        }
         if !isUsingSessionDocumentState {
             preferences.persistStructuredFilterVisible(isVisible)
         }
         rebuildSnapshot()
+        if isVisible, filterMode == .wireshark {
+            reapplyWiresharkFilterIfNeeded()
+        }
+    }
+
+    func setFilterMode(_ mode: PacketFilterMode) {
+        guard filterMode != mode else {
+            if !isStructuredFilterVisible {
+                setStructuredFilterVisible(true)
+            }
+            return
+        }
+
+        cancelWiresharkFilterEvaluation(clearMembership: true)
+        filterMode = mode
+        isStructuredFilterVisible = true
+        if !isUsingSessionDocumentState {
+            preferences.persistFilterMode(mode)
+            preferences.persistStructuredFilterVisible(true)
+        }
+        rebuildSnapshot()
+        if mode == .wireshark {
+            reapplyWiresharkFilterIfNeeded()
+        }
+    }
+
+    func updateWiresharkFilterDraft(_ expression: String) {
+        wiresharkFilterState.draftExpression = expression
+        wiresharkFilterState.isValidating = true
+        if !isUsingSessionDocumentState {
+            preferences.persistWiresharkFilterDraft(expression)
+        }
+        pendingDisplayFilterValidationWorkItem?.cancel()
+        displayFilterValidationGeneration &+= 1
+        let generation = displayFilterValidationGeneration
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.validateWiresharkFilterDraft(expression, generation: generation)
+        }
+        pendingDisplayFilterValidationWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: workItem)
+        rebuildSnapshot()
+    }
+
+    func applyWiresharkFilter(completion: ((Bool) -> Void)? = nil) {
+        pendingDisplayFilterValidationWorkItem?.cancel()
+        pendingDisplayFilterValidationWorkItem = nil
+        displayFilterValidationGeneration &+= 1
+        let generation = displayFilterValidationGeneration
+        let expression = wiresharkFilterState.draftExpression
+        wiresharkFilterState.isValidating = true
+        rebuildSnapshot()
+        controller.validateDisplayFilter(expression) { [weak self] validation in
+            DispatchQueue.main.async {
+                guard let self, self.displayFilterValidationGeneration == generation else {
+                    completion?(false)
+                    return
+                }
+                self.wiresharkFilterState.isValidating = false
+                self.wiresharkFilterState.validation = validation
+                guard validation.isApplicable else {
+                    self.rebuildSnapshot()
+                    completion?(false)
+                    return
+                }
+                self.evaluateWiresharkFilter(
+                    validation.normalizedExpression,
+                    validation: validation,
+                    completion: completion
+                )
+            }
+        }
     }
 
     func toggleQuickFilter(_ id: PacketQuickFilterID) {
@@ -1274,6 +1447,20 @@ final class NetworkInspectorViewModel {
         return savedFilter
     }
 
+    @discardableResult
+    func saveWiresharkCustomFilter(name: String) throws -> PacketCustomFilter {
+        let expression = wiresharkFilterState.appliedExpression
+        let savedFilter = try customFilterService.save(
+            name: name,
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: expression
+        )
+        selectedCustomFilterID = savedFilter.id
+        rebuildSnapshot()
+        return savedFilter
+    }
+
     // Toggle or replace the structured filter editor with a saved custom filter.
     func applyCustomFilter(id: PacketCustomFilter.ID) {
         guard let filter = customFilterService.filter(id: id) else {
@@ -1282,6 +1469,7 @@ final class NetworkInspectorViewModel {
 
         if isStructuredFilterVisible, selectedCustomFilterID == filter.id {
             isStructuredFilterVisible = false
+            cancelWiresharkFilterEvaluation(clearMembership: true)
             if !isUsingSessionDocumentState {
                 preferences.persistStructuredFilterVisible(false)
             }
@@ -1289,18 +1477,33 @@ final class NetworkInspectorViewModel {
             return
         }
 
-        structuredFilterGroup = PacketStructuredFilterGroup(filters: filter.group.filters, operator: filter.group.operator)
-        if !isUsingSessionDocumentState {
-            structuredFilterStore.save(structuredFilterGroup)
-        }
+        cancelWiresharkFilterEvaluation(clearMembership: filter.mode == .builder)
+        filterMode = filter.mode
         selectedCustomFilterID = filter.id
         if !isStructuredFilterVisible {
             isStructuredFilterVisible = true
+        }
+        switch filter.mode {
+        case .builder:
+            structuredFilterGroup = PacketStructuredFilterGroup(filters: filter.group.filters, operator: filter.group.operator)
             if !isUsingSessionDocumentState {
-                preferences.persistStructuredFilterVisible(true)
+                structuredFilterStore.save(structuredFilterGroup)
+            }
+        case .wireshark:
+            let expression = filter.wiresharkExpression ?? ""
+            wiresharkFilterState.draftExpression = expression
+            if !isUsingSessionDocumentState {
+                preferences.persistWiresharkFilterDraft(expression)
             }
         }
+        if !isUsingSessionDocumentState {
+            preferences.persistStructuredFilterVisible(true)
+            preferences.persistFilterMode(filter.mode)
+        }
         rebuildSnapshot()
+        if filter.mode == .wireshark {
+            applyWiresharkFilter()
+        }
     }
 
     // Rename a saved custom filter and refresh titlebar render models.
@@ -1334,6 +1537,193 @@ final class NetworkInspectorViewModel {
             selectedCustomFilterID = nil
         }
         rebuildSnapshot()
+    }
+
+    private func validateWiresharkFilterDraft(_ expression: String, generation: UInt64) {
+        controller.validateDisplayFilter(expression) { [weak self] validation in
+            DispatchQueue.main.async {
+                guard let self,
+                      self.displayFilterValidationGeneration == generation,
+                      self.wiresharkFilterState.draftExpression == expression else {
+                    return
+                }
+                self.pendingDisplayFilterValidationWorkItem = nil
+                self.wiresharkFilterState.isValidating = false
+                self.wiresharkFilterState.validation = validation
+                self.rebuildSnapshot()
+            }
+        }
+    }
+
+    private func reapplyWiresharkFilterIfNeeded() {
+        let expression = wiresharkFilterState.appliedExpression
+        guard !expression.isEmpty,
+              isStructuredFilterVisible,
+              filterMode == .wireshark else {
+            return
+        }
+        evaluateWiresharkFilter(
+            expression,
+            validation: DisplayFilterValidation(normalizedExpression: expression, status: .valid)
+        )
+    }
+
+    // Keep the old membership visible until the complete replacement result is ready.
+    private func evaluateWiresharkFilter(
+        _ expression: String,
+        validation: DisplayFilterValidation,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        guard isStructuredFilterVisible, filterMode == .wireshark else {
+            completion?(false)
+            return
+        }
+
+        if expression.isEmpty {
+            cancelWiresharkFilterEvaluation(clearMembership: true)
+            wiresharkFilterState.validation = validation
+            wiresharkFilterState.appliedExpression = ""
+            rebuildSnapshot()
+            completion?(true)
+            return
+        }
+
+        let ingestState = controller.snapshot.packetIngestState
+        let key = displayFilterCacheKey(expression: expression, ingestState: ingestState)
+        var entry = displayFilterResultCache.entry(for: key) ?? PacketDisplayFilterCacheEntry()
+        let unknownPacketIDs = entry.unknownPacketIDs(in: ingestState)
+        if unknownPacketIDs.isEmpty {
+            displayFilterEvaluationGeneration &+= 1
+            wiresharkFilterMembership = entry.membership(
+                generation: displayFilterEvaluationGeneration,
+                expression: expression
+            )
+            wiresharkFilterMembershipLineageRevision = ingestState.packetLineageRevision
+            wiresharkFilterState.validation = validation
+            wiresharkFilterState.appliedExpression = expression
+            wiresharkFilterState.isApplying = false
+            wiresharkFilterState.evaluatedPacketCount = ingestState.packets.count
+            wiresharkFilterState.totalPacketCount = ingestState.packets.count
+            rebuildSnapshot()
+            completion?(true)
+            return
+        }
+
+        displayFilterEvaluationGeneration &+= 1
+        let generation = displayFilterEvaluationGeneration
+        wiresharkFilterState.validation = validation
+        wiresharkFilterState.isApplying = true
+        wiresharkFilterState.evaluatedPacketCount = 0
+        wiresharkFilterState.totalPacketCount = unknownPacketIDs.count
+        rebuildSnapshot()
+
+        controller.evaluateDisplayFilter(
+            expression,
+            generation: generation,
+            packetIDs: unknownPacketIDs,
+            progress: { [weak self] batch in
+                DispatchQueue.main.async {
+                    guard let self,
+                          self.displayFilterEvaluationGeneration == generation,
+                          batch.generation == generation else {
+                        return
+                    }
+                    self.wiresharkFilterState.evaluatedPacketCount = min(
+                        self.wiresharkFilterState.evaluatedPacketCount + batch.evaluatedPacketIDs.count,
+                        self.wiresharkFilterState.totalPacketCount
+                    )
+                    let evaluatedCount = self.wiresharkFilterState.evaluatedPacketCount
+                    if evaluatedCount == self.wiresharkFilterState.totalPacketCount
+                        || evaluatedCount % 1_024 < batch.evaluatedPacketIDs.count {
+                        self.rebuildSnapshot()
+                    }
+                }
+            },
+            completion: { [weak self] result in
+                DispatchQueue.main.async {
+                    guard let self, self.displayFilterEvaluationGeneration == generation else {
+                        completion?(false)
+                        return
+                    }
+                    self.wiresharkFilterState.isApplying = false
+                    switch result {
+                    case .failure(let error):
+                        let message = (error as? TCPViewerCoreError)?.message ?? error.localizedDescription
+                        self.wiresharkFilterState.validation = DisplayFilterValidation(
+                            normalizedExpression: expression,
+                            status: .unavailable,
+                            diagnostics: [DisplayFilterDiagnostic(
+                                severity: .error,
+                                message: message
+                            )]
+                        )
+                        self.rebuildSnapshot()
+                        completion?(false)
+                    case .success(let batch):
+                        entry.record(batch: batch, packetIndexByID: ingestState.packetIndexByID)
+                        self.displayFilterResultCache.store(entry, for: key)
+                        self.wiresharkFilterMembership = entry.membership(
+                            generation: generation,
+                            expression: expression
+                        )
+                        self.wiresharkFilterMembershipLineageRevision = ingestState.packetLineageRevision
+                        self.wiresharkFilterState.appliedExpression = expression
+                        self.wiresharkFilterState.evaluatedPacketCount = unknownPacketIDs.count
+                        self.wiresharkFilterState.totalPacketCount = unknownPacketIDs.count
+                        self.rebuildSnapshot()
+                        completion?(true)
+                        self.evaluateNewPacketsForActiveWiresharkFilterIfNeeded()
+                    }
+                }
+            }
+        )
+    }
+
+    private func evaluateNewPacketsForActiveWiresharkFilterIfNeeded() {
+        guard isStructuredFilterVisible,
+              filterMode == .wireshark,
+              !wiresharkFilterState.isApplying,
+              !wiresharkFilterState.appliedExpression.isEmpty else {
+            return
+        }
+        let ingestState = controller.snapshot.packetIngestState
+        let key = displayFilterCacheKey(expression: wiresharkFilterState.appliedExpression, ingestState: ingestState)
+        let entry = displayFilterResultCache.entry(for: key) ?? PacketDisplayFilterCacheEntry()
+        guard !entry.unknownPacketIDs(in: ingestState, limit: 1).isEmpty else {
+            return
+        }
+        evaluateWiresharkFilter(
+            wiresharkFilterState.appliedExpression,
+            validation: wiresharkFilterState.validation
+        )
+    }
+
+    private func displayFilterCacheKey(
+        expression: String,
+        ingestState: PacketIngestState
+    ) -> PacketDisplayFilterCacheKey {
+        PacketDisplayFilterCacheKey(
+            backingIdentity: ingestState.backingIdentity ?? ingestState.source?.rawValue ?? "empty",
+            packetLineageRevision: ingestState.packetLineageRevision,
+            expression: expression,
+            dissectionRevision: PacketDisplayFilterCacheKey.dissectionRevision
+        )
+    }
+
+    private func cancelWiresharkFilterEvaluation(clearMembership: Bool) {
+        pendingDisplayFilterValidationWorkItem?.cancel()
+        pendingDisplayFilterValidationWorkItem = nil
+        displayFilterValidationGeneration &+= 1
+        displayFilterEvaluationGeneration &+= 1
+        wiresharkFilterState.isValidating = false
+        wiresharkFilterState.isApplying = false
+        wiresharkFilterState.evaluatedPacketCount = 0
+        wiresharkFilterState.totalPacketCount = 0
+        if clearMembership {
+            wiresharkFilterMembership = nil
+            wiresharkFilterMembershipLineageRevision = nil
+            controller.clearDisplayFilters()
+        }
     }
 
     func clearPackets() {
@@ -1549,6 +1939,10 @@ final class NetworkInspectorViewModel {
             inspectorPlacement: inspectorPlacement,
             isInspectorVisible: isInspectorVisible,
             isStructuredFilterVisible: isStructuredFilterVisible,
+            filterMode: filterMode,
+            wiresharkExpression: wiresharkFilterState.appliedExpression.isEmpty
+                ? nil
+                : wiresharkFilterState.appliedExpression,
             tableColumnLayout: packetTableColumnLayoutStore.load(),
             sourceMetadata: sourceMetadata
         )
@@ -1893,11 +2287,29 @@ final class NetworkInspectorViewModel {
         inspectorPlacement = NetworkInspectorPlacement(rawValue: state.inspectorPlacement) ?? .trailing
         isInspectorVisible = state.isInspectorVisible
         isStructuredFilterVisible = state.isStructuredFilterVisible
+        filterMode = state.filterMode ?? .builder
+        let wiresharkExpression = state.wiresharkExpression ?? ""
+        wiresharkFilterState = PacketWiresharkFilterState(
+            draftExpression: wiresharkExpression,
+            validation: DisplayFilterValidation(
+                normalizedExpression: wiresharkExpression,
+                status: .valid
+            ),
+            appliedExpression: wiresharkExpression
+        )
+        wiresharkFilterMembership = nil
+        wiresharkFilterMembershipLineageRevision = nil
+        displayFilterResultCache.removeAll()
         packetTableContentCache.reset()
 
         if let selectedPacketID = state.selectedPacketID,
            controller.snapshot.packetIngestState.packet(withID: selectedPacketID) != nil {
             controller.selectPacket(selectedPacketID)
+        }
+        if isStructuredFilterVisible, filterMode == .wireshark {
+            DispatchQueue.main.async { [weak self] in
+                self?.reapplyWiresharkFilterIfNeeded()
+            }
         }
     }
 
@@ -1916,6 +2328,11 @@ final class NetworkInspectorViewModel {
         displayFilterText = preferences.displayFilterText
         structuredFilterGroup = structuredFilterStore.load()
         isStructuredFilterVisible = preferences.isStructuredFilterVisible
+        filterMode = preferences.filterMode
+        wiresharkFilterState = PacketWiresharkFilterState(draftExpression: preferences.wiresharkFilterDraft)
+        wiresharkFilterMembership = nil
+        wiresharkFilterMembershipLineageRevision = nil
+        displayFilterResultCache.removeAll()
         inspectorPlacement = preferences.inspectorPlacement
         isInspectorVisible = preferences.isInspectorVisible
         packetTableContentCache.reset()
@@ -2336,8 +2753,11 @@ final class NetworkInspectorViewModel {
             selectedSourceListSelection = .allPackets
         }
 
-        // A hidden structured filter panel behaves like no structured filter, but keeps row state for restore.
-        let activeStructuredFilterGroup = isStructuredFilterVisible ? structuredFilterGroup : .default
+        // Only the visible editor mode contributes rows; both editors retain their drafts.
+        let activeStructuredFilterGroup = isStructuredFilterVisible && filterMode == .builder ? structuredFilterGroup : .default
+        let activeWiresharkFilterMembership = isStructuredFilterVisible && filterMode == .wireshark
+            ? wiresharkFilterMembership
+            : nil
         let packetTableInput = makePacketTableBuildInput(
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -2359,6 +2779,7 @@ final class NetworkInspectorViewModel {
                 sourceListSelection: selectedSourceListSelection,
                 pinnedItems: pinnedItems,
                 savedRecords: savedRecords,
+                wiresharkFilterMembership: activeWiresharkFilterMembership,
                 allowsAsyncRebuild: true,
                 asyncRebuildThreshold: packetTableAsyncRebuildThreshold
             ) {
@@ -2397,6 +2818,8 @@ final class NetworkInspectorViewModel {
             inspectorPlacement: inspectorPlacement,
             isInspectorVisible: isInspectorVisible,
             isStructuredFilterVisible: isStructuredFilterVisible,
+            filterMode: filterMode,
+            wiresharkFilterState: wiresharkFilterState,
             displayFilterText: displayFilterText,
             structuredFilterGroup: structuredFilterGroup,
             isPacketTableFiltering: isPacketTableFiltering,
@@ -2431,7 +2854,10 @@ final class NetworkInspectorViewModel {
             structuredFilterGroup: activeStructuredFilterGroup,
             sourceListSelection: selectedSourceListSelection,
             pinnedItems: pinnedItems,
-            savedRecords: savedRecords
+            savedRecords: savedRecords,
+            wiresharkFilterMembership: isStructuredFilterVisible && filterMode == .wireshark
+                ? wiresharkFilterMembership
+                : nil
         )
         return PacketTableBuildInput(
             ingestState: controller.snapshot.packetIngestState,
@@ -2517,7 +2943,7 @@ final class NetworkInspectorViewModel {
 
         let pinnedItems = pinService.pins()
         let savedRecords = savedPacketService.records()
-        let activeStructuredFilterGroup = isStructuredFilterVisible ? structuredFilterGroup : .default
+        let activeStructuredFilterGroup = isStructuredFilterVisible && filterMode == .builder ? structuredFilterGroup : .default
         let currentInput = makePacketTableBuildInput(
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -2708,6 +3134,13 @@ final class NetworkInspectorViewModel {
 extension NetworkInspectorViewModel: TCPViewerWorkspaceControllerDelegate {
     func tcpViewerWorkspaceControllerDidChange(_ controller: TCPViewerWorkspaceController) {
         recordStatusMetrics(from: controller.snapshot)
+        if let lineageRevision = wiresharkFilterMembershipLineageRevision,
+           lineageRevision != controller.snapshot.packetIngestState.packetLineageRevision {
+            cancelWiresharkFilterEvaluation(clearMembership: true)
+            reapplyWiresharkFilterIfNeeded()
+        } else {
+            evaluateNewPacketsForActiveWiresharkFilterIfNeeded()
+        }
         scheduleCoalescedRebuild()
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketStructuredFilterViewController.swift
@@ -433,7 +433,7 @@ final class PacketStructuredFilterViewController: NSViewController {
         let normalizedGroup = PacketStructuredFilterGroup(filters: group.filters, operator: group.operator)
         let rebuildsRows = normalizedGroup != self.group
         let rebuildsFooter = isFiltering != self.isFiltering
-        self.customFilterItems = customFilterItems
+        self.customFilterItems = customFilterItems.filter { $0.mode == .builder }
         self.isFiltering = isFiltering
 
         guard rebuildsRows || rebuildsFooter else {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWiresharkFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWiresharkFilterViewController.swift
@@ -22,6 +22,10 @@ protocol PacketWiresharkFilterViewControllerDelegate: AnyObject {
         _ controller: PacketWiresharkFilterViewController,
         didRequestSaveNamed name: String
     )
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didRequestOverrideCustomFilter filterID: PacketCustomFilter.ID
+    )
     func packetWiresharkFilterViewControllerCanSave(_ controller: PacketWiresharkFilterViewController) -> Bool
     func packetWiresharkFilterViewControllerDidRequestPaywall(_ controller: PacketWiresharkFilterViewController)
     func packetWiresharkFilterViewControllerDidRequestHide(_ controller: PacketWiresharkFilterViewController)
@@ -69,6 +73,7 @@ final class PacketWiresharkFilterViewController: NSViewController, NSTextFieldDe
         color: .secondaryLabelColor
     )
     private var renderedState = PacketWiresharkFilterState()
+    private var customFilterItems: [PacketCustomFilterItem] = []
 
     override func loadView() {
         view = TCPViewerDynamicBackgroundView(backgroundColor: .windowBackgroundColor)
@@ -88,8 +93,9 @@ final class PacketWiresharkFilterViewController: NSViewController, NSTextFieldDe
         closeButton.action = #selector(hideFilter(_:))
     }
 
-    func render(state: PacketWiresharkFilterState) {
+    func render(state: PacketWiresharkFilterState, customFilterItems: [PacketCustomFilterItem]) {
         renderedState = state
+        self.customFilterItems = customFilterItems.filter { $0.mode == .wireshark }
         if expressionField.stringValue != state.draftExpression {
             expressionField.stringValue = state.draftExpression
         }
@@ -220,8 +226,55 @@ final class PacketWiresharkFilterViewController: NSViewController, NSTextFieldDe
             guard succeeded else {
                 return
             }
-            self?.presentSaveNameAlert()
+            self?.showSaveCustomFilterMenu()
         })
+    }
+
+    private func showSaveCustomFilterMenu() {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        let newFilterItem = NSMenuItem(
+            title: "New Filter...",
+            action: #selector(saveNewCustomFilter(_:)),
+            keyEquivalent: ""
+        )
+        newFilterItem.target = self
+        menu.addItem(newFilterItem)
+        menu.addItem(.separator())
+
+        let overrideItem = NSMenuItem(title: "Override", action: nil, keyEquivalent: "")
+        let overrideMenu = NSMenu()
+        if customFilterItems.isEmpty {
+            let emptyItem = NSMenuItem(title: "No Wireshark filters", action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            overrideMenu.addItem(emptyItem)
+        } else {
+            for customItem in customFilterItems {
+                let menuItem = NSMenuItem(
+                    title: customItem.title,
+                    action: #selector(overrideCustomFilter(_:)),
+                    keyEquivalent: ""
+                )
+                menuItem.target = self
+                menuItem.representedObject = customItem.id
+                overrideMenu.addItem(menuItem)
+            }
+        }
+        menu.addItem(overrideItem)
+        menu.setSubmenu(overrideMenu, for: overrideItem)
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: saveButton.bounds.height + 4), in: saveButton)
+    }
+
+    @objc private func saveNewCustomFilter(_ sender: Any?) {
+        presentSaveNameAlert()
+    }
+
+    @objc private func overrideCustomFilter(_ sender: NSMenuItem) {
+        guard let filterID = sender.representedObject as? PacketCustomFilter.ID else {
+            return
+        }
+        delegate?.packetWiresharkFilterViewController(self, didRequestOverrideCustomFilter: filterID)
     }
 
     private func presentSaveNameAlert() {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWiresharkFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWiresharkFilterViewController.swift
@@ -1,0 +1,263 @@
+//
+//  PacketWiresharkFilterViewController.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import AppKit
+import PcapPlusPlusCore
+
+protocol PacketWiresharkFilterViewControllerDelegate: AnyObject {
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didUpdateExpression expression: String
+    )
+    func packetWiresharkFilterViewControllerDidRequestApply(_ controller: PacketWiresharkFilterViewController)
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didRequestApplyBeforeSaving completion: @escaping (Bool) -> Void
+    )
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didRequestSaveNamed name: String
+    )
+    func packetWiresharkFilterViewControllerCanSave(_ controller: PacketWiresharkFilterViewController) -> Bool
+    func packetWiresharkFilterViewControllerDidRequestPaywall(_ controller: PacketWiresharkFilterViewController)
+    func packetWiresharkFilterViewControllerDidRequestHide(_ controller: PacketWiresharkFilterViewController)
+}
+
+enum PacketWiresharkFilterTextRange {
+    static func nsRange(for range: DisplayFilterSourceRange, in expression: String) -> NSRange? {
+        let utf8 = expression.utf8
+        guard range.utf8StartOffset <= utf8.count,
+              range.utf8StartOffset + range.utf8Length <= utf8.count else {
+            return nil
+        }
+        let utf8Start = utf8.index(utf8.startIndex, offsetBy: range.utf8StartOffset)
+        let utf8End = utf8.index(utf8Start, offsetBy: range.utf8Length)
+        guard let start = String.Index(utf8Start, within: expression),
+              let end = String.Index(utf8End, within: expression) else {
+            return nil
+        }
+        return NSRange(start..<end, in: expression)
+    }
+
+    static func column(for range: DisplayFilterSourceRange, in expression: String) -> Int {
+        let utf8 = expression.utf8
+        let offset = min(range.utf8StartOffset, utf8.count)
+        let utf8Index = utf8.index(utf8.startIndex, offsetBy: offset)
+        guard let stringIndex = String.Index(utf8Index, within: expression) else {
+            return offset + 1
+        }
+        return expression.distance(from: expression.startIndex, to: stringIndex) + 1
+    }
+}
+
+final class PacketWiresharkFilterViewController: NSViewController, NSTextFieldDelegate {
+    weak var delegate: PacketWiresharkFilterViewControllerDelegate?
+
+    private let expressionField = NSTextField()
+    private let applyButton = NSButton(title: "Apply", target: nil, action: nil)
+    private let saveButton = NSButton(title: "Save", target: nil, action: nil)
+    private let helpButton = NSButton(title: "Syntax Help", target: nil, action: nil)
+    private let closeButton = NSButton(title: "", target: nil, action: nil)
+    private let progressIndicator = NSProgressIndicator()
+    private let diagnosticLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.smallSystemFontSize),
+        color: .secondaryLabelColor
+    )
+    private var renderedState = PacketWiresharkFilterState()
+
+    override func loadView() {
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .windowBackgroundColor)
+        setupLayout()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        expressionField.delegate = self
+        applyButton.target = self
+        applyButton.action = #selector(applyFilter(_:))
+        saveButton.target = self
+        saveButton.action = #selector(saveFilter(_:))
+        helpButton.target = self
+        helpButton.action = #selector(openSyntaxHelp(_:))
+        closeButton.target = self
+        closeButton.action = #selector(hideFilter(_:))
+    }
+
+    func render(state: PacketWiresharkFilterState) {
+        renderedState = state
+        if expressionField.stringValue != state.draftExpression {
+            expressionField.stringValue = state.draftExpression
+        }
+        applyButton.isEnabled = !state.isValidating && !state.isApplying
+        saveButton.isEnabled = !state.isValidating && !state.isApplying
+        progressIndicator.isHidden = !state.isValidating && !state.isApplying
+        if state.isValidating || state.isApplying {
+            progressIndicator.startAnimation(nil)
+        } else {
+            progressIndicator.stopAnimation(nil)
+        }
+        renderDiagnostic(state)
+    }
+
+    func focusExpressionField() {
+        view.window?.makeFirstResponder(expressionField)
+        expressionField.currentEditor()?.moveToEndOfDocument(nil)
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        delegate?.packetWiresharkFilterViewController(self, didUpdateExpression: expressionField.stringValue)
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        doCommandBy commandSelector: Selector
+    ) -> Bool {
+        switch commandSelector {
+        case #selector(NSResponder.insertNewline(_:)):
+            applyFilter(nil)
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            hideFilter(nil)
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func setupLayout() {
+        expressionField.placeholderString = "Wireshark display filter, for example: ip.addr == 192.168.1.1"
+        expressionField.usesSingleLineMode = true
+        expressionField.lineBreakMode = .byClipping
+        expressionField.cell?.isScrollable = true
+        expressionField.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
+
+        for button in [applyButton, saveButton] {
+            button.bezelStyle = .rounded
+            button.controlSize = .small
+        }
+        helpButton.bezelStyle = .inline
+        helpButton.controlSize = .small
+        helpButton.toolTip = "Open the Wireshark display-filter reference"
+
+        closeButton.bezelStyle = .inline
+        closeButton.controlSize = .small
+        closeButton.image = TCPViewerUI.image("xmark")
+        closeButton.toolTip = "Hide filter (Escape)"
+
+        progressIndicator.style = .spinning
+        progressIndicator.controlSize = .small
+        progressIndicator.isDisplayedWhenStopped = false
+        progressIndicator.isHidden = true
+
+        diagnosticLabel.lineBreakMode = .byTruncatingTail
+        diagnosticLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let fieldRow = NSStackView(views: [expressionField, progressIndicator, applyButton, saveButton, helpButton, closeButton])
+        fieldRow.orientation = .horizontal
+        fieldRow.alignment = .centerY
+        fieldRow.spacing = 8
+
+        let stack = NSStackView(views: [fieldRow, diagnosticLabel])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            expressionField.widthAnchor.constraint(greaterThanOrEqualToConstant: 280),
+            progressIndicator.widthAnchor.constraint(equalToConstant: 14),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
+            stack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -7),
+            fieldRow.widthAnchor.constraint(equalTo: stack.widthAnchor),
+        ])
+        expressionField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    }
+
+    private func renderDiagnostic(_ state: PacketWiresharkFilterState) {
+        if let progressText = state.progressText {
+            diagnosticLabel.stringValue = progressText
+            diagnosticLabel.textColor = .secondaryLabelColor
+            return
+        }
+        guard let diagnostic = state.diagnostic else {
+            diagnosticLabel.stringValue = state.appliedExpression.isEmpty ? "Use Wireshark display-filter syntax." : "Filter applied."
+            diagnosticLabel.textColor = .secondaryLabelColor
+            return
+        }
+
+        let columnText = diagnostic.range.map {
+            "Column \(PacketWiresharkFilterTextRange.column(for: $0, in: state.draftExpression)): "
+        } ?? ""
+        diagnosticLabel.stringValue = columnText + diagnostic.message
+        diagnosticLabel.textColor = diagnostic.severity == .warning ? .systemOrange : .systemRed
+        if let range = diagnostic.range,
+           let selection = PacketWiresharkFilterTextRange.nsRange(for: range, in: state.draftExpression),
+           let editor = expressionField.currentEditor() {
+            editor.selectedRange = selection
+            editor.scrollRangeToVisible(selection)
+        }
+    }
+
+    @objc private func applyFilter(_ sender: Any?) {
+        delegate?.packetWiresharkFilterViewControllerDidRequestApply(self)
+    }
+
+    @objc private func saveFilter(_ sender: Any?) {
+        guard delegate?.packetWiresharkFilterViewControllerCanSave(self) ?? true else {
+            delegate?.packetWiresharkFilterViewControllerDidRequestPaywall(self)
+            return
+        }
+        delegate?.packetWiresharkFilterViewController(self, didRequestApplyBeforeSaving: { [weak self] succeeded in
+            guard succeeded else {
+                return
+            }
+            self?.presentSaveNameAlert()
+        })
+    }
+
+    private func presentSaveNameAlert() {
+        let alert = NSAlert()
+        alert.messageText = "Save Wireshark Filter"
+        alert.informativeText = "Choose a name for this display filter."
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+        let nameField = NSTextField(string: "")
+        nameField.placeholderString = "Filter name"
+        alert.accessoryView = nameField
+        let handleResponse: (NSApplication.ModalResponse) -> Void = { [weak self] response in
+            guard response == .alertFirstButtonReturn,
+                  let name = try? PacketCustomFilterService.normalizedName(nameField.stringValue) else {
+                return
+            }
+            guard let self else {
+                return
+            }
+            self.delegate?.packetWiresharkFilterViewController(self, didRequestSaveNamed: name)
+        }
+        if let window = view.window {
+            alert.beginSheetModal(for: window, completionHandler: handleResponse)
+        } else {
+            handleResponse(alert.runModal())
+        }
+    }
+
+    @objc private func openSyntaxHelp(_ sender: Any?) {
+        guard let url = URL(string: "https://www.wireshark.org/docs/wsug_html_chunked/ChWorkBuildDisplayFilterSection.html") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func hideFilter(_ sender: Any?) {
+        delegate?.packetWiresharkFilterViewControllerDidRequestHide(self)
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWiresharkFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWiresharkFilterViewController.swift
@@ -99,8 +99,8 @@ final class PacketWiresharkFilterViewController: NSViewController, NSTextFieldDe
         if expressionField.stringValue != state.draftExpression {
             expressionField.stringValue = state.draftExpression
         }
-        applyButton.isEnabled = !state.isValidating && !state.isApplying
-        saveButton.isEnabled = !state.isValidating && !state.isApplying
+        applyButton.isEnabled = !state.isApplying
+        saveButton.isEnabled = !state.isApplying
         progressIndicator.isHidden = !state.isValidating && !state.isApplying
         if state.isValidating || state.isApplying {
             progressIndicator.startAnimation(nil)

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -58,6 +58,10 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
         _ controller: PacketWorkspaceViewController,
         didRequestSaveWiresharkFilterNamed name: String
     )
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestOverrideWiresharkFilter filterID: PacketCustomFilter.ID
+    )
 }
 
 private final class VerticallyCenteredTextFieldCell: NSTextFieldCell {
@@ -171,7 +175,10 @@ final class PacketWorkspaceViewController: NSViewController {
             isFiltering: snapshot.isPacketTableFiltering,
             customFilterItems: snapshot.customFilterItems
         )
-        wiresharkFilterController.render(state: snapshot.wiresharkFilterState)
+        wiresharkFilterController.render(
+            state: snapshot.wiresharkFilterState,
+            customFilterItems: snapshot.customFilterItems
+        )
         applyFilterVisibility(snapshot.isStructuredFilterVisible, mode: snapshot.filterMode)
 
         if viewModel.isEmpty {
@@ -555,6 +562,13 @@ extension PacketWorkspaceViewController: PacketWiresharkFilterViewControllerDele
         didRequestSaveNamed name: String
     ) {
         delegate?.packetWorkspaceViewController(self, didRequestSaveWiresharkFilterNamed: name)
+    }
+
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didRequestOverrideCustomFilter filterID: PacketCustomFilter.ID
+    ) {
+        delegate?.packetWorkspaceViewController(self, didRequestOverrideWiresharkFilter: filterID)
     }
 
     func packetWiresharkFilterViewControllerCanSave(_ controller: PacketWiresharkFilterViewController) -> Bool {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -45,6 +45,19 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
     func packetWorkspaceViewControllerCanSaveCustomFilter(_ controller: PacketWorkspaceViewController) -> Bool
     func packetWorkspaceViewControllerDidRequestStructuredFilterPaywall(_ controller: PacketWorkspaceViewController)
     func packetWorkspaceViewControllerDidRequestHideStructuredFilter(_ controller: PacketWorkspaceViewController)
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didUpdateWiresharkFilterExpression expression: String
+    )
+    func packetWorkspaceViewControllerDidRequestApplyWiresharkFilter(_ controller: PacketWorkspaceViewController)
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestApplyWiresharkFilterBeforeSaving completion: @escaping (Bool) -> Void
+    )
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestSaveWiresharkFilterNamed name: String
+    )
 }
 
 private final class VerticallyCenteredTextFieldCell: NSTextFieldCell {
@@ -119,10 +132,13 @@ final class PacketWorkspaceViewController: NSViewController {
     private let viewModel = PacketWorkspaceViewModel()
     private let contentContainer = NSView()
     private let structuredFilterController = PacketStructuredFilterViewController()
+    private let wiresharkFilterController = PacketWiresharkFilterViewController()
     private let tableController: PacketTableViewController
     private var placeholderView: NSView?
     private var isStructuredFilterVisible = false
-    private var contentTopToFilterBottomConstraint: NSLayoutConstraint?
+    private var filterMode: PacketFilterMode = .builder
+    private var contentTopToBuilderBottomConstraint: NSLayoutConstraint?
+    private var contentTopToWiresharkBottomConstraint: NSLayoutConstraint?
     private var contentTopToSafeAreaConstraint: NSLayoutConstraint?
 
     init(configuration: AppConfiguration) {
@@ -144,6 +160,7 @@ final class PacketWorkspaceViewController: NSViewController {
         super.viewDidLoad()
         tableController.delegate = self
         structuredFilterController.delegate = self
+        wiresharkFilterController.delegate = self
     }
 
     // Render the packet workspace and swap between the table and empty state as needed.
@@ -154,7 +171,8 @@ final class PacketWorkspaceViewController: NSViewController {
             isFiltering: snapshot.isPacketTableFiltering,
             customFilterItems: snapshot.customFilterItems
         )
-        applyStructuredFilterVisibility(snapshot.isStructuredFilterVisible)
+        wiresharkFilterController.render(state: snapshot.wiresharkFilterState)
+        applyFilterVisibility(snapshot.isStructuredFilterVisible, mode: snapshot.filterMode)
 
         if viewModel.isEmpty {
             showPlaceholder(
@@ -182,8 +200,13 @@ final class PacketWorkspaceViewController: NSViewController {
     }
 
     func focusStructuredFilter() {
-        applyStructuredFilterVisibility(true)
-        structuredFilterController.focusLastFilterTextField()
+        applyFilterVisibility(true, mode: filterMode)
+        switch filterMode {
+        case .builder:
+            structuredFilterController.focusLastFilterTextField()
+        case .wireshark:
+            wiresharkFilterController.focusExpressionField()
+        }
     }
 
     func createCustomColumn(from request: PacketCustomColumnRequest) {
@@ -195,15 +218,21 @@ final class PacketWorkspaceViewController: NSViewController {
         view.addSubview(contentContainer)
 
         addChild(structuredFilterController)
+        addChild(wiresharkFilterController)
         addChild(tableController)
         structuredFilterController.view.translatesAutoresizingMaskIntoConstraints = false
+        wiresharkFilterController.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(structuredFilterController.view)
+        view.addSubview(wiresharkFilterController.view)
 
-        let contentTopToFilterBottomConstraint = contentContainer.topAnchor.constraint(equalTo: structuredFilterController.view.bottomAnchor)
+        let contentTopToBuilderBottomConstraint = contentContainer.topAnchor.constraint(equalTo: structuredFilterController.view.bottomAnchor)
+        let contentTopToWiresharkBottomConstraint = contentContainer.topAnchor.constraint(equalTo: wiresharkFilterController.view.bottomAnchor)
         let contentTopToSafeAreaConstraint = contentContainer.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
-        self.contentTopToFilterBottomConstraint = contentTopToFilterBottomConstraint
+        self.contentTopToBuilderBottomConstraint = contentTopToBuilderBottomConstraint
+        self.contentTopToWiresharkBottomConstraint = contentTopToWiresharkBottomConstraint
         self.contentTopToSafeAreaConstraint = contentTopToSafeAreaConstraint
         structuredFilterController.view.isHidden = true
+        wiresharkFilterController.view.isHidden = true
 
         NSLayoutConstraint.activate([
             contentContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -214,21 +243,33 @@ final class PacketWorkspaceViewController: NSViewController {
             structuredFilterController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             structuredFilterController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             structuredFilterController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+
+            wiresharkFilterController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            wiresharkFilterController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            wiresharkFilterController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
         ])
     }
 
-    private func applyStructuredFilterVisibility(_ isVisible: Bool) {
-        guard isStructuredFilterVisible != isVisible else {
+    private func applyFilterVisibility(_ isVisible: Bool, mode: PacketFilterMode) {
+        guard isStructuredFilterVisible != isVisible || filterMode != mode else {
             return
         }
 
         isStructuredFilterVisible = isVisible
-        structuredFilterController.view.isHidden = !isVisible
+        filterMode = mode
+        structuredFilterController.view.isHidden = !isVisible || mode != .builder
+        wiresharkFilterController.view.isHidden = !isVisible || mode != .wireshark
+        contentTopToBuilderBottomConstraint?.isActive = false
+        contentTopToWiresharkBottomConstraint?.isActive = false
         if isVisible {
             contentTopToSafeAreaConstraint?.isActive = false
-            contentTopToFilterBottomConstraint?.isActive = true
+            switch mode {
+            case .builder:
+                contentTopToBuilderBottomConstraint?.isActive = true
+            case .wireshark:
+                contentTopToWiresharkBottomConstraint?.isActive = true
+            }
         } else {
-            contentTopToFilterBottomConstraint?.isActive = false
             contentTopToSafeAreaConstraint?.isActive = true
         }
     }
@@ -483,6 +524,48 @@ extension PacketWorkspaceViewController: PacketStructuredFilterViewControllerDel
     }
 
     func packetStructuredFilterViewControllerDidRequestHide(_ controller: PacketStructuredFilterViewController) {
+        delegate?.packetWorkspaceViewControllerDidRequestHideStructuredFilter(self)
+    }
+}
+
+extension PacketWorkspaceViewController: PacketWiresharkFilterViewControllerDelegate {
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didUpdateExpression expression: String
+    ) {
+        delegate?.packetWorkspaceViewController(self, didUpdateWiresharkFilterExpression: expression)
+    }
+
+    func packetWiresharkFilterViewControllerDidRequestApply(_ controller: PacketWiresharkFilterViewController) {
+        delegate?.packetWorkspaceViewControllerDidRequestApplyWiresharkFilter(self)
+    }
+
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didRequestApplyBeforeSaving completion: @escaping (Bool) -> Void
+    ) {
+        delegate?.packetWorkspaceViewController(
+            self,
+            didRequestApplyWiresharkFilterBeforeSaving: completion
+        )
+    }
+
+    func packetWiresharkFilterViewController(
+        _ controller: PacketWiresharkFilterViewController,
+        didRequestSaveNamed name: String
+    ) {
+        delegate?.packetWorkspaceViewController(self, didRequestSaveWiresharkFilterNamed: name)
+    }
+
+    func packetWiresharkFilterViewControllerCanSave(_ controller: PacketWiresharkFilterViewController) -> Bool {
+        delegate?.packetWorkspaceViewControllerCanSaveCustomFilter(self) ?? true
+    }
+
+    func packetWiresharkFilterViewControllerDidRequestPaywall(_ controller: PacketWiresharkFilterViewController) {
+        delegate?.packetWorkspaceViewControllerDidRequestStructuredFilterPaywall(self)
+    }
+
+    func packetWiresharkFilterViewControllerDidRequestHide(_ controller: PacketWiresharkFilterViewController) {
         delegate?.packetWorkspaceViewControllerDidRequestHideStructuredFilter(self)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
@@ -11,7 +11,8 @@ import PcapPlusPlusCore
 protocol StatusStripViewControllerDelegate: AnyObject {
     func statusStripViewControllerDidRequestCancelLoad(_ controller: StatusStripViewController)
     func statusStripViewControllerDidRequestClearPackets(_ controller: StatusStripViewController)
-    func statusStripViewControllerDidToggleStructuredFilter(_ controller: StatusStripViewController)
+    func statusStripViewController(_ controller: StatusStripViewController, didSelectFilterMode mode: PacketFilterMode)
+    func statusStripViewControllerDidRequestHideFilter(_ controller: StatusStripViewController)
 }
 
 final class StatusStripViewModel {
@@ -19,6 +20,7 @@ final class StatusStripViewModel {
     private(set) var canCancelLoad = false
     private(set) var canClear = false
     private(set) var isStructuredFilterVisible = false
+    private(set) var filterMode: PacketFilterMode = .builder
     private(set) var metricsText = TCPViewerStatusMetricsFormatter.displayText(for: .empty)
 
     // Build the compact bottom strip controls from the current packet/capture snapshot.
@@ -28,6 +30,7 @@ final class StatusStripViewModel {
         canCancelLoad = snapshot.base.loadState.canCancel
         canClear = snapshot.visiblePacketCount > 0 && !canCancelLoad
         isStructuredFilterVisible = snapshot.isStructuredFilterVisible
+        filterMode = snapshot.filterMode
     }
 
     // Format the lightweight process and captured-traffic metrics for the strip.
@@ -66,7 +69,7 @@ final class StatusStripViewController: NSViewController {
         clearButton.target = self
         clearButton.action = #selector(clearPackets(_:))
         filterButton.target = self
-        filterButton.action = #selector(toggleStructuredFilter(_:))
+        filterButton.action = #selector(showFilterMenu(_:))
     }
 
     func render(snapshot: NetworkInspectorSnapshot, metrics: TCPViewerStatusMetricsSnapshot = .empty) {
@@ -157,7 +160,32 @@ final class StatusStripViewController: NSViewController {
         delegate?.statusStripViewControllerDidRequestClearPackets(self)
     }
 
-    @objc private func toggleStructuredFilter(_ sender: Any?) {
-        delegate?.statusStripViewControllerDidToggleStructuredFilter(self)
+    @objc private func showFilterMenu(_ sender: Any?) {
+        let menu = NSMenu()
+        for mode in PacketFilterMode.allCases {
+            let item = NSMenuItem(title: mode.title, action: #selector(selectFilterMode(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = mode.rawValue
+            item.state = viewModel.isStructuredFilterVisible && viewModel.filterMode == mode ? .on : .off
+            menu.addItem(item)
+        }
+        menu.addItem(.separator())
+        let hideItem = NSMenuItem(title: "Hide Filter", action: #selector(hideFilter(_:)), keyEquivalent: "")
+        hideItem.target = self
+        hideItem.isEnabled = viewModel.isStructuredFilterVisible
+        menu.addItem(hideItem)
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: filterButton.bounds.maxY + 2), in: filterButton)
+    }
+
+    @objc private func selectFilterMode(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let mode = PacketFilterMode(rawValue: rawValue) else {
+            return
+        }
+        delegate?.statusStripViewController(self, didSelectFilterMode: mode)
+    }
+
+    @objc private func hideFilter(_ sender: Any?) {
+        delegate?.statusStripViewControllerDidRequestHideFilter(self)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -1438,6 +1438,17 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         }
     }
 
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestOverrideWiresharkFilter filterID: PacketCustomFilter.ID
+    ) {
+        do {
+            try viewModel.overrideWiresharkCustomFilter(id: filterID)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Override Filter")
+        }
+    }
+
     fileprivate func canUsePinFeature() -> Bool {
         TCPViewerLicenseService.shared.isLicenseAuthorized
     }

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -1409,6 +1409,35 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         viewModel.setStructuredFilterVisible(false)
     }
 
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didUpdateWiresharkFilterExpression expression: String
+    ) {
+        viewModel.updateWiresharkFilterDraft(expression)
+    }
+
+    func packetWorkspaceViewControllerDidRequestApplyWiresharkFilter(_ controller: PacketWorkspaceViewController) {
+        viewModel.applyWiresharkFilter()
+    }
+
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestApplyWiresharkFilterBeforeSaving completion: @escaping (Bool) -> Void
+    ) {
+        viewModel.applyWiresharkFilter(completion: completion)
+    }
+
+    func packetWorkspaceViewController(
+        _ controller: PacketWorkspaceViewController,
+        didRequestSaveWiresharkFilterNamed name: String
+    ) {
+        do {
+            try viewModel.saveWiresharkCustomFilter(name: name)
+        } catch {
+            presentCustomFilterError(error, title: "Could Not Save Filter")
+        }
+    }
+
     fileprivate func canUsePinFeature() -> Bool {
         TCPViewerLicenseService.shared.isLicenseAuthorized
     }
@@ -1549,12 +1578,13 @@ extension TCPViewerRootViewController: StatusStripViewControllerDelegate {
         viewModel.clearTablePackets()
     }
 
-    func statusStripViewControllerDidToggleStructuredFilter(_ controller: StatusStripViewController) {
-        let shouldShow = !viewModel.snapshot.isStructuredFilterVisible
-        viewModel.setStructuredFilterVisible(shouldShow)
-        if shouldShow {
-            workspaceViewController.focusStructuredFilter()
-        }
+    func statusStripViewController(_ controller: StatusStripViewController, didSelectFilterMode mode: PacketFilterMode) {
+        viewModel.setFilterMode(mode)
+        workspaceViewController.focusStructuredFilter()
+    }
+
+    func statusStripViewControllerDidRequestHideFilter(_ controller: StatusStripViewController) {
+        viewModel.setStructuredFilterVisible(false)
     }
 }
 

--- a/TCPViewerTests/App/WorkspaceControllerTests.swift
+++ b/TCPViewerTests/App/WorkspaceControllerTests.swift
@@ -771,6 +771,56 @@ struct WindowControllerTests {
         await tearDown(controller)
     }
 
+    @Test func importedDisplayFilterResultsRemapEachBackingDocumentToWorkspacePacketIDs() async throws {
+        let firstURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(URL(fileURLWithPath: "/tmp/filter-import-one.pcap"))
+        let secondURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(URL(fileURLWithPath: "/tmp/filter-import-two.pcapng"))
+        let firstPackets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .udp),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .tcp),
+        ]
+        let secondPackets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .dns),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .tls),
+        ]
+        let expression = "frame.number in {1, 2}"
+        let firstDocument = FakeOfflineDocument(
+            url: firstURL,
+            metadata: CaptureDocumentMetadata(format: .pcap),
+            openPlan: .completed(firstPackets),
+            displayFilterMatchesByExpression: [expression: [2]]
+        )
+        let secondDocument = FakeOfflineDocument(
+            url: secondURL,
+            metadata: CaptureDocumentMetadata(format: .pcapng),
+            openPlan: .completed(secondPackets),
+            displayFilterMatchesByExpression: [expression: [1]]
+        )
+        let controller = TCPViewerWorkspaceController(services: TCPViewerServiceRegistry(core: FakeTCPViewerCore(
+            interfaceInventories: [[]],
+            documentFactory: { $0 == secondURL ? secondDocument : firstDocument }
+        )))
+
+        await controller.importDocuments(at: [firstURL, secondURL])
+        await waitUntil { controller.snapshot.packetIngestState.totalPacketCount == 4 }
+
+        let result: Result<DisplayFilterMatchBatch, Error> = await withCheckedContinuation { continuation in
+            controller.evaluateDisplayFilter(
+                expression,
+                generation: 9,
+                packetIDs: [1, 2, 3, 4],
+                cancellationToken: DisplayFilterEvaluationCancellationToken()
+            ) { continuation.resume(returning: $0) }
+        }
+        let batch = try result.get()
+
+        #expect(batch.evaluatedPacketIDs == [1, 2, 3, 4])
+        #expect(batch.matchingPacketIDs == [2, 3])
+        #expect(firstDocument.displayFilterEvaluationRequests == [[1, 2]])
+        #expect(secondDocument.displayFilterEvaluationRequests == [[1, 2]])
+
+        await tearDown(controller)
+    }
+
     @Test func importingEmptyCaptureFileKeepsImportedFileStateAndDedupes() async {
         let captureURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(URL(fileURLWithPath: "/tmp/empty-import.pcapng"))
         let document = FakeOfflineDocument(
@@ -2172,25 +2222,30 @@ private final class FakeOfflineDocument: OfflineCaptureDocumentProviding, @unche
     private let openPlan: LoadPlan
     private let reopenPlan: LoadPlan
     private let inspections: [PacketSummary.ID: PacketInspection]
+    private let displayFilterMatchesByExpression: [String: Set<PacketSummary.ID>]
+    private var displayFilterExpressionByGeneration: [UInt64: String] = [:]
 
     private(set) var saveCount = 0
     private(set) var saveAsRequests: [(URL, CaptureFileFormat)] = []
     private(set) var exportRequests: [([PacketSummary.ID], URL, CaptureFileFormat)] = []
     private(set) var cancelLoadingCount = 0
     private(set) var currentProgress: PacketLoadProgress = .idle
+    private(set) var displayFilterEvaluationRequests: [[PacketSummary.ID]] = []
 
     init(
         url: URL,
         metadata: CaptureDocumentMetadata,
         openPlan: LoadPlan,
         reopenPlan: LoadPlan? = nil,
-        inspections: [PacketSummary.ID: PacketInspection] = [:]
+        inspections: [PacketSummary.ID: PacketInspection] = [:],
+        displayFilterMatchesByExpression: [String: Set<PacketSummary.ID>] = [:]
     ) {
         self.url = url
         self.metadata = metadata
         self.openPlan = openPlan
         self.reopenPlan = reopenPlan ?? openPlan
         self.inspections = inspections
+        self.displayFilterMatchesByExpression = displayFilterMatchesByExpression
     }
 
     func open(completion: @escaping TCPViewerCompletion<[PacketSummary]>) {
@@ -2226,6 +2281,35 @@ private final class FakeOfflineDocument: OfflineCaptureDocumentProviding, @unche
             ],
             decodeStatus: packet.decodeStatus
         )))
+    }
+
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        displayFilterExpressionByGeneration[generation] = expression
+        completion(DisplayFilterValidation(normalizedExpression: expression, status: .valid))
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        displayFilterEvaluationRequests.append(packetIDs)
+        let expression = displayFilterExpressionByGeneration[generation] ?? ""
+        let matchingIDs = displayFilterMatchesByExpression[expression] ?? []
+        completion(.success(DisplayFilterMatchBatch(
+            generation: generation,
+            evaluatedPacketIDs: packetIDs,
+            matchingPacketIDs: packetIDs.filter(matchingIDs.contains)
+        )))
+    }
+
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        displayFilterExpressionByGeneration.removeAll()
+        completion(.success(()))
     }
 
     func save(completion: @escaping TCPViewerVoidCompletion) {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -324,6 +324,51 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id])
     }
 
+    @Test func invalidSavedWiresharkFilterKeepsTheLastSuccessfulPacketMembership() async throws {
+        let openURL = URL(fileURLWithPath: "/tmp/display-filter-invalid-saved-reapply.pcapng")
+        let firstPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let secondPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .udp)
+        let document = InspectorFakeDocument(url: openURL, packets: [firstPacket, secondPacket])
+        document.displayFilterMatchesByExpression["tcp"] = [firstPacket.id]
+        let customFilterService = PacketCustomFilterService(
+            storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        )
+        let savedFilter = try customFilterService.save(
+            name: "Legacy expression",
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: "invalid filter"
+        )
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults(),
+            customFilterService: customFilterService
+        )
+
+        await viewModel.openDocument(at: openURL)
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("tcp")
+        viewModel.applyWiresharkFilter()
+        await waitUntil {
+            viewModel.snapshot.wiresharkFilterState.appliedExpression == "tcp"
+                && viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id]
+        }
+
+        viewModel.applyCustomFilter(id: savedFilter.id)
+        await waitUntil {
+            viewModel.snapshot.wiresharkFilterState.validation.status == .invalid
+                && !viewModel.snapshot.wiresharkFilterState.isValidating
+        }
+
+        #expect(viewModel.snapshot.filterMode == .wireshark)
+        #expect(viewModel.snapshot.wiresharkFilterState.draftExpression == "invalid filter")
+        #expect(viewModel.snapshot.wiresharkFilterState.appliedExpression == "tcp")
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id])
+    }
+
     @Test func staleWiresharkEvaluationCannotReplaceTheCurrentGeneration() async {
         let openURL = URL(fileURLWithPath: "/tmp/display-filter-generation.pcapng")
         let firstPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -290,6 +290,80 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.base.documentState.fileURL == saveURL)
     }
 
+    @Test func invalidWiresharkApplyKeepsTheLastSuccessfulPacketMembership() async {
+        let openURL = URL(fileURLWithPath: "/tmp/display-filter-invalid-apply.pcapng")
+        let firstPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let secondPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .udp)
+        let document = InspectorFakeDocument(url: openURL, packets: [firstPacket, secondPacket])
+        document.displayFilterMatchesByExpression["tcp"] = [firstPacket.id]
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.openDocument(at: openURL)
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("tcp")
+        viewModel.applyWiresharkFilter()
+        await waitUntil {
+            viewModel.snapshot.wiresharkFilterState.appliedExpression == "tcp"
+                && viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id]
+        }
+
+        viewModel.updateWiresharkFilterDraft("invalid filter")
+        viewModel.applyWiresharkFilter()
+        await waitUntil {
+            viewModel.snapshot.wiresharkFilterState.validation.status == .invalid
+                && !viewModel.snapshot.wiresharkFilterState.isValidating
+        }
+
+        #expect(viewModel.snapshot.wiresharkFilterState.appliedExpression == "tcp")
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id])
+    }
+
+    @Test func staleWiresharkEvaluationCannotReplaceTheCurrentGeneration() async {
+        let openURL = URL(fileURLWithPath: "/tmp/display-filter-generation.pcapng")
+        let firstPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let secondPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .udp)
+        let document = InspectorFakeDocument(url: openURL, packets: [firstPacket, secondPacket])
+        document.displayFilterMatchesByExpression["first"] = [firstPacket.id]
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.openDocument(at: openURL)
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("first")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id] }
+
+        document.holdsDisplayFilterEvaluations = true
+        viewModel.updateWiresharkFilterDraft("second")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { document.pendingDisplayFilterEvaluationCount == 1 }
+        viewModel.updateWiresharkFilterDraft("third")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { document.pendingDisplayFilterEvaluationCount == 2 }
+
+        document.completeDisplayFilterEvaluation(expression: "second", matchingPacketIDs: [secondPacket.id])
+        await Task.yield()
+        #expect(viewModel.snapshot.wiresharkFilterState.appliedExpression == "first")
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id])
+
+        document.completeDisplayFilterEvaluation(expression: "third", matchingPacketIDs: [secondPacket.id])
+        await waitUntil {
+            viewModel.snapshot.wiresharkFilterState.appliedExpression == "third"
+                && viewModel.snapshot.packetRows.map(\.id) == [secondPacket.id]
+        }
+    }
+
     @Test func missingNetworkHelperShowsOnboardingButOfflineOpenStillWorks() async {
         let openURL = URL(fileURLWithPath: "/tmp/offline-while-helper-missing.pcapng")
         let packets = [makePacket(packetNumber: 1, source: .offline, transportHint: .udp)]
@@ -3518,6 +3592,19 @@ private final class InspectorFakeCore: TCPViewerCoreProviding, @unchecked Sendab
         ))
     }
 
+    func validateDisplayFilter(_ expression: String, completion: @escaping (DisplayFilterValidation) -> Void) {
+        let normalized = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized == "invalid filter" {
+            completion(DisplayFilterValidation(
+                normalizedExpression: normalized,
+                status: .invalid,
+                diagnostics: [DisplayFilterDiagnostic(severity: .error, message: "Invalid display filter.")]
+            ))
+        } else {
+            completion(DisplayFilterValidation(normalizedExpression: normalized, status: .valid))
+        }
+    }
+
     func validateCaptureOptions(_ options: CaptureOptions, for interface: CaptureInterfaceSummary?) throws -> CaptureOptions {
         try options.validated(for: interface)
     }
@@ -3663,7 +3750,16 @@ private final class InspectorFakeLiveSession: LiveCaptureSessionProviding, @unch
 }
 
 private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unchecked Sendable {
+    private struct PendingDisplayFilterEvaluation {
+        let expression: String
+        let packetIDs: [PacketSummary.ID]
+        let generation: UInt64
+        let completion: TCPViewerCompletion<DisplayFilterMatchBatch>
+    }
+
     var eventHandler: PacketIngestEventHandler?
+    var displayFilterMatchesByExpression: [String: Set<PacketSummary.ID>] = [:]
+    var holdsDisplayFilterEvaluations = false
     private(set) var url: URL
     private(set) var packets: [PacketSummary]
     private(set) var metadata: CaptureDocumentMetadata
@@ -3672,6 +3768,12 @@ private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unc
     private(set) var exportRequests: [([PacketSummary.ID], URL, CaptureFileFormat)] = []
     private(set) var exportMetadataRequests: [PacketExportMetadata] = []
     private var progress: PacketLoadProgress = .idle
+    private var displayFilterExpressionByGeneration: [UInt64: String] = [:]
+    private var pendingDisplayFilterEvaluations: [PendingDisplayFilterEvaluation] = []
+
+    var pendingDisplayFilterEvaluationCount: Int {
+        pendingDisplayFilterEvaluations.count
+    }
 
     init(url: URL, packets: [PacketSummary]) {
         self.url = url
@@ -3716,6 +3818,73 @@ private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unc
             rawBytes: Data(repeating: 0, count: 8),
             detailNodes: [],
             decodeStatus: packet.decodeStatus
+        )))
+    }
+
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        let normalized = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        displayFilterExpressionByGeneration[generation] = normalized
+        completion(DisplayFilterValidation(normalizedExpression: normalized, status: .valid))
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        let expression = displayFilterExpressionByGeneration[generation] ?? ""
+        if holdsDisplayFilterEvaluations {
+            pendingDisplayFilterEvaluations.append(PendingDisplayFilterEvaluation(
+                expression: expression,
+                packetIDs: packetIDs,
+                generation: generation,
+                completion: completion
+            ))
+            return
+        }
+        completeDisplayFilterEvaluation(
+            packetIDs: packetIDs,
+            generation: generation,
+            matchingPacketIDs: displayFilterMatchesByExpression[expression] ?? [],
+            completion: completion
+        )
+    }
+
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        displayFilterExpressionByGeneration.removeAll()
+        completion(.success(()))
+    }
+
+    func completeDisplayFilterEvaluation(
+        expression: String,
+        matchingPacketIDs: Set<PacketSummary.ID>
+    ) {
+        guard let index = pendingDisplayFilterEvaluations.firstIndex(where: { $0.expression == expression }) else {
+            return
+        }
+        let pending = pendingDisplayFilterEvaluations.remove(at: index)
+        completeDisplayFilterEvaluation(
+            packetIDs: pending.packetIDs,
+            generation: pending.generation,
+            matchingPacketIDs: matchingPacketIDs,
+            completion: pending.completion
+        )
+    }
+
+    private func completeDisplayFilterEvaluation(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        matchingPacketIDs: Set<PacketSummary.ID>,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        completion(.success(DisplayFilterMatchBatch(
+            generation: generation,
+            evaluatedPacketIDs: packetIDs,
+            matchingPacketIDs: packetIDs.filter(matchingPacketIDs.contains)
         )))
     }
 

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -364,6 +364,187 @@ struct NetworkInspectorViewModelTests {
         }
     }
 
+    @Test func invalidApplyCancelsThePendingEvaluationBeforeValidationFinishes() async {
+        let openURL = URL(fileURLWithPath: "/tmp/display-filter-invalid-cancellation.pcapng")
+        let firstPacket = makePacket(packetNumber: 1, source: .offline, transportHint: .tcp)
+        let secondPacket = makePacket(packetNumber: 2, source: .offline, transportHint: .udp)
+        let document = InspectorFakeDocument(url: openURL, packets: [firstPacket, secondPacket])
+        document.displayFilterMatchesByExpression["tcp"] = [firstPacket.id]
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.openDocument(at: openURL)
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("tcp")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { viewModel.snapshot.wiresharkFilterState.appliedExpression == "tcp" }
+
+        document.holdsDisplayFilterEvaluations = true
+        viewModel.updateWiresharkFilterDraft("second")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { document.pendingDisplayFilterEvaluationCount == 1 }
+
+        viewModel.updateWiresharkFilterDraft("invalid filter")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { viewModel.snapshot.wiresharkFilterState.validation.status == .invalid }
+        document.completeDisplayFilterEvaluation(expression: "second", matchingPacketIDs: [secondPacket.id])
+        await Task.yield()
+
+        #expect(viewModel.snapshot.wiresharkFilterState.appliedExpression == "tcp")
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id])
+    }
+
+    @Test func cancelledBackfillStopsBeforeTheSecondBatch() async {
+        let openURL = URL(fileURLWithPath: "/tmp/display-filter-batch-cancellation.pcapng")
+        let packets = (1...300).map {
+            makePacket(packetNumber: UInt64($0), source: .offline, transportHint: .udp)
+        }
+        let document = InspectorFakeDocument(url: openURL, packets: packets)
+        document.holdsDisplayFilterEvaluations = true
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                document: document
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.openDocument(at: openURL)
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("udp")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { document.pendingDisplayFilterEvaluationCount == 1 }
+        #expect(document.displayFilterEvaluationRequestPacketIDs == [Array(packets.prefix(128).map(\.id))])
+
+        viewModel.updateWiresharkFilterDraft("invalid filter")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { viewModel.snapshot.wiresharkFilterState.validation.status == .invalid }
+        document.completeDisplayFilterEvaluation(expression: "udp", matchingPacketIDs: [])
+        await Task.yield()
+
+        #expect(document.displayFilterEvaluationRequestPacketIDs.count == 1)
+        #expect(!viewModel.snapshot.wiresharkFilterState.isApplying)
+    }
+
+    @Test func liveCaptureEventsContinueBetweenDisplayFilterBackfillBatches() async {
+        let liveSession = InspectorFakeLiveSession()
+        liveSession.holdsDisplayFilterEvaluations = true
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                liveSession: liveSession
+            )),
+            userDefaults: isolatedDefaults()
+        )
+        let initialPackets = (1...300).map {
+            makePacket(packetNumber: UInt64($0), source: .live, transportHint: .udp)
+        }
+        let appendedPacket = makePacket(packetNumber: 301, source: .live, transportHint: .udp)
+
+        await viewModel.performInitialLoadIfNeeded()
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+        liveSession.send(.packetBatch(initialPackets, disposition: .append))
+        await waitUntil { viewModel.snapshot.totalPacketCount == initialPackets.count }
+
+        viewModel.setStructuredFilterVisible(true)
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("udp")
+        viewModel.applyWiresharkFilter()
+        await waitUntil { liveSession.pendingDisplayFilterEvaluationCount == 1 }
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs == [Array(initialPackets.prefix(128).map(\.id))])
+
+        liveSession.send(.packetBatch([appendedPacket], disposition: .append))
+        await waitUntil { viewModel.snapshot.totalPacketCount == initialPackets.count + 1 }
+        #expect(liveSession.pendingDisplayFilterEvaluationCount == 1)
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs.count == 1)
+
+        liveSession.holdsDisplayFilterEvaluations = false
+        liveSession.completeNextDisplayFilterEvaluation(matchingPacketIDs: [])
+        await waitUntil {
+            !viewModel.snapshot.wiresharkFilterState.isApplying
+                && liveSession.displayFilterEvaluationRequestPacketIDs.flatMap { $0 }.count == 301
+        }
+
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs.allSatisfy { $0.count <= 128 })
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs.flatMap { $0 } == initialPackets.map(\.id) + [appendedPacket.id])
+    }
+
+    @Test func hundredThousandPacketEvaluationUsesCacheAndOnlyEvaluatesAppends() async {
+        let packets = (1...100_000).map {
+            makePacket(packetNumber: UInt64($0), source: .live, transportHint: .tcp)
+        }
+        let liveSession = InspectorFakeLiveSession()
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                liveSession: liveSession
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        func evaluatedPacketCount() -> Int {
+            liveSession.displayFilterEvaluationRequestPacketIDs.reduce(0) { $0 + $1.count }
+        }
+
+        func apply(_ expression: String) async {
+            viewModel.updateWiresharkFilterDraft(expression)
+            viewModel.applyWiresharkFilter()
+            await waitUntil(timeoutNanoseconds: 20_000_000_000) {
+                viewModel.snapshot.wiresharkFilterState.appliedExpression == expression
+                    && !viewModel.snapshot.wiresharkFilterState.isApplying
+            }
+        }
+
+        await viewModel.performInitialLoadIfNeeded()
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+        liveSession.send(.packetBatch(packets, disposition: .append))
+        await waitUntil(timeoutNanoseconds: 20_000_000_000) { viewModel.snapshot.totalPacketCount == 100_000 }
+        viewModel.setStructuredFilterVisible(true)
+        viewModel.setFilterMode(.wireshark)
+
+        await apply("expression-one")
+        #expect(evaluatedPacketCount() == 100_000)
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs.allSatisfy { $0.count <= 128 })
+
+        await apply("expression-one")
+        #expect(evaluatedPacketCount() == 100_000)
+
+        let appendedPacket = makePacket(packetNumber: 100_001, source: .live, transportHint: .tcp)
+        liveSession.send(.packetBatch([appendedPacket], disposition: .append))
+        await waitUntil(timeoutNanoseconds: 20_000_000_000) {
+            viewModel.snapshot.totalPacketCount == 100_001
+                && evaluatedPacketCount() == 100_001
+                && !viewModel.snapshot.wiresharkFilterState.isApplying
+        }
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs.last == [appendedPacket.id])
+
+        for expression in ["expression-two", "expression-three", "expression-four"] {
+            let countBeforeApply = evaluatedPacketCount()
+            await apply(expression)
+            #expect(evaluatedPacketCount() - countBeforeApply == 100_001)
+        }
+
+        let countBeforeCachedApply = evaluatedPacketCount()
+        await apply("expression-one")
+        #expect(evaluatedPacketCount() == countBeforeCachedApply)
+
+        let countBeforeFifthExpression = evaluatedPacketCount()
+        await apply("expression-five")
+        #expect(evaluatedPacketCount() - countBeforeFifthExpression == 100_001)
+
+        let countBeforeEvictedExpression = evaluatedPacketCount()
+        await apply("expression-two")
+        #expect(evaluatedPacketCount() - countBeforeEvictedExpression == 100_001)
+        #expect(liveSession.displayFilterEvaluationRequestPacketIDs.allSatisfy { $0.count <= 128 })
+    }
+
     @Test func missingNetworkHelperShowsOnboardingButOfflineOpenStillWorks() async {
         let openURL = URL(fileURLWithPath: "/tmp/offline-while-helper-missing.pcapng")
         let packets = [makePacket(packetNumber: 1, source: .offline, transportHint: .udp)]
@@ -1296,6 +1477,36 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.structuredFilterGroup == replacementGroup)
         #expect(viewModel.snapshot.customFilterItems == [
             PacketCustomFilterItem(id: savedFilter.id, title: "Traffic", isSelected: true),
+        ])
+    }
+
+    @Test func overridingWiresharkFilterPreservesModeAndReplacesOnlyItsExpression() async throws {
+        let customFilterService = PacketCustomFilterService(
+            storageURL: temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        )
+        let savedFilter = try customFilterService.save(
+            name: "TLS SNI",
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: "tls.handshake.extensions_server_name == \"old.example\""
+        )
+        let viewModel = makeOfflineViewModel(packets: [], customFilterService: customFilterService)
+
+        viewModel.setFilterMode(.wireshark)
+        viewModel.updateWiresharkFilterDraft("tls.handshake.extensions_server_name == \"new.example\"")
+        viewModel.applyWiresharkFilter()
+        await waitUntil {
+            viewModel.snapshot.wiresharkFilterState.appliedExpression
+                == "tls.handshake.extensions_server_name == \"new.example\""
+        }
+        try viewModel.overrideWiresharkCustomFilter(id: savedFilter.id)
+
+        let updatedFilter = try #require(customFilterService.filter(id: savedFilter.id))
+        #expect(updatedFilter.mode == .wireshark)
+        #expect(updatedFilter.group == .default)
+        #expect(updatedFilter.wiresharkExpression == "tls.handshake.extensions_server_name == \"new.example\"")
+        #expect(viewModel.snapshot.customFilterItems == [
+            PacketCustomFilterItem(id: savedFilter.id, title: "TLS SNI", mode: .wireshark, isSelected: true),
         ])
     }
 
@@ -3685,11 +3896,25 @@ private final class InspectorFakePacketClientResolver: PacketClientResolving {
 }
 
 private final class InspectorFakeLiveSession: LiveCaptureSessionProviding, @unchecked Sendable {
+    private struct PendingDisplayFilterEvaluation {
+        let packetIDs: [PacketSummary.ID]
+        let generation: UInt64
+        let completion: TCPViewerCompletion<DisplayFilterMatchBatch>
+    }
+
     var eventHandler: PacketIngestEventHandler?
     var inspections: [PacketSummary.ID: PacketInspection] = [:]
+    var holdsDisplayFilterEvaluations = false
     private(set) var startCount = 0
     private(set) var stopCount = 0
     private(set) var exportRequests: [([PacketSummary.ID], URL, CaptureFileFormat)] = []
+    private(set) var displayFilterEvaluationRequestPacketIDs: [[PacketSummary.ID]] = []
+    private var displayFilterExpressionByGeneration: [UInt64: String] = [:]
+    private var pendingDisplayFilterEvaluations: [PendingDisplayFilterEvaluation] = []
+
+    var pendingDisplayFilterEvaluationCount: Int {
+        pendingDisplayFilterEvaluations.count
+    }
 
     func start(completion: @escaping TCPViewerVoidCompletion) {
         startCount += 1
@@ -3720,6 +3945,53 @@ private final class InspectorFakeLiveSession: LiveCaptureSessionProviding, @unch
         }
 
         completion(.success(inspection))
+    }
+
+    func activateDisplayFilter(
+        _ expression: String,
+        generation: UInt64,
+        completion: @escaping (DisplayFilterValidation) -> Void
+    ) {
+        displayFilterExpressionByGeneration[generation] = expression
+        completion(DisplayFilterValidation(normalizedExpression: expression, status: .valid))
+    }
+
+    func evaluateDisplayFilter(
+        packetIDs: [PacketSummary.ID],
+        generation: UInt64,
+        completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
+    ) {
+        displayFilterEvaluationRequestPacketIDs.append(packetIDs)
+        if holdsDisplayFilterEvaluations {
+            pendingDisplayFilterEvaluations.append(PendingDisplayFilterEvaluation(
+                packetIDs: packetIDs,
+                generation: generation,
+                completion: completion
+            ))
+            return
+        }
+        completion(.success(DisplayFilterMatchBatch(
+            generation: generation,
+            evaluatedPacketIDs: packetIDs,
+            matchingPacketIDs: []
+        )))
+    }
+
+    func clearDisplayFilter(completion: @escaping TCPViewerVoidCompletion) {
+        displayFilterExpressionByGeneration.removeAll()
+        completion(.success(()))
+    }
+
+    func completeNextDisplayFilterEvaluation(matchingPacketIDs: Set<PacketSummary.ID>) {
+        guard !pendingDisplayFilterEvaluations.isEmpty else {
+            return
+        }
+        let pending = pendingDisplayFilterEvaluations.removeFirst()
+        pending.completion(.success(DisplayFilterMatchBatch(
+            generation: pending.generation,
+            evaluatedPacketIDs: pending.packetIDs,
+            matchingPacketIDs: pending.packetIDs.filter(matchingPacketIDs.contains)
+        )))
     }
 
     func healthSnapshot(completion: @escaping (CaptureHealthSnapshot) -> Void) {
@@ -3770,6 +4042,7 @@ private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unc
     private var progress: PacketLoadProgress = .idle
     private var displayFilterExpressionByGeneration: [UInt64: String] = [:]
     private var pendingDisplayFilterEvaluations: [PendingDisplayFilterEvaluation] = []
+    private(set) var displayFilterEvaluationRequestPacketIDs: [[PacketSummary.ID]] = []
 
     var pendingDisplayFilterEvaluationCount: Int {
         pendingDisplayFilterEvaluations.count
@@ -3836,6 +4109,7 @@ private final class InspectorFakeDocument: OfflineCaptureDocumentProviding, @unc
         generation: UInt64,
         completion: @escaping TCPViewerCompletion<DisplayFilterMatchBatch>
     ) {
+        displayFilterEvaluationRequestPacketIDs.append(packetIDs)
         let expression = displayFilterExpressionByGeneration[generation] ?? ""
         if holdsDisplayFilterEvaluations {
             pendingDisplayFilterEvaluations.append(PendingDisplayFilterEvaluation(

--- a/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
@@ -165,11 +165,53 @@ struct PacketCustomFilterServiceTests {
             now: Date(timeIntervalSince1970: 10)
         )
 
+        try service.rename(id: saved.id, name: "Renamed TLS SNI", now: Date(timeIntervalSince1970: 15))
         let duplicate = try #require(try service.duplicate(id: saved.id, now: Date(timeIntervalSince1970: 20)))
-        let reloaded = PacketCustomFilterService(storageURL: storageURL).filters()
+        let replacementExpression = "tls.handshake.extensions_server_name == \"api.example.com\""
+        try service.update(
+            id: saved.id,
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: replacementExpression,
+            now: Date(timeIntervalSince1970: 30)
+        )
 
+        var reloaded = PacketCustomFilterService(storageURL: storageURL).filters()
+
+        #expect(reloaded.map(\.name) == ["Renamed TLS SNI", "Renamed TLS SNI"])
         #expect(reloaded.map(\.mode) == [.wireshark, .wireshark])
-        #expect(reloaded.map(\.wiresharkExpression) == [saved.wiresharkExpression, duplicate.wiresharkExpression])
+        #expect(reloaded.map(\.wiresharkExpression) == [replacementExpression, duplicate.wiresharkExpression])
+
+        try service.delete(id: duplicate.id)
+        reloaded = PacketCustomFilterService(storageURL: storageURL).filters()
+        #expect(reloaded.map(\.id) == [saved.id])
+        #expect(reloaded.first?.mode == .wireshark)
+        #expect(reloaded.first?.wiresharkExpression == replacementExpression)
+    }
+
+    @Test func builderUpdateCannotEraseAWiresharkFilterPayload() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+        let expression = "tls.handshake.extensions_server_name == \"example.com\""
+        let saved = try service.save(
+            name: "TLS SNI",
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: expression
+        )
+
+        try service.updateGroup(
+            id: saved.id,
+            group: PacketStructuredFilterGroup(
+                filters: [PacketStructuredFilter(query: .protocol, condition: .contains, text: "TCP")],
+                operator: .and
+            )
+        )
+
+        let reloaded = try #require(PacketCustomFilterService(storageURL: storageURL).filter(id: saved.id))
+        #expect(reloaded.mode == .wireshark)
+        #expect(reloaded.wiresharkExpression == expression)
+        #expect(reloaded.group == .default)
     }
 
     @Test func legacyFilterWithoutModeDecodesAsBuilder() throws {

--- a/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketCustomFilterServiceTests.swift
@@ -154,6 +154,45 @@ struct PacketCustomFilterServiceTests {
         #expect(reloadedFilters.map(\.name) == ["Traffic", "Traffic", "Methods"])
     }
 
+    @Test func wiresharkFilterRoundTripsAndDuplicatePreservesItsModeAndExpression() throws {
+        let storageURL = temporaryDirectory().appendingPathComponent("CustomFilters.json")
+        let service = PacketCustomFilterService(storageURL: storageURL)
+        let saved = try service.save(
+            name: "TLS SNI",
+            mode: .wireshark,
+            group: .default,
+            wiresharkExpression: "tls.handshake.extensions_server_name == \"example.com\"",
+            now: Date(timeIntervalSince1970: 10)
+        )
+
+        let duplicate = try #require(try service.duplicate(id: saved.id, now: Date(timeIntervalSince1970: 20)))
+        let reloaded = PacketCustomFilterService(storageURL: storageURL).filters()
+
+        #expect(reloaded.map(\.mode) == [.wireshark, .wireshark])
+        #expect(reloaded.map(\.wiresharkExpression) == [saved.wiresharkExpression, duplicate.wiresharkExpression])
+    }
+
+    @Test func legacyFilterWithoutModeDecodesAsBuilder() throws {
+        let filter = PacketCustomFilter(
+            id: "legacy",
+            name: "Legacy",
+            createdAt: Date(timeIntervalSince1970: 10),
+            updatedAt: Date(timeIntervalSince1970: 20),
+            group: .default
+        )
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(filter)) as? [String: Any])
+        object.removeValue(forKey: "mode")
+        object.removeValue(forKey: "wiresharkExpression")
+
+        let decoded = try JSONDecoder().decode(
+            PacketCustomFilter.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+
+        #expect(decoded.mode == .builder)
+        #expect(decoded.wiresharkExpression == nil)
+    }
+
     private func expectValidationError(
         _ expectedError: PacketCustomFilterValidationError,
         operation: () throws -> Void

--- a/TCPViewerTests/Features/NetworkInspector/PacketWiresharkFilterTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketWiresharkFilterTests.swift
@@ -69,7 +69,31 @@ struct PacketWiresharkFilterTests {
 
         #expect(entry.membership(generation: 7, expression: "frame.number % 2 == 1").evaluatedPacketCount == 50_000)
         #expect(entry.membership(generation: 7, expression: "frame.number % 2 == 1").matchingPacketIndexes.setBitCount == 10)
+        #expect(entry.evaluatedPrefixCount == 1)
         #expect(entry.unknownPacketIDs(in: ingestState, limit: 3) == [2, 4, 6])
+
+        entry.record(
+            batch: DisplayFilterMatchBatch(
+                generation: 7,
+                evaluatedPacketIDs: stride(from: 2, through: 100_000, by: 2).map(UInt64.init),
+                matchingPacketIDs: []
+            ),
+            packetIndexByID: ingestState.packetIndexByID
+        )
+        #expect(entry.evaluatedPrefixCount == 100_000)
+
+        let appendedPacket = Self.packet(id: 100_001)
+        let appendedState = Self.ingestState(packets: packets + [appendedPacket])
+        #expect(entry.unknownPacketIDs(in: appendedState) == [appendedPacket.id])
+        entry.record(
+            batch: DisplayFilterMatchBatch(
+                generation: 7,
+                evaluatedPacketIDs: [appendedPacket.id],
+                matchingPacketIDs: []
+            ),
+            packetIndexByID: appendedState.packetIndexByID
+        )
+        #expect(entry.evaluatedPrefixCount == 100_001)
     }
 
     @Test func diagnosticRangeConvertsUTF8OffsetsToNativeTextRanges() throws {

--- a/TCPViewerTests/Features/NetworkInspector/PacketWiresharkFilterTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketWiresharkFilterTests.swift
@@ -1,0 +1,122 @@
+//
+//  PacketWiresharkFilterTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 30/8/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+import Testing
+@testable import TCPViewer
+
+struct PacketWiresharkFilterTests {
+    @Test func bitSetStoresSparseIndexesAndCountsOnlyRequestedPrefix() {
+        var bitSet = PacketIndexBitSet()
+        for index in [0, 1, 63, 64, 99_999] {
+            bitSet.insert(index)
+        }
+
+        #expect(bitSet.contains(0))
+        #expect(bitSet.contains(64))
+        #expect(bitSet.contains(99_999))
+        #expect(!bitSet.contains(2))
+        #expect(!bitSet.contains(100_000))
+        #expect(bitSet.setBitCount == 5)
+        #expect(bitSet.setBitCount(upTo: 64) == 3)
+        #expect(bitSet.setBitCount(upTo: 100_000) == 5)
+    }
+
+    @Test func cacheRetainsFourMostRecentlyUsedExpressions() {
+        var cache = PacketDisplayFilterResultCache()
+        let keys = (0..<5).map { index in
+            PacketDisplayFilterCacheKey(
+                backingIdentity: "capture",
+                packetLineageRevision: 1,
+                expression: "frame.number == \(index)",
+                dissectionRevision: PacketDisplayFilterCacheKey.dissectionRevision
+            )
+        }
+
+        for (index, key) in keys.prefix(4).enumerated() {
+            cache.store(Self.entry(matchingIndex: index), for: key)
+        }
+        _ = cache.entry(for: keys[0])
+        cache.store(Self.entry(matchingIndex: 4), for: keys[4])
+
+        #expect(cache.entry(for: keys[0]) != nil)
+        #expect(cache.entry(for: keys[1]) == nil)
+        #expect(cache.entry(for: keys[2]) != nil)
+        #expect(cache.entry(for: keys[3]) != nil)
+        #expect(cache.entry(for: keys[4]) != nil)
+    }
+
+    @Test func cacheEntryTracksEvaluatedAndMatchingPacketIndexesIncrementally() {
+        let packets = (0..<100_000).map { Self.packet(id: UInt64($0 + 1)) }
+        let ingestState = Self.ingestState(packets: packets)
+        var entry = PacketDisplayFilterCacheEntry()
+        let evaluatedIDs = stride(from: 1, through: 100_000, by: 2).map(UInt64.init)
+        let matchingIDs = stride(from: 1, through: 100_000, by: 10_000).map(UInt64.init)
+
+        entry.record(
+            batch: DisplayFilterMatchBatch(
+                generation: 7,
+                evaluatedPacketIDs: evaluatedIDs,
+                matchingPacketIDs: matchingIDs
+            ),
+            packetIndexByID: ingestState.packetIndexByID
+        )
+
+        #expect(entry.membership(generation: 7, expression: "frame.number % 2 == 1").evaluatedPacketCount == 50_000)
+        #expect(entry.membership(generation: 7, expression: "frame.number % 2 == 1").matchingPacketIndexes.setBitCount == 10)
+        #expect(entry.unknownPacketIDs(in: ingestState, limit: 3) == [2, 4, 6])
+    }
+
+    @Test func diagnosticRangeConvertsUTF8OffsetsToNativeTextRanges() throws {
+        let expression = "ip.addr == \"café\" && tcp.port =="
+        let byteOffset = try #require(expression.range(of: "tcp.port"))
+        let utf8Index = try #require(byteOffset.lowerBound.samePosition(in: expression.utf8))
+        let utf8Start = expression.utf8.distance(from: expression.utf8.startIndex, to: utf8Index)
+        let sourceRange = DisplayFilterSourceRange(utf8StartOffset: utf8Start, utf8Length: "tcp.port".utf8.count)
+
+        #expect(PacketWiresharkFilterTextRange.nsRange(for: sourceRange, in: expression) == NSRange(location: 21, length: 8))
+        #expect(PacketWiresharkFilterTextRange.column(for: sourceRange, in: expression) == 22)
+    }
+
+    private static func entry(matchingIndex: Int) -> PacketDisplayFilterCacheEntry {
+        var entry = PacketDisplayFilterCacheEntry()
+        entry.evaluatedPacketIndexes.insert(matchingIndex)
+        entry.matchingPacketIndexes.insert(matchingIndex)
+        return entry
+    }
+
+    private static func ingestState(packets: [PacketSummary]) -> PacketIngestState {
+        var state = PacketIngestState.empty
+        state.backingIdentity = "capture"
+        state.packets = packets
+        state.packetIndexByID = Dictionary(uniqueKeysWithValues: packets.enumerated().map { ($0.element.id, $0.offset) })
+        state.packetLineageRevision = 1
+        return state
+    }
+
+    private static func packet(id: UInt64) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: id,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(id)),
+            source: .offline,
+            transportHint: .tcp,
+            protocolSummary: "TCP",
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.1", port: 1234),
+                destination: PacketEndpoint(address: "10.0.0.2", port: 443)
+            ),
+            originalLength: 64,
+            capturedLength: 64,
+            infoSummary: "Packet \(id)",
+            layers: [PacketLayer(name: "Ethernet"), PacketLayer(name: "IPv4"), PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false)
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
@@ -84,6 +84,8 @@ struct TCPViewSessionFormatTests {
             customFilters: [customFilter],
             quickFilterSelection: PacketQuickFilterSelection(selectedIDs: [.tcp, .dns]),
             structuredFilterGroup: structuredGroup,
+            filterMode: .wireshark,
+            wiresharkExpression: "tls.handshake.extensions_server_name == \"example.com\"",
             selectedPacketID: packet.id,
             selectedSourceListSelection: selectedSource,
             tableColumnLayout: layout
@@ -96,6 +98,23 @@ struct TCPViewSessionFormatTests {
         #expect(decoded.importedPacketReferenceByID[packet.id]?.originalPacketID == 1)
         #expect(decoded.selectedSourceListSelection?.selection() == selectedSource)
         #expect(decoded.importedFileProvenance != nil)
+        #expect(decoded.filterMode == .wireshark)
+        #expect(decoded.wiresharkExpression == "tls.handshake.extensions_server_name == \"example.com\"")
+    }
+
+    @Test func legacySessionWithoutWiresharkFieldsDecodesWithBuilderCompatibleDefaults() throws {
+        let state = Self.makeSnapshot(packets: []).state
+        var object = try #require(JSONSerialization.jsonObject(with: Self.encode(state)) as? [String: Any])
+        object.removeValue(forKey: "filterMode")
+        object.removeValue(forKey: "wiresharkExpression")
+
+        let decoded = try Self.decode(
+            TCPViewSessionState.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+
+        #expect(decoded.filterMode == nil)
+        #expect(decoded.wiresharkExpression == nil)
     }
 
     @Test func annotationsRoundTripReservedCommentAndColorFields() throws {
@@ -634,6 +653,8 @@ struct TCPViewSessionFormatTests {
         customFilters: [PacketCustomFilter] = [],
         quickFilterSelection: PacketQuickFilterSelection = .all,
         structuredFilterGroup: PacketStructuredFilterGroup = .default,
+        filterMode: PacketFilterMode? = nil,
+        wiresharkExpression: String? = nil,
         selectedPacketID: PacketSummary.ID? = nil,
         selectedSourceListSelection: PacketSourceListSelection = .allPackets,
         tableColumnLayout: PacketTableColumnLayout? = nil
@@ -658,6 +679,8 @@ struct TCPViewSessionFormatTests {
             inspectorPlacement: .bottom,
             isInspectorVisible: true,
             isStructuredFilterVisible: true,
+            filterMode: filterMode,
+            wiresharkExpression: wiresharkExpression,
             tableColumnLayout: tableColumnLayout,
             sourceMetadata: TCPViewSessionSourceMetadata(
                 fileName: "source.pcapng",


### PR DESCRIPTION
## Summary

- Add a native Wireshark display-filter mode to the existing AppKit filter panel.
- Compile and evaluate expressions with embedded Wireshark EPAN, including diagnostics, source ranges, registered columns, and official IP helpers.
- Keep live filtering bounded and incremental with 128-packet batches, compact bitsets, a four-entry LRU cache, prefix-based append lookup, cancellation tokens, and stale-generation guards.
- Persist builder and Wireshark saved filters and session state without changing legacy decoding behavior.

## Review fixes

- Rehydrate stopped live captures from disk one packet at a time.
- Cancel prior evaluation immediately when Apply begins and stop between workspace batches.
- Keep builder and Wireshark override menus mode-specific so saved expressions cannot be erased.
- Complete exact diagnostic ranges, PCAP/PCAPNG/live semantic checks, native resource lifecycle coverage, remapped imports, saved-filter lifecycle, true 100,000-packet caching, and live interleaving tests.
- Merge the latest main branch and review the complete feature diff against it.

## Testing

- TCPViewer unsigned macOS build passed.
- Full merged macOS test suite passed: 668 tests, 0 failures, 0 skipped.
- Focused regression tests passed.
- Diff formatting and added-line secret scans passed.

## AI assistance

OpenAI Codex substantially assisted with this PR. Codex reviewed the complete branch against main, implemented the fixes, and ran the build and full test suite. The human contributor remains responsible for final review and merge.