### PR TITLE
Add endpoint statistics filtering and packet drill-down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - Add the standard header to Swift and Objective-C source files with the correct filename, `TCPViewer` project name, and `Created by Proxyman LLC on <file created date>.`
 - If the logic is complicated and hard to understand, explain why you do it
 - Make sure to build the project if you change code, to verify all syntax are correct and works
-- Run Unit Tests that you've made a change or created or entire test suit if it's possible
+- By default, run only the focused unit or integration tests that cover the code you changed and the behavior most likely to regress
 - For tiny change, no need to run project, because it can slows the development process
 - TCP Viewer is the main macOS app; do not reintroduce the deleted TCPViewer SwiftUI app or TCPViewerTests target
 - TCPViewer main window and inspector must be 100% AppKit: NSViewController, NSSplitViewController/NSSplitView, NSTableView, NSScrollView, NSStackView, NSToolbar, NSSegmentedControl
@@ -26,7 +26,7 @@
 - Live capture can receive 10,000+ packets per second; always think about bounded, incremental, and backpressure-friendly designs before adding capture, parsing, metadata, table, sidebar, or inspector work.
 - Do not run repeated O(total captured packets) work on live-capture timers or append paths; prefer queued packet IDs, capped batches, indexes, caches, and coalesced UI updates. This specifically prevents regressions like reanalyzing every captured packet every 250 ms.
 - After TCPViewer or core changes, verify with `xcodebuild -project TCPViewer.xcodeproj -scheme TCPViewer build`
-- Run `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'` and relevant `PcapPlusPlusCore` tests when app/core behavior changes
+- Run the full TCPViewer test suite with `xcodebuild test -project TCPViewer.xcodeproj -scheme TCPViewer -destination 'platform=macOS'` only when a change affects broad or shared app logic, its impact is uncertain, or whole-app regression verification is necessary; apply the same rule to the full `PcapPlusPlusCore` test suite
 - Try adding 1 line and concise short comment to explain a group of logic if the func is big
 - Add 1 line concise comment to explain a func in the top of func
 

--- a/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
+++ b/TCPViewer/App/Windowing/TCPViewerToolbarDataSource.swift
@@ -315,6 +315,10 @@ final class TCPViewerToolbarDataSource: NSObject {
     private func renderInspectorButton() {
         inspectorButton.state = viewModel.isTrailingInspectorVisible ? .on : .off
         inspectorBottomButton.state = viewModel.isBottomInspectorVisible ? .on : .off
+        inspectorButton.isEnabled = viewModel.canUseInspector
+        inspectorBottomButton.isEnabled = viewModel.canUseInspector
+        inspectorButton.alphaValue = viewModel.canUseInspector ? 1 : 0.45
+        inspectorBottomButton.alphaValue = viewModel.canUseInspector ? 1 : 0.45
     }
 
     private func syncTrialToolbarItem() {
@@ -492,6 +496,7 @@ private final class TCPViewerToolbarViewModel {
     private(set) var canSaveAs = false
     private(set) var canExport = false
     private(set) var isInspectorVisible = true
+    private(set) var canUseInspector = true
     private(set) var inspectorPlacement: NetworkInspectorPlacement = .trailing
     private(set) var statusText = "TCP Viewer | Idle"
     private(set) var emphasizedText: String?
@@ -519,6 +524,7 @@ private final class TCPViewerToolbarViewModel {
         canSaveAs = snapshot.base.documentState.canSaveAs
         canExport = snapshot.totalPacketCount > 0 && snapshot.base.loadState.progress.phase != .loading
         isInspectorVisible = snapshot.isInspectorVisible
+        canUseInspector = snapshot.workspaceMode != .overview
         inspectorPlacement = snapshot.inspectorPlacement
         bpfCaptureFilter = snapshot.base.filterState.normalizedCaptureFilter
         helperError = Self.helperError(for: viewModel.networkHelperToolSnapshot)

--- a/TCPViewer/App/Windowing/TCPViewerWindowController.swift
+++ b/TCPViewer/App/Windowing/TCPViewerWindowController.swift
@@ -106,6 +106,10 @@ final class TCPViewerWindowController: NSWindowController {
         rootViewController.clearAllPackets()
     }
 
+    @IBAction func showEndpointStatistics(_ sender: Any?) {
+        rootViewController.showEndpointStatistics()
+    }
+
     private func setupToolbar() {
         toolbarDataSource.delegate = self
         window?.toolbar = toolbarDataSource.toolbar

--- a/TCPViewer/Base.lproj/Main.storyboard
+++ b/TCPViewer/Base.lproj/Main.storyboard
@@ -371,6 +371,19 @@
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Statistics" id="Z7s-Ep-t0p">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Statistics" id="Z7s-Ep-m3n">
+                                    <items>
+                                        <menuItem title="Endpoints…" id="Z7s-Ep-r0w">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="showEndpointStatistics:" target="Ady-hI-5gd" id="Z7s-Ep-act"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Window" id="aUF-d1-5bR">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">

--- a/TCPViewer/Features/NetworkInspector/Models/EndpointStatisticsModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/EndpointStatisticsModels.swift
@@ -1,0 +1,208 @@
+//
+//  EndpointStatisticsModels.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+
+enum EndpointStatisticsGroup: String, CaseIterable, Hashable, Sendable {
+    case apps
+    case domains
+    case ipv4
+    case ipv6
+    case tcp
+    case udp
+
+    var title: String {
+        switch self {
+        case .apps: return "Apps"
+        case .domains: return "Domains"
+        case .ipv4: return "IPv4"
+        case .ipv6: return "IPv6"
+        case .tcp: return "TCP"
+        case .udp: return "UDP"
+        }
+    }
+}
+
+struct EndpointStatisticsRowID: Hashable, Sendable {
+    let group: EndpointStatisticsGroup
+    let key: String
+}
+
+struct EndpointStatisticsTotals: Equatable, Sendable {
+    var packets: UInt64
+    var bytes: UInt64
+    var txPackets: UInt64
+    var txBytes: UInt64
+    var rxPackets: UInt64
+    var rxBytes: UInt64
+    var unclassifiedPackets: UInt64
+    var unclassifiedBytes: UInt64
+
+    static let zero = EndpointStatisticsTotals(
+        packets: 0,
+        bytes: 0,
+        txPackets: 0,
+        txBytes: 0,
+        rxPackets: 0,
+        rxBytes: 0,
+        unclassifiedPackets: 0,
+        unclassifiedBytes: 0
+    )
+
+    var summary: String {
+        let classifiedBytes = Double(txBytes) + Double(rxBytes) + Double(unclassifiedBytes)
+        guard classifiedBytes > 0 else {
+            return "No byte data"
+        }
+
+        var parts: [String] = []
+        if txBytes > 0 {
+            parts.append("Tx \(percentage(txBytes, of: classifiedBytes))%")
+        }
+        if rxBytes > 0 {
+            parts.append("Rx \(percentage(rxBytes, of: classifiedBytes))%")
+        }
+        if unclassifiedBytes > 0 {
+            parts.append("Unclassified \(percentage(unclassifiedBytes, of: classifiedBytes))%")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func percentage(_ value: UInt64, of total: Double) -> Int {
+        Int((Double(value) / Double(total) * 100).rounded())
+    }
+}
+
+struct EndpointStatisticsRow: Identifiable, Equatable, Sendable {
+    static let multipleValue = "Multiple"
+
+    let id: EndpointStatisticsRowID
+    let address: String?
+    let port: String?
+    let protocolName: String?
+    let client: String?
+    let domain: String?
+    let isAddressMultiple: Bool
+    let isPortMultiple: Bool
+    let isProtocolMultiple: Bool
+    let isClientMultiple: Bool
+    let isDomainMultiple: Bool
+    let packets: UInt64
+    let bytes: UInt64
+    let txPackets: UInt64
+    let txBytes: UInt64
+    let rxPackets: UInt64
+    let rxBytes: UInt64
+    let unclassifiedPackets: UInt64
+    let unclassifiedBytes: UInt64
+
+    init(
+        id: EndpointStatisticsRowID,
+        address: String?,
+        port: String?,
+        protocolName: String?,
+        client: String?,
+        domain: String?,
+        isAddressMultiple: Bool = false,
+        isPortMultiple: Bool = false,
+        isProtocolMultiple: Bool = false,
+        isClientMultiple: Bool = false,
+        isDomainMultiple: Bool = false,
+        packets: UInt64,
+        bytes: UInt64,
+        txPackets: UInt64,
+        txBytes: UInt64,
+        rxPackets: UInt64,
+        rxBytes: UInt64,
+        unclassifiedPackets: UInt64,
+        unclassifiedBytes: UInt64
+    ) {
+        self.id = id
+        self.address = address
+        self.port = port
+        self.protocolName = protocolName
+        self.client = client
+        self.domain = domain
+        self.isAddressMultiple = isAddressMultiple
+        self.isPortMultiple = isPortMultiple
+        self.isProtocolMultiple = isProtocolMultiple
+        self.isClientMultiple = isClientMultiple
+        self.isDomainMultiple = isDomainMultiple
+        self.packets = packets
+        self.bytes = bytes
+        self.txPackets = txPackets
+        self.txBytes = txBytes
+        self.rxPackets = rxPackets
+        self.rxBytes = rxBytes
+        self.unclassifiedPackets = unclassifiedPackets
+        self.unclassifiedBytes = unclassifiedBytes
+    }
+
+    var group: EndpointStatisticsGroup {
+        id.group
+    }
+
+    var totals: EndpointStatisticsTotals {
+        EndpointStatisticsTotals(
+            packets: packets,
+            bytes: bytes,
+            txPackets: txPackets,
+            txBytes: txBytes,
+            rxPackets: rxPackets,
+            rxBytes: rxBytes,
+            unclassifiedPackets: unclassifiedPackets,
+            unclassifiedBytes: unclassifiedBytes
+        )
+    }
+
+    var summary: String {
+        totals.summary
+    }
+}
+
+struct EndpointStatisticsSnapshot: Equatable, Sendable {
+    let rowsByGroup: [EndpointStatisticsGroup: [EndpointStatisticsRow]]
+    let endpointCounts: [EndpointStatisticsGroup: Int]
+    let footerTotals: EndpointStatisticsTotals
+
+    static let empty = EndpointStatisticsSnapshot(rowsByGroup: [:], footerTotals: .zero)
+
+    init(
+        rowsByGroup: [EndpointStatisticsGroup: [EndpointStatisticsRow]],
+        footerTotals: EndpointStatisticsTotals
+    ) {
+        var completeRows: [EndpointStatisticsGroup: [EndpointStatisticsRow]] = [:]
+        var counts: [EndpointStatisticsGroup: Int] = [:]
+        for group in EndpointStatisticsGroup.allCases {
+            let rows = rowsByGroup[group] ?? []
+            completeRows[group] = rows
+            counts[group] = rows.count
+        }
+        self.rowsByGroup = completeRows
+        endpointCounts = counts
+        self.footerTotals = footerTotals
+    }
+
+    func rows(for group: EndpointStatisticsGroup) -> [EndpointStatisticsRow] {
+        rowsByGroup[group] ?? []
+    }
+
+    func endpointCount(for group: EndpointStatisticsGroup) -> Int {
+        endpointCounts[group] ?? 0
+    }
+}
+
+struct EndpointStatisticsGroupSnapshot: Equatable, Sendable {
+    let group: EndpointStatisticsGroup
+    let rows: [EndpointStatisticsRow]
+    let endpointCounts: [EndpointStatisticsGroup: Int]
+    let footerTotals: EndpointStatisticsTotals
+
+    func endpointCount(for group: EndpointStatisticsGroup) -> Int {
+        endpointCounts[group] ?? 0
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Models/EndpointStatisticsModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/EndpointStatisticsModels.swift
@@ -85,6 +85,7 @@ struct EndpointStatisticsRow: Identifiable, Equatable, Sendable {
     let port: String?
     let protocolName: String?
     let client: String?
+    let clientIconFilePath: String?
     let domain: String?
     let isAddressMultiple: Bool
     let isPortMultiple: Bool
@@ -106,6 +107,7 @@ struct EndpointStatisticsRow: Identifiable, Equatable, Sendable {
         port: String?,
         protocolName: String?,
         client: String?,
+        clientIconFilePath: String? = nil,
         domain: String?,
         isAddressMultiple: Bool = false,
         isPortMultiple: Bool = false,
@@ -126,6 +128,7 @@ struct EndpointStatisticsRow: Identifiable, Equatable, Sendable {
         self.port = port
         self.protocolName = protocolName
         self.client = client
+        self.clientIconFilePath = clientIconFilePath
         self.domain = domain
         self.isAddressMultiple = isAddressMultiple
         self.isPortMultiple = isPortMultiple

--- a/TCPViewer/Features/NetworkInspector/Models/EndpointStatisticsTablePresentation.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/EndpointStatisticsTablePresentation.swift
@@ -1,0 +1,652 @@
+//
+//  EndpointStatisticsTablePresentation.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+
+enum EndpointStatisticsTableColumn: String, CaseIterable, Sendable {
+    case address
+    case port
+    case protocolName = "protocol"
+    case client
+    case domain
+    case packets
+    case bytes
+    case txPackets
+    case txBytes
+    case rxPackets
+    case rxBytes
+    case summary
+
+    var title: String {
+        switch self {
+        case .address: "Address"
+        case .port: "Port"
+        case .protocolName: "Protocol"
+        case .client: "Client"
+        case .domain: "Domain"
+        case .packets: "Packets"
+        case .bytes: "Bytes"
+        case .txPackets: "Tx Packets"
+        case .txBytes: "Tx Bytes"
+        case .rxPackets: "Rx Packets"
+        case .rxBytes: "Rx Bytes"
+        case .summary: "Summary"
+        }
+    }
+
+    var jsonKey: String {
+        switch self {
+        case .protocolName: "protocol"
+        case .txPackets: "tx_packets"
+        case .txBytes: "tx_bytes"
+        case .rxPackets: "rx_packets"
+        case .rxBytes: "rx_bytes"
+        default: rawValue
+        }
+    }
+
+    var isNumeric: Bool {
+        switch self {
+        case .packets, .bytes, .txPackets, .txBytes, .rxPackets, .rxBytes:
+            true
+        default:
+            false
+        }
+    }
+
+    func stringValue(in row: EndpointStatisticsRow) -> String {
+        switch self {
+        case .address: row.address ?? ""
+        case .port: row.port ?? ""
+        case .protocolName: row.protocolName ?? ""
+        case .client: row.client ?? ""
+        case .domain: row.domain ?? ""
+        case .packets: String(row.packets)
+        case .bytes: String(row.bytes)
+        case .txPackets: String(row.txPackets)
+        case .txBytes: String(row.txBytes)
+        case .rxPackets: String(row.rxPackets)
+        case .rxBytes: String(row.rxBytes)
+        case .summary: row.summary
+        }
+    }
+
+    func isAggregatePlaceholder(in row: EndpointStatisticsRow) -> Bool {
+        switch self {
+        case .address: row.isAddressMultiple
+        case .port: row.isPortMultiple
+        case .protocolName: row.isProtocolMultiple
+        case .client: row.isClientMultiple
+        case .domain: row.isDomainMultiple
+        case .packets, .bytes, .txPackets, .txBytes, .rxPackets, .rxBytes, .summary: false
+        }
+    }
+
+    fileprivate func stringSortValue(in row: EndpointStatisticsRow) -> String? {
+        switch self {
+        case .address: row.address
+        case .port: row.port
+        case .protocolName: row.protocolName
+        case .client: row.client
+        case .domain: row.domain
+        case .summary: row.summary
+        default: nil
+        }
+    }
+
+    fileprivate func numericSortValue(in row: EndpointStatisticsRow) -> UInt64? {
+        switch self {
+        case .packets: row.packets
+        case .bytes: row.bytes
+        case .txPackets: row.txPackets
+        case .txBytes: row.txBytes
+        case .rxPackets: row.rxPackets
+        case .rxBytes: row.rxBytes
+        default: nil
+        }
+    }
+}
+
+struct EndpointStatisticsTableSort: Equatable, Sendable {
+    let column: EndpointStatisticsTableColumn
+    let isAscending: Bool
+
+    static let busiestFirst = EndpointStatisticsTableSort(column: .bytes, isAscending: false)
+}
+
+struct EndpointStatisticsTablePresentation: Equatable, Sendable {
+    let rows: [EndpointStatisticsRow]
+    let rowIndexByID: [EndpointStatisticsRow.ID: Int]
+    let unfilteredRowCount: Int
+    let totals: EndpointStatisticsTotals
+}
+
+enum EndpointStatisticsSelectionRestoration {
+    static func selectedRowIDs(
+        rows: [EndpointStatisticsRow],
+        selectedIndexes: IndexSet
+    ) -> [EndpointStatisticsRow.ID] {
+        guard !selectedIndexes.isEmpty else {
+            return []
+        }
+        return selectedIndexes.compactMap { index in
+            rows.indices.contains(index) ? rows[index].id : nil
+        }
+    }
+
+    static func rowIndexes(
+        for selectedRowIDs: [EndpointStatisticsRow.ID],
+        rowIndexByID: [EndpointStatisticsRow.ID: Int]
+    ) -> IndexSet {
+        guard !selectedRowIDs.isEmpty else {
+            return []
+        }
+        return IndexSet(selectedRowIDs.compactMap { rowIndexByID[$0] })
+    }
+}
+
+struct EndpointStatisticsContextTarget: Equatable, Sendable {
+    let rowID: EndpointStatisticsRow.ID?
+    let column: EndpointStatisticsTableColumn?
+
+    static let none = EndpointStatisticsContextTarget(rowID: nil, column: nil)
+
+    func resolvedRowIndex(
+        rowIndexByID: [EndpointStatisticsRow.ID: Int],
+        rowCount: Int
+    ) -> Int? {
+        guard let rowID,
+              let index = rowIndexByID[rowID],
+              index >= 0,
+              index < rowCount else {
+            return nil
+        }
+        return index
+    }
+}
+
+enum EndpointStatisticsRowSelection: Equatable, Sendable {
+    case all
+    case indexes(IndexSet)
+
+    func isEmpty(rowCount: Int) -> Bool {
+        switch self {
+        case .all: rowCount == 0
+        case .indexes(let indexes): indexes.isEmpty
+        }
+    }
+
+    func firstIndex(rowCount: Int) -> Int? {
+        switch self {
+        case .all: rowCount > 0 ? 0 : nil
+        case .indexes(let indexes): indexes.first(where: { $0 >= 0 && $0 < rowCount })
+        }
+    }
+
+    func containsCopyableValue(
+        in rows: [EndpointStatisticsRow],
+        field: EndpointStatisticsSemanticCopyField
+    ) -> Bool {
+        switch self {
+        case .all:
+            return rows.contains { field.copyableValue(in: $0) != nil }
+        case .indexes(let indexes):
+            return indexes.contains { index in
+                rows.indices.contains(index) && field.copyableValue(in: rows[index]) != nil
+            }
+        }
+    }
+
+    // Selected rows are resolved after leaving AppKit's main thread.
+    func resolvedRows(
+        from rows: [EndpointStatisticsRow],
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> [EndpointStatisticsRow]? {
+        guard !cancellationToken.isCancelled() else {
+            return nil
+        }
+        switch self {
+        case .all:
+            return rows
+        case .indexes(let indexes):
+            var result: [EndpointStatisticsRow] = []
+            result.reserveCapacity(min(indexes.count, rows.count))
+            for (offset, index) in indexes.enumerated() {
+                if offset.isMultiple(of: 256), cancellationToken.isCancelled() {
+                    return nil
+                }
+                if rows.indices.contains(index) {
+                    result.append(rows[index])
+                }
+            }
+            return cancellationToken.isCancelled() ? nil : result
+        }
+    }
+}
+
+enum EndpointStatisticsSemanticCopyPolicy {
+    static func copyableValue(_ value: String?, isAggregatePlaceholder: Bool = false) -> String? {
+        guard let value, !value.isEmpty, !isAggregatePlaceholder else {
+            return nil
+        }
+        return value
+    }
+}
+
+enum EndpointStatisticsSemanticCopyField: Sendable {
+    case address
+    case domain
+    case client
+
+    func copyableValue(in row: EndpointStatisticsRow) -> String? {
+        switch self {
+        case .address:
+            EndpointStatisticsSemanticCopyPolicy.copyableValue(
+                row.address,
+                isAggregatePlaceholder: row.isAddressMultiple
+            )
+        case .domain:
+            EndpointStatisticsSemanticCopyPolicy.copyableValue(
+                row.domain,
+                isAggregatePlaceholder: row.isDomainMultiple
+            )
+        case .client:
+            EndpointStatisticsSemanticCopyPolicy.copyableValue(
+                row.client,
+                isAggregatePlaceholder: row.isClientMultiple
+            )
+        }
+    }
+}
+
+enum EndpointStatisticsSemanticValueFormatter {
+    static func joinedValues(
+        rows: [EndpointStatisticsRow],
+        field: EndpointStatisticsSemanticCopyField,
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> String? {
+        guard !cancellationToken.isCancelled() else {
+            return nil
+        }
+        var seen = Set<String>()
+        var values: [String] = []
+        for (index, row) in rows.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken.isCancelled() {
+                return nil
+            }
+            if let value = field.copyableValue(in: row), seen.insert(value).inserted {
+                values.append(value)
+            }
+        }
+        return cancellationToken.isCancelled() ? nil : values.joined(separator: "\n")
+    }
+}
+
+enum EndpointStatisticsTablePresenter {
+    // Search every identity field, then sort with a stable endpoint-key tie breaker.
+    static func presentation(
+        rows: [EndpointStatisticsRow],
+        searchText: String,
+        sort: EndpointStatisticsTableSort
+    ) -> EndpointStatisticsTablePresentation {
+        presentation(
+            rows: rows,
+            searchText: searchText,
+            sort: sort,
+            cancellationToken: nil
+        )!
+    }
+
+    static func presentation(
+        rows: [EndpointStatisticsRow],
+        searchText: String,
+        sort: EndpointStatisticsTableSort,
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> EndpointStatisticsTablePresentation? {
+        presentation(
+            rows: rows,
+            searchText: searchText,
+            sort: sort,
+            cancellationToken: Optional(cancellationToken)
+        )
+    }
+
+    private static func presentation(
+        rows: [EndpointStatisticsRow],
+        searchText: String,
+        sort: EndpointStatisticsTableSort,
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> EndpointStatisticsTablePresentation? {
+        let searchTerms = searchText
+            .split(whereSeparator: \.isWhitespace)
+            .map { $0.lowercased() }
+        var filteredRows: [EndpointStatisticsRow] = []
+        filteredRows.reserveCapacity(rows.count)
+        for (index, row) in rows.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return nil
+            }
+            guard !searchTerms.isEmpty else {
+                filteredRows.append(row)
+                continue
+            }
+            let searchableText = [
+                row.id.key,
+                row.address,
+                row.port,
+                row.protocolName,
+                row.client,
+                row.domain,
+            ]
+                .compactMap { $0 }
+                .joined(separator: " ")
+                .lowercased()
+            if searchTerms.allSatisfy(searchableText.contains) {
+                filteredRows.append(row)
+            }
+        }
+        guard let sortedRows = cancellableSortedRows(
+            filteredRows,
+            sort: sort,
+            cancellationToken: cancellationToken
+        ),
+        let totals = cancellableTotals(for: sortedRows, cancellationToken: cancellationToken) else {
+            return nil
+        }
+        var rowIndexByID: [EndpointStatisticsRow.ID: Int] = [:]
+        rowIndexByID.reserveCapacity(sortedRows.count)
+        for (index, row) in sortedRows.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return nil
+            }
+            rowIndexByID[row.id] = index
+        }
+        return EndpointStatisticsTablePresentation(
+            rows: sortedRows,
+            rowIndexByID: rowIndexByID,
+            unfilteredRowCount: rows.count,
+            totals: totals
+        )
+    }
+
+    static func totals(for rows: [EndpointStatisticsRow]) -> EndpointStatisticsTotals {
+        cancellableTotals(for: rows, cancellationToken: nil) ?? .zero
+    }
+
+    private static func cancellableTotals(
+        for rows: [EndpointStatisticsRow],
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> EndpointStatisticsTotals? {
+        var result = EndpointStatisticsTotals.zero
+        for (index, row) in rows.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return nil
+            }
+            result.packets = addingClamped(result.packets, row.packets)
+            result.bytes = addingClamped(result.bytes, row.bytes)
+            result.txPackets = addingClamped(result.txPackets, row.txPackets)
+            result.txBytes = addingClamped(result.txBytes, row.txBytes)
+            result.rxPackets = addingClamped(result.rxPackets, row.rxPackets)
+            result.rxBytes = addingClamped(result.rxBytes, row.rxBytes)
+            result.unclassifiedPackets = addingClamped(result.unclassifiedPackets, row.unclassifiedPackets)
+            result.unclassifiedBytes = addingClamped(result.unclassifiedBytes, row.unclassifiedBytes)
+        }
+        return result
+    }
+
+    // A bottom-up merge sort checks cancellation without retaining the window controller.
+    private static func cancellableSortedRows(
+        _ rows: [EndpointStatisticsRow],
+        sort: EndpointStatisticsTableSort,
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> [EndpointStatisticsRow]? {
+        guard rows.count > 1 else {
+            return cancellationToken?.isCancelled() == true ? nil : rows
+        }
+        var source = rows
+        var destination = rows
+        var width = 1
+        var comparisonCount = 0
+        while width < source.count {
+            var start = 0
+            while start < source.count {
+                if cancellationToken?.isCancelled() == true {
+                    return nil
+                }
+                let middle = min(start + width, source.count)
+                let end = min(start + width + width, source.count)
+                var left = start
+                var right = middle
+                var output = start
+                while left < middle || right < end {
+                    comparisonCount &+= 1
+                    if comparisonCount.isMultiple(of: 256),
+                       cancellationToken?.isCancelled() == true {
+                        return nil
+                    }
+                    if right >= end ||
+                        (left < middle && !isOrderedBefore(source[right], source[left], sort: sort)) {
+                        destination[output] = source[left]
+                        left += 1
+                    } else {
+                        destination[output] = source[right]
+                        right += 1
+                    }
+                    output += 1
+                }
+                start = end
+            }
+            swap(&source, &destination)
+            width = width > source.count / 2 ? source.count : width * 2
+        }
+        return cancellationToken?.isCancelled() == true ? nil : source
+    }
+
+    private static func isOrderedBefore(
+        _ lhs: EndpointStatisticsRow,
+        _ rhs: EndpointStatisticsRow,
+        sort: EndpointStatisticsTableSort
+    ) -> Bool {
+        let comparison: ComparisonResult
+        if let lhsNumber = sort.column.numericSortValue(in: lhs),
+           let rhsNumber = sort.column.numericSortValue(in: rhs) {
+            comparison = lhsNumber == rhsNumber ? .orderedSame : (lhsNumber < rhsNumber ? .orderedAscending : .orderedDescending)
+        } else if sort.column == .summary {
+            comparison = compareSummary(lhs, rhs)
+        } else {
+            let lhsValue = sort.column.stringSortValue(in: lhs)
+            let rhsValue = sort.column.stringSortValue(in: rhs)
+            if lhsValue == nil || rhsValue == nil {
+                if lhsValue == nil, rhsValue != nil {
+                    return false
+                }
+                if lhsValue != nil, rhsValue == nil {
+                    return true
+                }
+                comparison = .orderedSame
+            } else if sort.column == .port,
+                      let lhsPort = UInt64(lhsValue!),
+                      let rhsPort = UInt64(rhsValue!) {
+                comparison = lhsPort == rhsPort ? .orderedSame : (lhsPort < rhsPort ? .orderedAscending : .orderedDescending)
+            } else {
+                comparison = lhsValue!.localizedStandardCompare(rhsValue!)
+            }
+        }
+
+        if comparison == .orderedSame {
+            return lhs.id.key.localizedStandardCompare(rhs.id.key) == .orderedAscending
+        }
+        return sort.isAscending ? comparison == .orderedAscending : comparison == .orderedDescending
+    }
+
+    private static func compareSummary(
+        _ lhs: EndpointStatisticsRow,
+        _ rhs: EndpointStatisticsRow
+    ) -> ComparisonResult {
+        let lhsTotal = Double(lhs.txBytes) + Double(lhs.rxBytes) + Double(lhs.unclassifiedBytes)
+        let rhsTotal = Double(rhs.txBytes) + Double(rhs.rxBytes) + Double(rhs.unclassifiedBytes)
+        let lhsShare = lhsTotal == 0 ? 0 : Double(lhs.txBytes) / lhsTotal
+        let rhsShare = rhsTotal == 0 ? 0 : Double(rhs.txBytes) / rhsTotal
+        if lhsShare == rhsShare {
+            return .orderedSame
+        }
+        return lhsShare < rhsShare ? .orderedAscending : .orderedDescending
+    }
+
+    private static func addingClamped(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? .max : result.partialValue
+    }
+}
+
+enum EndpointStatisticsTableExportFormatter {
+    static func csv(
+        rows: [EndpointStatisticsRow],
+        columns: [EndpointStatisticsTableColumn]
+    ) -> String {
+        csv(rows: rows, columns: columns, cancellationToken: nil) ?? ""
+    }
+
+    static func csv(
+        rows: [EndpointStatisticsRow],
+        columns: [EndpointStatisticsTableColumn],
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> String? {
+        csv(rows: rows, columns: columns, cancellationToken: Optional(cancellationToken))
+    }
+
+    private static func csv(
+        rows: [EndpointStatisticsRow],
+        columns: [EndpointStatisticsTableColumn],
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> String? {
+        guard !columns.isEmpty else {
+            return ""
+        }
+        guard cancellationToken?.isCancelled() != true else {
+            return nil
+        }
+        let header = columns.map { csvField($0.title, protectsFormula: false) }.joined(separator: ",")
+        var lines = [header]
+        lines.reserveCapacity(rows.count + 1)
+        for (index, row) in rows.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return nil
+            }
+            lines.append(columns.map { column in
+                csvField(column.stringValue(in: row), protectsFormula: !column.isNumeric)
+            }.joined(separator: ","))
+        }
+        return cancellationToken?.isCancelled() == true ? nil : lines.joined(separator: "\r\n")
+    }
+
+    static func json(
+        rows: [EndpointStatisticsRow],
+        columns: [EndpointStatisticsTableColumn]
+    ) -> String {
+        json(rows: rows, columns: columns, cancellationToken: nil) ?? "[]"
+    }
+
+    static func json(
+        rows: [EndpointStatisticsRow],
+        columns: [EndpointStatisticsTableColumn],
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> String? {
+        json(rows: rows, columns: columns, cancellationToken: Optional(cancellationToken))
+    }
+
+    // Build JSON incrementally so cancellation never waits behind one monolithic encoder pass.
+    private static func json(
+        rows: [EndpointStatisticsRow],
+        columns: [EndpointStatisticsTableColumn],
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> String? {
+        guard cancellationToken?.isCancelled() != true else {
+            return nil
+        }
+        guard !rows.isEmpty else {
+            return "[]"
+        }
+        var result = "[\n"
+        for (rowIndex, row) in rows.enumerated() {
+            if rowIndex.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return nil
+            }
+            if rowIndex > 0 {
+                result.append(",\n")
+            }
+            if columns.isEmpty {
+                result.append("  {}")
+                continue
+            }
+            result.append("  {\n")
+            for (columnIndex, column) in columns.enumerated() {
+                if columnIndex > 0 {
+                    result.append(",\n")
+                }
+                result.append("    \(jsonString(column.jsonKey)): \(jsonValue(column: column, row: row))")
+            }
+            result.append("\n  }")
+        }
+        result.append("\n]")
+        return cancellationToken?.isCancelled() == true ? nil : result
+    }
+
+    private static func csvField(_ value: String, protectsFormula: Bool) -> String {
+        let protectedValue = protectsFormula && needsFormulaProtection(value) ? "'\(value)" : value
+        guard protectedValue.contains(",") || protectedValue.contains("\"") || protectedValue.contains("\r") || protectedValue.contains("\n") else {
+            return protectedValue
+        }
+        return "\"\(protectedValue.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    private static func needsFormulaProtection(_ value: String) -> Bool {
+        if let first = value.first, first == "\t" || first == "\r" {
+            return true
+        }
+        let firstNonWhitespace = value.drop(while: \.isWhitespace).first
+        guard let first = firstNonWhitespace else {
+            return false
+        }
+        return "=+-@".contains(first)
+    }
+
+    private static func jsonValue(
+        column: EndpointStatisticsTableColumn,
+        row: EndpointStatisticsRow
+    ) -> String {
+        switch column {
+        case .packets: String(row.packets)
+        case .bytes: String(row.bytes)
+        case .txPackets: String(row.txPackets)
+        case .txBytes: String(row.txBytes)
+        case .rxPackets: String(row.rxPackets)
+        case .rxBytes: String(row.rxBytes)
+        default: jsonString(column.stringValue(in: row))
+        }
+    }
+
+    private static func jsonString(_ value: String) -> String {
+        var result = "\""
+        result.reserveCapacity(value.utf8.count + 2)
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x22: result.append("\\\"")
+            case 0x5C: result.append("\\\\")
+            case 0x08: result.append("\\b")
+            case 0x0C: result.append("\\f")
+            case 0x0A: result.append("\\n")
+            case 0x0D: result.append("\\r")
+            case 0x09: result.append("\\t")
+            case 0x00...0x1F: result.append(String(format: "\\u%04x", scalar.value))
+            default: result.unicodeScalars.append(scalar)
+            }
+        }
+        result.append("\"")
+        return result
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -100,6 +100,64 @@ private extension String {
     }
 }
 
+private enum PacketTableSummaryFormatter {
+    static func summary(for packet: PacketSummary) -> String {
+        guard packet.transportHint == .dns,
+              let dnsSummary = conciseDNS(
+                packet.infoSummary,
+                resolutions: packet.dnsResolutions
+              ) else {
+            return packet.infoSummary
+        }
+        return dnsSummary
+    }
+
+    // Wireshark's DNS sentence is useful in packet details but too long for a scannable table row.
+    private static func conciseDNS(
+        _ summary: String,
+        resolutions: [DNSResolutionObservation]?
+    ) -> String? {
+        let components = summary.split(whereSeparator: \Character.isWhitespace).map(String.init)
+        let words = components.map { $0.lowercased() }
+        let isResponse: Bool
+        var queryIndex: Int
+
+        if words.starts(with: ["standard", "query", "response"]) {
+            isResponse = true
+            queryIndex = 3
+        } else if words.starts(with: ["standard", "query"]) {
+            isResponse = false
+            queryIndex = 2
+        } else {
+            return nil
+        }
+
+        if components.indices.contains(queryIndex), components[queryIndex].hasPrefix("0x") {
+            queryIndex += 1
+        }
+        guard components.indices.contains(queryIndex + 1) else {
+            return nil
+        }
+
+        let queryType = components[queryIndex]
+        let queryName = components[queryIndex + 1].trimmingCharacters(in: CharacterSet(charactersIn: ","))
+        guard !queryType.isEmpty, !queryName.isEmpty else {
+            return nil
+        }
+
+        guard isResponse else {
+            return "\(queryType)? \(queryName)"
+        }
+        let matchingResolution = resolutions?.first {
+            $0.domainName.caseInsensitiveCompare(queryName) == .orderedSame
+        } ?? resolutions?.first
+        guard let matchingResolution else {
+            return "\(queryType) \(queryName)"
+        }
+        return "\(queryType) \(queryName) → \(matchingResolution.ipAddress)"
+    }
+}
+
 enum PacketInspectorTab: String, CaseIterable, Identifiable, Sendable, Hashable {
     case summary
     case detail
@@ -245,7 +303,7 @@ struct PacketTableRow: Identifiable, Sendable, Hashable {
         self.decodeStatusText = NetworkInspectorFormatters.decodeStatusLabel(packet.decodeStatus).tcpviewerNativeCopy
         self.interfaceText = (packet.captureMetadata.interfaceName ?? packet.interfaceID ?? "-").tcpviewerNativeCopy
         self.lengthText = NetworkInspectorFormatters.byteCount(packet.capturedLength)
-        self.summaryText = packet.infoSummary.tcpviewerNativeCopy
+        self.summaryText = PacketTableSummaryFormatter.summary(for: packet).tcpviewerNativeCopy
         self.comment = packet.resolvedComment?.tcpviewerNativeCopy
         self.commentText = (packet.resolvedComment ?? "")
             .components(separatedBy: .newlines)

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -543,6 +543,7 @@ struct NetworkInspectorSnapshot: Equatable {
     var displayFilter: PacketDisplayFilter
     var displayFilterChips: [PacketFilterChip]
     var structuredFilterGroup: PacketStructuredFilterGroup
+    var endpointStatisticsFilterLabel: String?
     var isPacketTableFiltering: Bool
     var packetTableRowStore: PacketTableRowStore
     var packetTableGeneration: UInt64
@@ -571,6 +572,7 @@ struct NetworkInspectorSnapshot: Equatable {
         wiresharkFilterState: PacketWiresharkFilterState = PacketWiresharkFilterState(),
         displayFilterText: String,
         structuredFilterGroup: PacketStructuredFilterGroup = .default,
+        endpointStatisticsFilterLabel: String? = nil,
         isPacketTableFiltering: Bool = false,
         packetTableContent: PacketTableContent
     ) -> NetworkInspectorSnapshot {
@@ -594,6 +596,7 @@ struct NetworkInspectorSnapshot: Equatable {
             displayFilter: packetTableContent.displayFilter,
             displayFilterChips: packetTableContent.displayFilterChips,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilterLabel: endpointStatisticsFilterLabel,
             isPacketTableFiltering: isPacketTableFiltering,
             packetTableRowStore: packetTableContent.store,
             packetTableGeneration: packetTableContent.generation,
@@ -629,6 +632,7 @@ struct NetworkInspectorSnapshot: Equatable {
             lhs.displayFilter == rhs.displayFilter &&
             lhs.displayFilterChips == rhs.displayFilterChips &&
             lhs.structuredFilterGroup == rhs.structuredFilterGroup &&
+            lhs.endpointStatisticsFilterLabel == rhs.endpointStatisticsFilterLabel &&
             lhs.isPacketTableFiltering == rhs.isPacketTableFiltering &&
             lhs.packetTableGeneration == rhs.packetTableGeneration &&
             lhs.packetTableUpdatePlan == rhs.packetTableUpdatePlan &&
@@ -656,7 +660,7 @@ struct NetworkInspectorSnapshot: Equatable {
     var activeFilterBarLabels: [String] {
         quickFilterSelection.activeLabels + customFilterItems
             .filter(\.isSelected)
-            .map(\.title)
+            .map(\.title) + [endpointStatisticsFilterLabel].compactMap { $0 }
     }
 
     var isQuickFilterResetVisible: Bool {

--- a/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/NetworkInspectorModels.swift
@@ -9,6 +9,7 @@ import Foundation
 import PcapPlusPlusCore
 
 enum NetworkInspectorWorkspaceMode: String, CaseIterable, Identifiable, Sendable, Hashable {
+    case overview
     case packets
     case flows
     case timeline
@@ -19,6 +20,8 @@ enum NetworkInspectorWorkspaceMode: String, CaseIterable, Identifiable, Sendable
 
     var title: String {
         switch self {
+        case .overview:
+            "Overview"
         case .packets:
             "Packets"
         case .flows:
@@ -34,6 +37,8 @@ enum NetworkInspectorWorkspaceMode: String, CaseIterable, Identifiable, Sendable
 
     var systemImage: String {
         switch self {
+        case .overview:
+            "chart.bar.xaxis"
         case .packets:
             "list.bullet.rectangle"
         case .flows:
@@ -49,6 +54,8 @@ enum NetworkInspectorWorkspaceMode: String, CaseIterable, Identifiable, Sendable
 
     var preparedStateMessage: String {
         switch self {
+        case .overview:
+            "Capture overview is ready."
         case .packets:
             "Packet inspection is ready."
         case .flows:

--- a/TCPViewer/Features/NetworkInspector/Services/CaptureOverviewService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/CaptureOverviewService.swift
@@ -45,18 +45,6 @@ struct CaptureOverviewTrafficTotals: Equatable, Sendable {
     }
 }
 
-enum CaptureOverviewTopGroup: Int, CaseIterable, Sendable {
-    case apps
-    case domains
-
-    var title: String {
-        switch self {
-        case .apps: "Apps"
-        case .domains: "Domains"
-        }
-    }
-}
-
 struct CaptureOverviewTopRow: Identifiable, Equatable, Sendable {
     let id: String
     let title: String
@@ -84,7 +72,7 @@ struct CaptureOverviewSnapshot: Equatable, Sendable {
     let domainCount: Int
     let malformedPacketCount: UInt64
     let topApps: [CaptureOverviewTopRow]
-    let topDomains: [CaptureOverviewTopRow]
+    let topDestinations: [CaptureOverviewTopRow]
     let protocols: [CaptureOverviewProtocolRow]
     let timeline: [CaptureOverviewTimelinePoint]
 
@@ -96,17 +84,11 @@ struct CaptureOverviewSnapshot: Equatable, Sendable {
         domainCount: 0,
         malformedPacketCount: 0,
         topApps: [],
-        topDomains: [],
+        topDestinations: [],
         protocols: [],
         timeline: []
     )
 
-    func topRows(for group: CaptureOverviewTopGroup) -> [CaptureOverviewTopRow] {
-        switch group {
-        case .apps: topApps
-        case .domains: topDomains
-        }
-    }
 }
 
 private struct CaptureOverviewContribution: Equatable {
@@ -114,6 +96,7 @@ private struct CaptureOverviewContribution: Equatable {
     let timestamp: Date
     let app: PacketSourceClientIdentity?
     let domain: PacketSourceDomainIdentity?
+    let ipAddresses: [PacketSourceIPAddressIdentity]
     let protocolName: String
     let totals: CaptureOverviewTrafficTotals
     let isMalformed: Bool
@@ -126,6 +109,11 @@ private struct CaptureOverviewAppBucket {
 
 private struct CaptureOverviewDomainBucket {
     var identity: PacketSourceDomainIdentity
+    var totals = CaptureOverviewTrafficTotals()
+}
+
+private struct CaptureOverviewIPAddressBucket {
+    var identity: PacketSourceIPAddressIdentity
     var totals = CaptureOverviewTrafficTotals()
 }
 
@@ -142,12 +130,13 @@ private struct CaptureOverviewSourceIdentity: Equatable {
 struct CaptureOverviewAccumulator {
     static let maximumTimelineBucketCount = 1_024
     static let maximumRenderedTimelinePointCount = 240
-    static let maximumTopRowCount = 8
+    static let maximumTopRowCount = 10
     static let maximumProtocolRowCount = 5
 
     private var contributionsByPacketID: [PacketSummary.ID: CaptureOverviewContribution] = [:]
     private var appBuckets: [PacketSourceClientKey: CaptureOverviewAppBucket] = [:]
     private var domainBuckets: [PacketSourceDomainKey: CaptureOverviewDomainBucket] = [:]
+    private var ipAddressBuckets: [PacketSourceIPAddressKey: CaptureOverviewIPAddressBucket] = [:]
     private var protocolBuckets: [String: CaptureOverviewProtocolBucket] = [:]
     private var timelineBuckets: [Int64: CaptureOverviewTrafficTotals] = [:]
     private var timelineBucketWidth: TimeInterval = 1
@@ -161,6 +150,7 @@ struct CaptureOverviewAccumulator {
         contributionsByPacketID.removeAll(keepingCapacity: false)
         appBuckets.removeAll(keepingCapacity: false)
         domainBuckets.removeAll(keepingCapacity: false)
+        ipAddressBuckets.removeAll(keepingCapacity: false)
         protocolBuckets.removeAll(keepingCapacity: false)
         timelineBuckets.removeAll(keepingCapacity: false)
         timelineBucketWidth = 1
@@ -240,7 +230,7 @@ struct CaptureOverviewAccumulator {
             domainCount: domainBuckets.count,
             malformedPacketCount: malformedPacketCount,
             topApps: topAppRows(),
-            topDomains: topDomainRows(),
+            topDestinations: topDestinationRows(),
             protocols: protocolRows(),
             timeline: timelinePoints()
         )
@@ -271,6 +261,12 @@ struct CaptureOverviewAccumulator {
             bucket.identity = domain
             bucket.totals.add(contribution.totals)
             domainBuckets[domain.key] = bucket
+        }
+        for ipAddress in contribution.ipAddresses {
+            var bucket = ipAddressBuckets[ipAddress.key] ?? CaptureOverviewIPAddressBucket(identity: ipAddress)
+            bucket.identity = ipAddress
+            bucket.totals.add(contribution.totals)
+            ipAddressBuckets[ipAddress.key] = bucket
         }
         var protocolBucket = protocolBuckets[contribution.protocolName]
             ?? CaptureOverviewProtocolBucket(title: contribution.protocolName)
@@ -307,6 +303,17 @@ struct CaptureOverviewAccumulator {
                 domainBuckets[domain.key] = bucket
             }
         }
+        for ipAddress in contribution.ipAddresses {
+            guard var bucket = ipAddressBuckets[ipAddress.key] else {
+                continue
+            }
+            bucket.totals.remove(contribution.totals)
+            if bucket.totals.isEmpty {
+                ipAddressBuckets.removeValue(forKey: ipAddress.key)
+            } else {
+                ipAddressBuckets[ipAddress.key] = bucket
+            }
+        }
         if var bucket = protocolBuckets[contribution.protocolName] {
             bucket.totals.remove(contribution.totals)
             if bucket.totals.isEmpty {
@@ -333,6 +340,7 @@ struct CaptureOverviewAccumulator {
             timestamp: packet.timestamp,
             app: PacketSourceListClassifier.clientIdentity(for: packet),
             domain: PacketSourceListClassifier.domainIdentity(for: packet),
+            ipAddresses: PacketSourceListClassifier.ipAddressIdentities(for: packet),
             protocolName: EndpointStatisticsClassifier.protocolName(for: packet),
             totals: trafficTotals(bytes: UInt64(max(0, packet.originalLength)), direction: packet.direction),
             isMalformed: packet.decodeStatus.kind == .malformed
@@ -370,35 +378,51 @@ struct CaptureOverviewAccumulator {
         })
     }
 
-    private func topDomainRows() -> [CaptureOverviewTopRow] {
-        topRows(domainBuckets.values.lazy.map { bucket in
-            CaptureOverviewTopRow(
-                id: bucket.identity.key.rawValue,
+    private func topDestinationRows() -> [CaptureOverviewTopRow] {
+        var result: [CaptureOverviewTopRow] = []
+        result.reserveCapacity(Self.maximumTopRowCount)
+        for bucket in domainBuckets.values {
+            insertTopRow(CaptureOverviewTopRow(
+                id: "domain:\(bucket.identity.key.rawValue)",
                 title: bucket.identity.displayName,
                 iconFilePath: nil,
                 selection: .domain(bucket.identity.key),
                 totals: bucket.totals
-            )
-        })
+            ), into: &result)
+        }
+        for bucket in ipAddressBuckets.values {
+            insertTopRow(CaptureOverviewTopRow(
+                id: "ip:\(bucket.identity.key.rawValue)",
+                title: bucket.identity.displayName,
+                iconFilePath: nil,
+                selection: .ipAddress(bucket.identity.key),
+                totals: bucket.totals
+            ), into: &result)
+        }
+        return result
     }
 
-    // Keep only eight candidates while scanning so high-cardinality captures avoid a full sort.
+    // Keep only ten candidates while scanning so high-cardinality captures avoid a full sort.
     private func topRows<Rows: Sequence>(_ rows: Rows) -> [CaptureOverviewTopRow]
         where Rows.Element == CaptureOverviewTopRow {
         var result: [CaptureOverviewTopRow] = []
         result.reserveCapacity(Self.maximumTopRowCount)
         for row in rows {
-            let insertionIndex = result.firstIndex { Self.precedes(row, $0) } ?? result.endIndex
-            if insertionIndex < Self.maximumTopRowCount {
-                result.insert(row, at: insertionIndex)
-                if result.count > Self.maximumTopRowCount {
-                    result.removeLast()
-                }
-            } else if result.count < Self.maximumTopRowCount {
-                result.append(row)
-            }
+            insertTopRow(row, into: &result)
         }
         return result
+    }
+
+    private func insertTopRow(_ row: CaptureOverviewTopRow, into result: inout [CaptureOverviewTopRow]) {
+        let insertionIndex = result.firstIndex { Self.precedes(row, $0) } ?? result.endIndex
+        if insertionIndex < Self.maximumTopRowCount {
+            result.insert(row, at: insertionIndex)
+            if result.count > Self.maximumTopRowCount {
+                result.removeLast()
+            }
+        } else if result.count < Self.maximumTopRowCount {
+            result.append(row)
+        }
     }
 
     private static func precedes(_ lhs: CaptureOverviewTopRow, _ rhs: CaptureOverviewTopRow) -> Bool {

--- a/TCPViewer/Features/NetworkInspector/Services/CaptureOverviewService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/CaptureOverviewService.swift
@@ -1,0 +1,839 @@
+//
+//  CaptureOverviewService.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/9/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+
+struct CaptureOverviewTrafficTotals: Equatable, Sendable {
+    var packets: UInt64 = 0
+    var bytes: UInt64 = 0
+    var sentPackets: UInt64 = 0
+    var sentBytes: UInt64 = 0
+    var receivedPackets: UInt64 = 0
+    var receivedBytes: UInt64 = 0
+    var unclassifiedPackets: UInt64 = 0
+    var unclassifiedBytes: UInt64 = 0
+
+    var isEmpty: Bool {
+        packets == 0
+    }
+
+    mutating func add(_ value: CaptureOverviewTrafficTotals) {
+        packets += value.packets
+        bytes += value.bytes
+        sentPackets += value.sentPackets
+        sentBytes += value.sentBytes
+        receivedPackets += value.receivedPackets
+        receivedBytes += value.receivedBytes
+        unclassifiedPackets += value.unclassifiedPackets
+        unclassifiedBytes += value.unclassifiedBytes
+    }
+
+    mutating func remove(_ value: CaptureOverviewTrafficTotals) {
+        packets -= value.packets
+        bytes -= value.bytes
+        sentPackets -= value.sentPackets
+        sentBytes -= value.sentBytes
+        receivedPackets -= value.receivedPackets
+        receivedBytes -= value.receivedBytes
+        unclassifiedPackets -= value.unclassifiedPackets
+        unclassifiedBytes -= value.unclassifiedBytes
+    }
+}
+
+enum CaptureOverviewTopGroup: Int, CaseIterable, Sendable {
+    case apps
+    case domains
+
+    var title: String {
+        switch self {
+        case .apps: "Apps"
+        case .domains: "Domains"
+        }
+    }
+}
+
+struct CaptureOverviewTopRow: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let iconFilePath: String?
+    let selection: PacketSourceListSelection
+    let totals: CaptureOverviewTrafficTotals
+}
+
+struct CaptureOverviewProtocolRow: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let totals: CaptureOverviewTrafficTotals
+}
+
+struct CaptureOverviewTimelinePoint: Equatable, Sendable {
+    let date: Date
+    let totals: CaptureOverviewTrafficTotals
+}
+
+struct CaptureOverviewSnapshot: Equatable, Sendable {
+    let totals: CaptureOverviewTrafficTotals
+    let firstPacketDate: Date?
+    let lastPacketDate: Date?
+    let appCount: Int
+    let domainCount: Int
+    let malformedPacketCount: UInt64
+    let topApps: [CaptureOverviewTopRow]
+    let topDomains: [CaptureOverviewTopRow]
+    let protocols: [CaptureOverviewProtocolRow]
+    let timeline: [CaptureOverviewTimelinePoint]
+
+    static let empty = CaptureOverviewSnapshot(
+        totals: CaptureOverviewTrafficTotals(),
+        firstPacketDate: nil,
+        lastPacketDate: nil,
+        appCount: 0,
+        domainCount: 0,
+        malformedPacketCount: 0,
+        topApps: [],
+        topDomains: [],
+        protocols: [],
+        timeline: []
+    )
+
+    func topRows(for group: CaptureOverviewTopGroup) -> [CaptureOverviewTopRow] {
+        switch group {
+        case .apps: topApps
+        case .domains: topDomains
+        }
+    }
+}
+
+private struct CaptureOverviewContribution: Equatable {
+    let packetID: PacketSummary.ID
+    let timestamp: Date
+    let app: PacketSourceClientIdentity?
+    let domain: PacketSourceDomainIdentity?
+    let protocolName: String
+    let totals: CaptureOverviewTrafficTotals
+    let isMalformed: Bool
+}
+
+private struct CaptureOverviewAppBucket {
+    var identity: PacketSourceClientIdentity
+    var totals = CaptureOverviewTrafficTotals()
+}
+
+private struct CaptureOverviewDomainBucket {
+    var identity: PacketSourceDomainIdentity
+    var totals = CaptureOverviewTrafficTotals()
+}
+
+private struct CaptureOverviewProtocolBucket {
+    let title: String
+    var totals = CaptureOverviewTrafficTotals()
+}
+
+private struct CaptureOverviewSourceIdentity: Equatable {
+    let backingIdentity: String?
+    let packetLineageRevision: UInt64
+}
+
+struct CaptureOverviewAccumulator {
+    static let maximumTimelineBucketCount = 1_024
+    static let maximumRenderedTimelinePointCount = 240
+    static let maximumTopRowCount = 8
+    static let maximumProtocolRowCount = 5
+
+    private var contributionsByPacketID: [PacketSummary.ID: CaptureOverviewContribution] = [:]
+    private var appBuckets: [PacketSourceClientKey: CaptureOverviewAppBucket] = [:]
+    private var domainBuckets: [PacketSourceDomainKey: CaptureOverviewDomainBucket] = [:]
+    private var protocolBuckets: [String: CaptureOverviewProtocolBucket] = [:]
+    private var timelineBuckets: [Int64: CaptureOverviewTrafficTotals] = [:]
+    private var timelineBucketWidth: TimeInterval = 1
+    private var totals = CaptureOverviewTrafficTotals()
+    private var malformedPacketCount: UInt64 = 0
+    private var firstPacketDate: Date?
+    private var lastPacketDate: Date?
+    private var cursor: EndpointStatisticsIngestCursor?
+
+    mutating func reset() {
+        contributionsByPacketID.removeAll(keepingCapacity: false)
+        appBuckets.removeAll(keepingCapacity: false)
+        domainBuckets.removeAll(keepingCapacity: false)
+        protocolBuckets.removeAll(keepingCapacity: false)
+        timelineBuckets.removeAll(keepingCapacity: false)
+        timelineBucketWidth = 1
+        totals = CaptureOverviewTrafficTotals()
+        malformedPacketCount = 0
+        firstPacketDate = nil
+        lastPacketDate = nil
+        cursor = nil
+    }
+
+    mutating func appendReplacementChunk(_ packets: [PacketSummary]) {
+        for packet in packets {
+            replaceContribution(for: packet)
+        }
+    }
+
+    mutating func finishReplacement(cursor: EndpointStatisticsIngestCursor) -> Bool {
+        guard contributionsByPacketID.count == cursor.totalPacketCount else {
+            return false
+        }
+        self.cursor = cursor
+        return true
+    }
+
+    // Apply exact revisions so a dropped live mutation requests a fresh chunked replacement.
+    mutating func consume(_ update: EndpointStatisticsIngestUpdate) -> Bool {
+        guard let cursor,
+              cursor.packetLineageRevision == update.packetLineageRevision,
+              update.previousPacketRevision == cursor.packetRevision else {
+            return false
+        }
+
+        switch update.kind {
+        case .replace:
+            return false
+        case .append(let packets):
+            guard contributionsByPacketID.count + packets.count == update.totalPacketCount else {
+                return false
+            }
+            for packet in packets {
+                replaceContribution(for: packet)
+            }
+        case .appendWithMetadata(let newPackets, let updatedPackets):
+            guard contributionsByPacketID.count + newPackets.count == update.totalPacketCount else {
+                return false
+            }
+            for packet in newPackets {
+                replaceContribution(for: packet)
+            }
+            for packet in updatedPackets {
+                replaceContribution(for: packet)
+            }
+        case .metadata(let packets):
+            guard contributionsByPacketID.count == update.totalPacketCount else {
+                return false
+            }
+            for packet in packets {
+                replaceContribution(for: packet)
+            }
+        }
+        self.cursor = update.cursor
+        return true
+    }
+
+    mutating func applyMetadata(_ packets: [PacketSummary]) {
+        for packet in packets {
+            replaceContribution(for: packet)
+        }
+    }
+
+    func snapshot() -> CaptureOverviewSnapshot {
+        CaptureOverviewSnapshot(
+            totals: totals,
+            firstPacketDate: firstPacketDate,
+            lastPacketDate: lastPacketDate,
+            appCount: appBuckets.count,
+            domainCount: domainBuckets.count,
+            malformedPacketCount: malformedPacketCount,
+            topApps: topAppRows(),
+            topDomains: topDomainRows(),
+            protocols: protocolRows(),
+            timeline: timelinePoints()
+        )
+    }
+
+    private mutating func replaceContribution(for packet: PacketSummary) {
+        if let oldContribution = contributionsByPacketID[packet.id] {
+            remove(oldContribution)
+        }
+        let contribution = Self.contribution(for: packet)
+        contributionsByPacketID[packet.id] = contribution
+        add(contribution)
+    }
+
+    private mutating func add(_ contribution: CaptureOverviewContribution) {
+        totals.add(contribution.totals)
+        if contribution.isMalformed {
+            malformedPacketCount += 1
+        }
+        if let app = contribution.app {
+            var bucket = appBuckets[app.key] ?? CaptureOverviewAppBucket(identity: app)
+            bucket.identity = app
+            bucket.totals.add(contribution.totals)
+            appBuckets[app.key] = bucket
+        }
+        if let domain = contribution.domain, !domain.key.isMissingDomain {
+            var bucket = domainBuckets[domain.key] ?? CaptureOverviewDomainBucket(identity: domain)
+            bucket.identity = domain
+            bucket.totals.add(contribution.totals)
+            domainBuckets[domain.key] = bucket
+        }
+        var protocolBucket = protocolBuckets[contribution.protocolName]
+            ?? CaptureOverviewProtocolBucket(title: contribution.protocolName)
+        protocolBucket.totals.add(contribution.totals)
+        protocolBuckets[contribution.protocolName] = protocolBucket
+
+        let timelineKey = self.timelineKey(for: contribution.timestamp)
+        timelineBuckets[timelineKey, default: CaptureOverviewTrafficTotals()].add(contribution.totals)
+        firstPacketDate = min(firstPacketDate ?? contribution.timestamp, contribution.timestamp)
+        lastPacketDate = max(lastPacketDate ?? contribution.timestamp, contribution.timestamp)
+        compactTimelineIfNeeded()
+    }
+
+    private mutating func remove(_ contribution: CaptureOverviewContribution) {
+        totals.remove(contribution.totals)
+        if contribution.isMalformed {
+            malformedPacketCount -= 1
+        }
+        if let app = contribution.app, var bucket = appBuckets[app.key] {
+            bucket.totals.remove(contribution.totals)
+            if bucket.totals.isEmpty {
+                appBuckets.removeValue(forKey: app.key)
+            } else {
+                appBuckets[app.key] = bucket
+            }
+        }
+        if let domain = contribution.domain,
+           !domain.key.isMissingDomain,
+           var bucket = domainBuckets[domain.key] {
+            bucket.totals.remove(contribution.totals)
+            if bucket.totals.isEmpty {
+                domainBuckets.removeValue(forKey: domain.key)
+            } else {
+                domainBuckets[domain.key] = bucket
+            }
+        }
+        if var bucket = protocolBuckets[contribution.protocolName] {
+            bucket.totals.remove(contribution.totals)
+            if bucket.totals.isEmpty {
+                protocolBuckets.removeValue(forKey: contribution.protocolName)
+            } else {
+                protocolBuckets[contribution.protocolName] = bucket
+            }
+        }
+
+        let timelineKey = self.timelineKey(for: contribution.timestamp)
+        if var bucket = timelineBuckets[timelineKey] {
+            bucket.remove(contribution.totals)
+            if bucket.isEmpty {
+                timelineBuckets.removeValue(forKey: timelineKey)
+            } else {
+                timelineBuckets[timelineKey] = bucket
+            }
+        }
+    }
+
+    private static func contribution(for packet: PacketSummary) -> CaptureOverviewContribution {
+        CaptureOverviewContribution(
+            packetID: packet.id,
+            timestamp: packet.timestamp,
+            app: PacketSourceListClassifier.clientIdentity(for: packet),
+            domain: PacketSourceListClassifier.domainIdentity(for: packet),
+            protocolName: EndpointStatisticsClassifier.protocolName(for: packet),
+            totals: trafficTotals(bytes: UInt64(max(0, packet.originalLength)), direction: packet.direction),
+            isMalformed: packet.decodeStatus.kind == .malformed
+        )
+    }
+
+    private static func trafficTotals(bytes: UInt64, direction: PacketDirection?) -> CaptureOverviewTrafficTotals {
+        var value = CaptureOverviewTrafficTotals(packets: 1, bytes: bytes)
+        switch direction {
+        case .outbound:
+            value.sentPackets = 1
+            value.sentBytes = bytes
+        case .inbound:
+            value.receivedPackets = 1
+            value.receivedBytes = bytes
+        case .local, .unknown, nil:
+            value.unclassifiedPackets = 1
+            value.unclassifiedBytes = bytes
+        @unknown default:
+            value.unclassifiedPackets = 1
+            value.unclassifiedBytes = bytes
+        }
+        return value
+    }
+
+    private func topAppRows() -> [CaptureOverviewTopRow] {
+        topRows(appBuckets.values.lazy.map { bucket in
+            CaptureOverviewTopRow(
+                id: bucket.identity.key.rawValue,
+                title: bucket.identity.displayName,
+                iconFilePath: bucket.identity.iconFilePath,
+                selection: .app(bucket.identity.key),
+                totals: bucket.totals
+            )
+        })
+    }
+
+    private func topDomainRows() -> [CaptureOverviewTopRow] {
+        topRows(domainBuckets.values.lazy.map { bucket in
+            CaptureOverviewTopRow(
+                id: bucket.identity.key.rawValue,
+                title: bucket.identity.displayName,
+                iconFilePath: nil,
+                selection: .domain(bucket.identity.key),
+                totals: bucket.totals
+            )
+        })
+    }
+
+    // Keep only eight candidates while scanning so high-cardinality captures avoid a full sort.
+    private func topRows<Rows: Sequence>(_ rows: Rows) -> [CaptureOverviewTopRow]
+        where Rows.Element == CaptureOverviewTopRow {
+        var result: [CaptureOverviewTopRow] = []
+        result.reserveCapacity(Self.maximumTopRowCount)
+        for row in rows {
+            let insertionIndex = result.firstIndex { Self.precedes(row, $0) } ?? result.endIndex
+            if insertionIndex < Self.maximumTopRowCount {
+                result.insert(row, at: insertionIndex)
+                if result.count > Self.maximumTopRowCount {
+                    result.removeLast()
+                }
+            } else if result.count < Self.maximumTopRowCount {
+                result.append(row)
+            }
+        }
+        return result
+    }
+
+    private static func precedes(_ lhs: CaptureOverviewTopRow, _ rhs: CaptureOverviewTopRow) -> Bool {
+        if lhs.totals.bytes != rhs.totals.bytes {
+            return lhs.totals.bytes > rhs.totals.bytes
+        }
+        if lhs.totals.packets != rhs.totals.packets {
+            return lhs.totals.packets > rhs.totals.packets
+        }
+        let titleComparison = lhs.title.localizedCaseInsensitiveCompare(rhs.title)
+        if titleComparison != .orderedSame {
+            return titleComparison == .orderedAscending
+        }
+        return lhs.id < rhs.id
+    }
+
+    private func protocolRows() -> [CaptureOverviewProtocolRow] {
+        let sortedRows = protocolBuckets.values.map { bucket in
+            CaptureOverviewProtocolRow(id: bucket.title, title: bucket.title, totals: bucket.totals)
+        }.sorted { lhs, rhs in
+            if lhs.totals.bytes != rhs.totals.bytes {
+                return lhs.totals.bytes > rhs.totals.bytes
+            }
+            if lhs.totals.packets != rhs.totals.packets {
+                return lhs.totals.packets > rhs.totals.packets
+            }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+        guard sortedRows.count > Self.maximumProtocolRowCount else {
+            return sortedRows
+        }
+        var otherTotals = CaptureOverviewTrafficTotals()
+        for row in sortedRows.dropFirst(Self.maximumProtocolRowCount) {
+            otherTotals.add(row.totals)
+        }
+        return Array(sortedRows.prefix(Self.maximumProtocolRowCount)) + [
+            CaptureOverviewProtocolRow(id: "__other__", title: "Other", totals: otherTotals),
+        ]
+    }
+
+    private mutating func compactTimelineIfNeeded() {
+        while timelineBuckets.count > Self.maximumTimelineBucketCount {
+            let previousWidth = timelineBucketWidth
+            timelineBucketWidth *= 2
+            var merged: [Int64: CaptureOverviewTrafficTotals] = [:]
+            merged.reserveCapacity((timelineBuckets.count + 1) / 2)
+            for (key, value) in timelineBuckets {
+                let timestamp = TimeInterval(key) * previousWidth
+                let mergedKey = Int64(floor(timestamp / timelineBucketWidth))
+                merged[mergedKey, default: CaptureOverviewTrafficTotals()].add(value)
+            }
+            timelineBuckets = merged
+        }
+    }
+
+    private func timelinePoints() -> [CaptureOverviewTimelinePoint] {
+        guard let minimumKey = timelineBuckets.keys.min(),
+              let maximumKey = timelineBuckets.keys.max() else {
+            return []
+        }
+        let span = TimeInterval(maximumKey - minimumKey + 1) * timelineBucketWidth
+        var renderedWidth = timelineBucketWidth
+        while span / renderedWidth > Double(Self.maximumRenderedTimelinePointCount) {
+            renderedWidth *= 2
+        }
+
+        var renderedBuckets: [Int64: CaptureOverviewTrafficTotals] = [:]
+        renderedBuckets.reserveCapacity(min(Self.maximumRenderedTimelinePointCount, timelineBuckets.count))
+        for (key, value) in timelineBuckets {
+            let timestamp = TimeInterval(key) * timelineBucketWidth
+            let renderedKey = Int64(floor(timestamp / renderedWidth))
+            renderedBuckets[renderedKey, default: CaptureOverviewTrafficTotals()].add(value)
+        }
+        return renderedBuckets.keys.sorted().map { key in
+            CaptureOverviewTimelinePoint(
+                date: Date(timeIntervalSince1970: TimeInterval(key) * renderedWidth),
+                totals: renderedBuckets[key] ?? CaptureOverviewTrafficTotals()
+            )
+        }
+    }
+
+    private func timelineKey(for date: Date) -> Int64 {
+        Int64(floor(date.timeIntervalSince1970 / timelineBucketWidth))
+    }
+}
+
+private final class CaptureOverviewReplacementWork {
+    static let chunkSize = 2_048
+    static let maximumMetadataPacketCount = 10_000
+
+    let identity: CaptureOverviewSourceIdentity
+    var cursor: EndpointStatisticsIngestCursor
+    var nextPacketIndex = 0
+    var isChunkInFlight = false
+    var isFinishing = false
+    var updatedPacketsByID: [PacketSummary.ID: PacketSummary] = [:]
+
+    init(ingestState: PacketIngestState) {
+        identity = CaptureOverviewSourceIdentity(
+            backingIdentity: ingestState.backingIdentity,
+            packetLineageRevision: ingestState.packetLineageRevision
+        )
+        cursor = EndpointStatisticsIngestCursor(
+            packetRevision: ingestState.packetRevision,
+            packetLineageRevision: ingestState.packetLineageRevision,
+            totalPacketCount: ingestState.packets.count
+        )
+    }
+
+    var nextRange: Range<Int>? {
+        guard nextPacketIndex < cursor.totalPacketCount else {
+            return nil
+        }
+        return nextPacketIndex..<min(cursor.totalPacketCount, nextPacketIndex + Self.chunkSize)
+    }
+
+    func advance(to index: Int) {
+        nextPacketIndex = index
+    }
+
+    // Extend an in-progress replacement across exact live deltas without retaining the source array.
+    func update(from ingestState: PacketIngestState) -> Bool {
+        guard !isFinishing,
+              ingestState.backingIdentity == identity.backingIdentity,
+              ingestState.packetLineageRevision == identity.packetLineageRevision,
+              ingestState.packetRevision == cursor.packetRevision &+ 1 else {
+            return false
+        }
+
+        switch ingestState.lastMutation {
+        case .append(let range):
+            guard range.lowerBound == cursor.totalPacketCount,
+                  range.upperBound == ingestState.packets.count else {
+                return false
+            }
+        case .appendWithMetadataUpdates(let range, let packetIDs):
+            guard range.lowerBound == cursor.totalPacketCount,
+                  range.upperBound == ingestState.packets.count,
+                  recordMetadata(packetIDs, from: ingestState) else {
+                return false
+            }
+        case .metadataUpdate(let packetIDs):
+            guard ingestState.packets.count == cursor.totalPacketCount,
+                  recordMetadata(packetIDs, from: ingestState) else {
+                return false
+            }
+        case .none, .reset, .replace:
+            return false
+        }
+        cursor = EndpointStatisticsIngestCursor(
+            packetRevision: ingestState.packetRevision,
+            packetLineageRevision: ingestState.packetLineageRevision,
+            totalPacketCount: ingestState.packets.count
+        )
+        return true
+    }
+
+    private func recordMetadata(_ packetIDs: [PacketSummary.ID], from ingestState: PacketIngestState) -> Bool {
+        guard packetIDs.count <= Self.maximumMetadataPacketCount - updatedPacketsByID.count else {
+            return false
+        }
+        for packetID in packetIDs {
+            guard let packet = ingestState.packet(withID: packetID) else {
+                continue
+            }
+            updatedPacketsByID[packetID] = packet
+        }
+        return updatedPacketsByID.count <= Self.maximumMetadataPacketCount
+    }
+}
+
+final class CaptureOverviewService {
+    static let presentationInterval: TimeInterval = 0.5
+
+    var snapshotHandler: ((CaptureOverviewSnapshot) -> Void)?
+
+    private let latestIngestStateProvider: () -> PacketIngestState
+    private let processingQueue = DispatchQueue(
+        label: "com.proxyman.tcpviewer.capture-overview",
+        qos: .userInitiated
+    )
+    private var accumulator = CaptureOverviewAccumulator()
+    private var updateCoordinator = EndpointStatisticsUpdateDrainCoordinator(maximumPendingPacketCount: 10_000)
+    private var latestObservedCursor: EndpointStatisticsIngestCursor?
+    private var latestObservedIdentity: CaptureOverviewSourceIdentity?
+    private var forwardedCursor: EndpointStatisticsIngestCursor?
+    private var forwardedIdentity: CaptureOverviewSourceIdentity?
+    private var replacementWork: CaptureOverviewReplacementWork?
+    private var processingGeneration: UInt64 = 0
+    private var presentationWorkItem: DispatchWorkItem?
+    private var lastPresentationTime: TimeInterval = 0
+    private var isCancelled = false
+
+    init(latestIngestStateProvider: @escaping () -> PacketIngestState) {
+        self.latestIngestStateProvider = latestIngestStateProvider
+    }
+
+    deinit {
+        cancel()
+    }
+
+    // Convert live state to owned deltas on main, then aggregate them on one bounded queue.
+    func consume(_ ingestState: PacketIngestState) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard !isCancelled else {
+            return
+        }
+        let nextCursor = EndpointStatisticsIngestCursor(
+            packetRevision: ingestState.packetRevision,
+            packetLineageRevision: ingestState.packetLineageRevision,
+            totalPacketCount: ingestState.packets.count
+        )
+        let sourceIdentity = CaptureOverviewSourceIdentity(
+            backingIdentity: ingestState.backingIdentity,
+            packetLineageRevision: ingestState.packetLineageRevision
+        )
+        guard latestObservedCursor != nextCursor || latestObservedIdentity != sourceIdentity else {
+            return
+        }
+        latestObservedCursor = nextCursor
+        latestObservedIdentity = sourceIdentity
+
+        if let replacementWork {
+            if replacementWork.update(from: ingestState) {
+                return
+            }
+            startReplacement(from: ingestState)
+            return
+        }
+
+        guard let forwardedCursor,
+              forwardedIdentity == sourceIdentity,
+              forwardedCursor.packetLineageRevision == nextCursor.packetLineageRevision,
+              ingestState.packetRevision == forwardedCursor.packetRevision &+ 1,
+              ingestState.lastMutation != .reset,
+              ingestState.lastMutation != .replace else {
+            startReplacement(from: ingestState)
+            return
+        }
+
+        let update = EndpointStatisticsIngestUpdate(
+            ingestState: ingestState,
+            previousCursor: forwardedCursor
+        )
+        guard update.previousPacketRevision != nil else {
+            startReplacement(from: ingestState)
+            return
+        }
+        self.forwardedCursor = update.cursor
+        handle(updateCoordinator.enqueue(update))
+    }
+
+    func cancel() {
+        guard !isCancelled else {
+            return
+        }
+        isCancelled = true
+        processingGeneration &+= 1
+        presentationWorkItem?.cancel()
+        presentationWorkItem = nil
+        replacementWork = nil
+        updateCoordinator.cancel()
+        snapshotHandler = nil
+    }
+
+    private func startReplacement(from ingestState: PacketIngestState) {
+        processingGeneration &+= 1
+        let generation = processingGeneration
+        presentationWorkItem?.cancel()
+        presentationWorkItem = nil
+        updateCoordinator.cancel()
+        forwardedCursor = nil
+        forwardedIdentity = nil
+        let work = CaptureOverviewReplacementWork(ingestState: ingestState)
+        replacementWork = work
+        processingQueue.async { [weak self, weak work] in
+            guard let self, work != nil else {
+                return
+            }
+            self.accumulator.reset()
+            DispatchQueue.main.async { [weak self, weak work] in
+                guard let self, let work,
+                      self.processingGeneration == generation,
+                      self.replacementWork === work else {
+                    return
+                }
+                self.continueReplacement(work, generation: generation)
+            }
+        }
+    }
+
+    // Copy and consume one bounded packet range before requesting the next range.
+    private func continueReplacement(_ work: CaptureOverviewReplacementWork, generation: UInt64) {
+        guard replacementWork === work,
+              !work.isChunkInFlight,
+              !work.isFinishing,
+              processingGeneration == generation else {
+            return
+        }
+        let ingestState = latestIngestStateProvider()
+        let identity = CaptureOverviewSourceIdentity(
+            backingIdentity: ingestState.backingIdentity,
+            packetLineageRevision: ingestState.packetLineageRevision
+        )
+        guard identity == work.identity,
+              ingestState.packetRevision == work.cursor.packetRevision,
+              ingestState.packets.count == work.cursor.totalPacketCount else {
+            startReplacement(from: ingestState)
+            return
+        }
+        guard let range = work.nextRange else {
+            finishReplacement(work, generation: generation)
+            return
+        }
+
+        let packets = Array(ingestState.packets[range])
+        work.advance(to: range.upperBound)
+        work.isChunkInFlight = true
+        processingQueue.async { [weak self, weak work] in
+            guard let self, work != nil else {
+                return
+            }
+            self.accumulator.appendReplacementChunk(packets)
+            DispatchQueue.main.async { [weak self, weak work] in
+                guard let self, let work,
+                      self.processingGeneration == generation,
+                      self.replacementWork === work else {
+                    return
+                }
+                work.isChunkInFlight = false
+                self.continueReplacement(work, generation: generation)
+            }
+        }
+    }
+
+    private func finishReplacement(_ work: CaptureOverviewReplacementWork, generation: UInt64) {
+        work.isFinishing = true
+        let cursor = work.cursor
+        let metadata = Array(work.updatedPacketsByID.values)
+        processingQueue.async { [weak self, weak work] in
+            guard let self, work != nil else {
+                return
+            }
+            self.accumulator.applyMetadata(metadata)
+            let didFinish = self.accumulator.finishReplacement(cursor: cursor)
+            DispatchQueue.main.async { [weak self, weak work] in
+                guard let self, let work,
+                      self.processingGeneration == generation,
+                      self.replacementWork === work else {
+                    return
+                }
+                let latestState = self.latestIngestStateProvider()
+                let latestCursor = EndpointStatisticsIngestCursor(
+                    packetRevision: latestState.packetRevision,
+                    packetLineageRevision: latestState.packetLineageRevision,
+                    totalPacketCount: latestState.packets.count
+                )
+                guard didFinish, latestCursor == cursor else {
+                    self.startReplacement(from: latestState)
+                    return
+                }
+                self.replacementWork = nil
+                self.forwardedCursor = cursor
+                self.forwardedIdentity = work.identity
+                self.requestPresentation()
+            }
+        }
+    }
+
+    private func handle(_ action: EndpointStatisticsUpdateDrainCoordinator.Action) {
+        switch action {
+        case .none:
+            return
+        case .drain(let update):
+            let generation = processingGeneration
+            processingQueue.async { [weak self] in
+                guard let self else {
+                    return
+                }
+                let didConsume = self.accumulator.consume(update)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self,
+                          !self.isCancelled,
+                          self.processingGeneration == generation else {
+                        return
+                    }
+                    let nextAction = self.updateCoordinator.drainCompleted(didConsume: didConsume)
+                    if didConsume {
+                        self.requestPresentation()
+                    }
+                    self.handle(nextAction)
+                }
+            }
+        case .paused:
+            guard !updateCoordinator.isDrainInFlight else {
+                return
+            }
+            startReplacement(from: latestIngestStateProvider())
+        }
+    }
+
+    private func requestPresentation() {
+        guard presentationWorkItem == nil, replacementWork == nil else {
+            return
+        }
+        let elapsed = ProcessInfo.processInfo.systemUptime - lastPresentationTime
+        let delay = max(0, Self.presentationInterval - elapsed)
+        let generation = processingGeneration
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else {
+                return
+            }
+            self.presentationWorkItem = nil
+            self.processingQueue.async { [weak self] in
+                guard let self else {
+                    return
+                }
+                let snapshot = self.accumulator.snapshot()
+                DispatchQueue.main.async { [weak self] in
+                    guard let self,
+                          !self.isCancelled,
+                          self.processingGeneration == generation,
+                          self.replacementWork == nil else {
+                        return
+                    }
+                    self.commit(snapshot)
+                }
+            }
+        }
+        presentationWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func commit(_ snapshot: CaptureOverviewSnapshot) {
+        lastPresentationTime = ProcessInfo.processInfo.systemUptime
+        snapshotHandler?(snapshot)
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsCancellationToken.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsCancellationToken.swift
@@ -1,0 +1,52 @@
+//
+//  EndpointStatisticsCancellationToken.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+
+final class EndpointStatisticsCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+    #if DEBUG
+    private var remainingChecksBeforeCancellation: Int?
+    #endif
+
+    init() {}
+
+    #if DEBUG
+    init(cancelAfterCheckCount: Int) {
+        precondition(cancelAfterCheckCount >= 0)
+        remainingChecksBeforeCancellation = cancelAfterCheckCount
+    }
+    #endif
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    func isCancelled() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        #if DEBUG
+        if !cancelled, let remainingChecksBeforeCancellation {
+            if remainingChecksBeforeCancellation == 0 {
+                cancelled = true
+            } else {
+                self.remainingChecksBeforeCancellation = remainingChecksBeforeCancellation - 1
+            }
+        }
+        #endif
+        return cancelled
+    }
+}
+
+enum EndpointStatisticsConsumeResult: Equatable {
+    case consumed
+    case rejected
+    case cancelled
+}

--- a/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsService.swift
@@ -1,0 +1,1114 @@
+//
+//  EndpointStatisticsService.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Darwin
+import Foundation
+import PcapPlusPlusCore
+
+struct EndpointStatisticsIngestCursor: Equatable, Sendable {
+    let packetRevision: UInt64
+    let packetLineageRevision: UInt64
+    let totalPacketCount: Int
+}
+
+struct EndpointStatisticsIngestUpdate: Sendable {
+    enum Kind: Sendable {
+        case replace([PacketSummary])
+        case append([PacketSummary])
+        case appendWithMetadata(newPackets: [PacketSummary], updatedPackets: [PacketSummary])
+        case metadata([PacketSummary])
+    }
+
+    let packetRevision: UInt64
+    let previousPacketRevision: UInt64?
+    let packetLineageRevision: UInt64
+    let totalPacketCount: Int
+    let kind: Kind
+
+    var cursor: EndpointStatisticsIngestCursor {
+        EndpointStatisticsIngestCursor(
+            packetRevision: packetRevision,
+            packetLineageRevision: packetLineageRevision,
+            totalPacketCount: totalPacketCount
+        )
+    }
+
+    init(
+        packetRevision: UInt64,
+        packetLineageRevision: UInt64,
+        totalPacketCount: Int,
+        kind: Kind,
+        previousPacketRevision: UInt64? = nil
+    ) {
+        self.packetRevision = packetRevision
+        if case .replace = kind {
+            self.previousPacketRevision = nil
+        } else {
+            self.previousPacketRevision = previousPacketRevision ?? packetRevision &- 1
+        }
+        self.packetLineageRevision = packetLineageRevision
+        self.totalPacketCount = totalPacketCount
+        self.kind = kind
+    }
+
+    // Copy only the changed packet values when the caller has forwarded the preceding state.
+    init(ingestState: PacketIngestState, previousPacketCount: Int?) {
+        packetRevision = ingestState.packetRevision
+        packetLineageRevision = ingestState.packetLineageRevision
+        totalPacketCount = ingestState.packets.count
+
+        switch ingestState.lastMutation {
+        case .append(let range) where Self.canCopy(range, from: ingestState, previousPacketCount: previousPacketCount):
+            kind = .append(Array(ingestState.packets[range]))
+        case .appendWithMetadataUpdates(let range, let packetIDs)
+            where Self.canCopy(range, from: ingestState, previousPacketCount: previousPacketCount):
+            kind = .appendWithMetadata(
+                newPackets: Array(ingestState.packets[range]),
+                updatedPackets: Self.packets(withIDs: packetIDs, in: ingestState)
+            )
+        case .metadataUpdate(let packetIDs) where previousPacketCount == ingestState.packets.count:
+            kind = .metadata(Self.packets(withIDs: packetIDs, in: ingestState))
+        case .none, .reset, .replace, .append, .appendWithMetadataUpdates, .metadataUpdate:
+            kind = .replace(ingestState.packets)
+        }
+        if case .replace = kind {
+            previousPacketRevision = nil
+        } else {
+            previousPacketRevision = packetRevision &- 1
+        }
+    }
+
+    // A small cursor lets callers detect skipped revisions before dispatching work to another queue.
+    init(ingestState: PacketIngestState, previousCursor: EndpointStatisticsIngestCursor?) {
+        guard let previousCursor else {
+            self = .replacement(from: ingestState)
+            return
+        }
+        if previousCursor.packetRevision == ingestState.packetRevision,
+           previousCursor.packetLineageRevision == ingestState.packetLineageRevision,
+           previousCursor.totalPacketCount == ingestState.packets.count {
+            self.init(
+                packetRevision: ingestState.packetRevision,
+                packetLineageRevision: ingestState.packetLineageRevision,
+                totalPacketCount: ingestState.packets.count,
+                kind: .metadata([])
+            )
+            return
+        }
+        guard previousCursor.packetLineageRevision == ingestState.packetLineageRevision,
+              ingestState.packetRevision == previousCursor.packetRevision &+ 1 else {
+            self = .replacement(from: ingestState)
+            return
+        }
+        self.init(ingestState: ingestState, previousPacketCount: previousCursor.totalPacketCount)
+    }
+
+    static func replacement(from ingestState: PacketIngestState) -> EndpointStatisticsIngestUpdate {
+        EndpointStatisticsIngestUpdate(
+            packetRevision: ingestState.packetRevision,
+            packetLineageRevision: ingestState.packetLineageRevision,
+            totalPacketCount: ingestState.packets.count,
+            kind: .replace(ingestState.packets)
+        )
+    }
+
+    private static func canCopy(
+        _ range: Range<Int>,
+        from ingestState: PacketIngestState,
+        previousPacketCount: Int?
+    ) -> Bool {
+        previousPacketCount == range.lowerBound &&
+            range.lowerBound >= 0 &&
+            range.lowerBound < range.upperBound &&
+            range.upperBound == ingestState.packets.count
+    }
+
+    private static func packets(
+        withIDs packetIDs: [PacketSummary.ID],
+        in ingestState: PacketIngestState
+    ) -> [PacketSummary] {
+        var seenPacketIDs = Set<PacketSummary.ID>()
+        return packetIDs.compactMap { packetID in
+            guard seenPacketIDs.insert(packetID).inserted else {
+                return nil
+            }
+            return ingestState.packet(withID: packetID)
+        }
+    }
+}
+
+extension EndpointStatisticsRowID {
+    func matches(_ packet: PacketSummary) -> Bool {
+        EndpointStatisticsClassifier.matches(packet, rowID: self)
+    }
+}
+
+enum EndpointStatisticsClassifier {
+    static func matches(_ packet: PacketSummary, rowID: EndpointStatisticsRowID) -> Bool {
+        switch rowID.group {
+        case .apps:
+            return PacketSourceListClassifier.clientIdentity(for: packet)?.key.rawValue == rowID.key
+        case .domains:
+            return canonicalDomain(packet.domainName) == rowID.key
+        case .ipv4, .ipv6:
+            return canonicalEndpoints(for: packet).contains { endpoint in
+                endpoint.group == rowID.group && endpoint.address == rowID.key
+            }
+        case .tcp, .udp:
+            guard transportGroup(for: packet) == rowID.group else {
+                return false
+            }
+            return canonicalEndpoints(for: packet).contains { endpoint in
+                endpoint.port.map { transportKey(address: endpoint.address, port: $0) } == rowID.key
+            }
+        }
+    }
+
+    static func rowIDs(for packet: PacketSummary) -> Set<EndpointStatisticsRowID> {
+        let metadata = metadata(for: packet)
+        let endpoints = canonicalEndpoints(for: packet)
+        var rowIDs = Set<EndpointStatisticsRowID>()
+
+        if let client = metadata.client {
+            rowIDs.insert(EndpointStatisticsRowID(group: .apps, key: client.key))
+        }
+        if let domain = metadata.domain {
+            rowIDs.insert(EndpointStatisticsRowID(group: .domains, key: domain))
+        }
+        for endpoint in endpoints {
+            rowIDs.insert(EndpointStatisticsRowID(group: endpoint.group, key: endpoint.address))
+        }
+        if let transportGroup = transportGroup(for: packet) {
+            for endpoint in endpoints {
+                guard let port = endpoint.port else {
+                    continue
+                }
+                rowIDs.insert(EndpointStatisticsRowID(
+                    group: transportGroup,
+                    key: transportKey(address: endpoint.address, port: port)
+                ))
+            }
+        }
+
+        return rowIDs
+    }
+
+    fileprivate static func metadata(for packet: PacketSummary) -> PacketStatisticsMetadata {
+        let clientIdentity = PacketSourceListClassifier.clientIdentity(for: packet).map {
+            PacketStatisticsClient(key: $0.key.rawValue, displayName: $0.displayName)
+        }
+        return PacketStatisticsMetadata(
+            client: clientIdentity,
+            domain: canonicalDomain(packet.domainName),
+            direction: packet.direction,
+            protocolName: protocolName(for: packet)
+        )
+    }
+
+    fileprivate static func canonicalEndpoints(for packet: PacketSummary) -> [PacketStatisticsEndpoint] {
+        [
+            canonicalEndpoint(packet.endpoints.source, role: .source),
+            canonicalEndpoint(packet.endpoints.destination, role: .destination),
+        ].compactMap { $0 }
+    }
+
+    fileprivate static func transportGroup(for packet: PacketSummary) -> EndpointStatisticsGroup? {
+        if packet.layers.contains(where: { $0.name.localizedCaseInsensitiveCompare("TCP") == .orderedSame }) {
+            return .tcp
+        }
+        if packet.layers.contains(where: { $0.name.localizedCaseInsensitiveCompare("UDP") == .orderedSame }) {
+            return .udp
+        }
+
+        switch packet.transportHint {
+        case .tcp, .http1, .tls, .websocket:
+            return .tcp
+        case .udp:
+            return .udp
+        default:
+            return nil
+        }
+    }
+
+    fileprivate static func transportKey(address: String, port: UInt16) -> String {
+        address.contains(":") ? "[\(address)]:\(port)" : "\(address):\(port)"
+    }
+
+    private static func canonicalEndpoint(
+        _ endpoint: PacketEndpoint,
+        role: PacketStatisticsEndpoint.Role
+    ) -> PacketStatisticsEndpoint? {
+        guard let canonicalAddress = canonicalIPAddress(endpoint.address) else {
+            return nil
+        }
+        return PacketStatisticsEndpoint(
+            address: canonicalAddress.address,
+            port: endpoint.port,
+            group: canonicalAddress.group,
+            role: role
+        )
+    }
+
+    private static func canonicalDomain(_ value: String?) -> String? {
+        let normalized = value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        guard let normalized, !normalized.isEmpty, normalized.utf8.count <= 253 else {
+            return nil
+        }
+        return normalized
+    }
+
+    private static func canonicalIPAddress(_ rawValue: String?) -> (address: String, group: EndpointStatisticsGroup)? {
+        guard var value = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        if value.first == "[", let closingBracket = value.firstIndex(of: "]") {
+            value = String(value[value.index(after: value.startIndex)..<closingBracket])
+        }
+        if let zoneIndex = value.firstIndex(of: "%") {
+            value = String(value[..<zoneIndex])
+        }
+
+        var ipv4 = in_addr()
+        if inet_pton(AF_INET, value, &ipv4) == 1 {
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &ipv4, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return (String(cString: buffer), .ipv4)
+        }
+
+        var ipv6 = in6_addr()
+        if inet_pton(AF_INET6, value, &ipv6) == 1 {
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            guard inet_ntop(AF_INET6, &ipv6, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return (String(cString: buffer), .ipv6)
+        }
+        return nil
+    }
+
+    private static func protocolName(for packet: PacketSummary) -> String {
+        switch packet.transportHint {
+        case .ethernet: return "Ethernet"
+        case .arp: return "ARP"
+        case .ipv4: return "IPv4"
+        case .ipv6: return "IPv6"
+        case .icmp: return "ICMP"
+        case .tcp: return "TCP"
+        case .udp: return "UDP"
+        case .dns: return "DNS"
+        case .http1: return "HTTP"
+        case .tls: return "TLS"
+        case .websocket: return "WebSocket"
+        case .payload: return trimmed(packet.protocolSummary) ?? "Payload"
+        case .unknown: return trimmed(packet.protocolSummary) ?? "Unknown"
+        @unknown default: return trimmed(packet.protocolSummary) ?? "Unknown"
+        }
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}
+
+#if DEBUG
+struct EndpointStatisticsDebugSnapshot: Equatable {
+    let fullRebuildCount: Int
+    let processedPacketCount: Int
+    let appendedPacketCount: Int
+    let metadataPacketCount: Int
+    let unchangedSnapshotCount: Int
+    let rowMaterializationCountByGroup: [EndpointStatisticsGroup: Int]
+    let materializedRowCount: Int
+}
+#endif
+
+final class EndpointStatisticsService {
+    private var bucketsByGroup: [EndpointStatisticsGroup: [EndpointStatisticsRowID: PacketStatisticsBucket]] = [:]
+    private var metadataByPacketID: [PacketSummary.ID: PacketStatisticsMetadata] = [:]
+    private var footerTotals = EndpointStatisticsTotals.zero
+    private var packetRevision: UInt64?
+    private var packetLineageRevision: UInt64?
+    private var sourcePacketCount = 0
+    private var cachedSnapshot: EndpointStatisticsSnapshot? = .empty
+    private var cachedRowsByGroup: [EndpointStatisticsGroup: [EndpointStatisticsRow]] = [:]
+    private var dirtyGroups = Set<EndpointStatisticsGroup>()
+
+    #if DEBUG
+    private var fullRebuildCount = 0
+    private var processedPacketCount = 0
+    private var appendedPacketCount = 0
+    private var metadataPacketCount = 0
+    private var unchangedSnapshotCount = 0
+    private var rowMaterializationCountByGroup: [EndpointStatisticsGroup: Int] = [:]
+    private var materializedRowCount = 0
+    #endif
+
+    @discardableResult
+    func rebuild(from packets: [PacketSummary]) -> EndpointStatisticsSnapshot {
+        packetRevision = nil
+        packetLineageRevision = nil
+        _ = rebuildStorage(from: packets)
+        return currentSnapshot()
+    }
+
+    func snapshot(for ingestState: PacketIngestState) -> EndpointStatisticsSnapshot {
+        consume(ingestState)
+        return currentSnapshot()
+    }
+
+    // Consume every ingest mutation cheaply so a window can materialize rows at a slower cadence.
+    func consume(_ ingestState: PacketIngestState) {
+        guard packetRevision != ingestState.packetRevision else {
+            #if DEBUG
+            unchangedSnapshotCount += 1
+            #endif
+            return
+        }
+        let previousCursor = packetRevision.map {
+            EndpointStatisticsIngestCursor(
+                packetRevision: $0,
+                packetLineageRevision: packetLineageRevision ?? 0,
+                totalPacketCount: sourcePacketCount
+            )
+        }
+        let update = EndpointStatisticsIngestUpdate(
+            ingestState: ingestState,
+            previousCursor: previousCursor
+        )
+        if !consume(update) {
+            _ = consume(.replacement(from: ingestState))
+        }
+    }
+
+    // Return false when a queued update skipped a revision and the caller must send a replacement.
+    @discardableResult
+    func consume(_ update: EndpointStatisticsIngestUpdate) -> Bool {
+        consumeUpdate(update, cancellationToken: nil) == .consumed
+    }
+
+    @discardableResult
+    func consume(
+        _ update: EndpointStatisticsIngestUpdate,
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> EndpointStatisticsConsumeResult {
+        consumeUpdate(update, cancellationToken: cancellationToken)
+    }
+
+    private func consumeUpdate(
+        _ update: EndpointStatisticsIngestUpdate,
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> EndpointStatisticsConsumeResult {
+        guard cancellationToken?.isCancelled() != true else {
+            return .cancelled
+        }
+        guard packetRevision != update.packetRevision else {
+            #if DEBUG
+            unchangedSnapshotCount += 1
+            #endif
+            return .consumed
+        }
+
+        if case .replace(let packets) = update.kind {
+            guard packets.count == update.totalPacketCount else {
+                return .rejected
+            }
+            guard rebuildStorage(from: packets, cancellationToken: cancellationToken) else {
+                return .cancelled
+            }
+            storeState(for: update)
+            return .consumed
+        }
+
+        guard packetLineageRevision == update.packetLineageRevision,
+              let packetRevision,
+              update.previousPacketRevision == packetRevision else {
+            return .rejected
+        }
+
+        switch update.kind {
+        case .append(let packets):
+            guard sourcePacketCount + packets.count == update.totalPacketCount else {
+                return .rejected
+            }
+            guard applyNewPackets(
+                packets,
+                countsAsAppend: true,
+                cancellationToken: cancellationToken
+            ) else {
+                reset()
+                return .cancelled
+            }
+        case .appendWithMetadata(let newPackets, let updatedPackets):
+            guard sourcePacketCount + newPackets.count == update.totalPacketCount else {
+                return .rejected
+            }
+            guard applyNewPackets(
+                newPackets,
+                countsAsAppend: true,
+                cancellationToken: cancellationToken
+            ), applyMetadataUpdates(updatedPackets, cancellationToken: cancellationToken) else {
+                reset()
+                return .cancelled
+            }
+        case .metadata(let packets):
+            guard sourcePacketCount == update.totalPacketCount else {
+                return .rejected
+            }
+            guard applyMetadataUpdates(packets, cancellationToken: cancellationToken) else {
+                reset()
+                return .cancelled
+            }
+        case .replace:
+            break
+        }
+        storeState(for: update)
+        return .consumed
+    }
+
+    func currentSnapshot() -> EndpointStatisticsSnapshot {
+        if dirtyGroups.isEmpty, let cachedSnapshot {
+            return cachedSnapshot
+        }
+        let snapshot = makeSnapshot()
+        cachedSnapshot = snapshot
+        return snapshot
+    }
+
+    // Materialize only the visible protocol group; tab counts come directly from the accumulator dictionaries.
+    func currentSnapshot(for group: EndpointStatisticsGroup) -> EndpointStatisticsGroupSnapshot {
+        EndpointStatisticsGroupSnapshot(
+            group: group,
+            rows: materializedRows(for: group),
+            endpointCounts: makeEndpointCounts(),
+            footerTotals: footerTotals
+        )
+    }
+
+    func currentSnapshot(
+        for group: EndpointStatisticsGroup,
+        cancellationToken: EndpointStatisticsCancellationToken
+    ) -> EndpointStatisticsGroupSnapshot? {
+        guard let rows = materializedRows(for: group, cancellationToken: cancellationToken) else {
+            return nil
+        }
+        return EndpointStatisticsGroupSnapshot(
+            group: group,
+            rows: rows,
+            endpointCounts: makeEndpointCounts(),
+            footerTotals: footerTotals
+        )
+    }
+
+    func reset() {
+        bucketsByGroup.removeAll(keepingCapacity: false)
+        metadataByPacketID.removeAll(keepingCapacity: false)
+        footerTotals = .zero
+        packetRevision = nil
+        packetLineageRevision = nil
+        sourcePacketCount = 0
+        cachedSnapshot = .empty
+        cachedRowsByGroup.removeAll(keepingCapacity: false)
+        dirtyGroups.removeAll(keepingCapacity: false)
+    }
+
+    #if DEBUG
+    func debugSnapshot() -> EndpointStatisticsDebugSnapshot {
+        EndpointStatisticsDebugSnapshot(
+            fullRebuildCount: fullRebuildCount,
+            processedPacketCount: processedPacketCount,
+            appendedPacketCount: appendedPacketCount,
+            metadataPacketCount: metadataPacketCount,
+            unchangedSnapshotCount: unchangedSnapshotCount,
+            rowMaterializationCountByGroup: rowMaterializationCountByGroup,
+            materializedRowCount: materializedRowCount
+        )
+    }
+    #endif
+
+    private func rebuildStorage(
+        from packets: [PacketSummary],
+        cancellationToken: EndpointStatisticsCancellationToken? = nil
+    ) -> Bool {
+        bucketsByGroup.removeAll(keepingCapacity: true)
+        metadataByPacketID.removeAll(keepingCapacity: true)
+        footerTotals = .zero
+        sourcePacketCount = 0
+        #if DEBUG
+        fullRebuildCount += 1
+        #endif
+        guard applyNewPackets(
+            packets,
+            countsAsAppend: false,
+            cancellationToken: cancellationToken
+        ) else {
+            reset()
+            return false
+        }
+        markRowsDirty()
+        return true
+    }
+
+    private func applyNewPackets<Packets: Collection>(
+        _ packets: Packets,
+        countsAsAppend: Bool,
+        cancellationToken: EndpointStatisticsCancellationToken? = nil
+    ) -> Bool
+    where Packets.Element == PacketSummary {
+        metadataByPacketID.reserveCapacity(metadataByPacketID.count + packets.count)
+        for (index, packet) in packets.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return false
+            }
+            let metadata = EndpointStatisticsClassifier.metadata(for: packet)
+            add(packet, metadata: metadata)
+            metadataByPacketID[packet.id] = metadata
+        }
+        sourcePacketCount += packets.count
+        #if DEBUG
+        processedPacketCount += packets.count
+        if countsAsAppend {
+            appendedPacketCount += packets.count
+        }
+        #endif
+        return cancellationToken?.isCancelled() != true
+    }
+
+    // Metadata updates reclassify only the listed packets and leave immutable endpoint totals alone.
+    private func applyMetadataUpdates(
+        _ packets: [PacketSummary],
+        cancellationToken: EndpointStatisticsCancellationToken? = nil
+    ) -> Bool {
+        var seenPacketIDs = Set<PacketSummary.ID>()
+        for (index, packet) in packets.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return false
+            }
+            guard seenPacketIDs.insert(packet.id).inserted else {
+                continue
+            }
+            #if DEBUG
+            metadataPacketCount += 1
+            #endif
+            let newMetadata = EndpointStatisticsClassifier.metadata(for: packet)
+            guard let oldMetadata = metadataByPacketID[packet.id] else {
+                continue
+            }
+            guard oldMetadata != newMetadata else {
+                continue
+            }
+            remove(packet, metadata: oldMetadata)
+            add(packet, metadata: newMetadata)
+            metadataByPacketID[packet.id] = newMetadata
+        }
+        return cancellationToken?.isCancelled() != true
+    }
+
+    private func add(_ packet: PacketSummary, metadata: PacketStatisticsMetadata) {
+        apply(packet, metadata: metadata, operation: .add)
+    }
+
+    private func remove(_ packet: PacketSummary, metadata: PacketStatisticsMetadata) {
+        apply(packet, metadata: metadata, operation: .remove)
+    }
+
+    // Build at most six row contributions per packet and merge identical source/destination keys.
+    private func apply(
+        _ packet: PacketSummary,
+        metadata: PacketStatisticsMetadata,
+        operation: PacketStatisticsOperation
+    ) {
+        let bytes = UInt64(max(packet.originalLength, 0))
+        operation.apply(directionalTotals(bytes: bytes, direction: metadata.direction), to: &footerTotals)
+
+        let endpoints = EndpointStatisticsClassifier.canonicalEndpoints(for: packet)
+        let remoteValues = remoteEndpointValues(endpoints, direction: metadata.direction)
+        if let client = metadata.client {
+            applyContribution(
+                id: EndpointStatisticsRowID(group: .apps, key: client.key),
+                identity: PacketStatisticsIdentity(),
+                related: PacketStatisticsRelatedValues(
+                    addresses: remoteValues.addresses,
+                    ports: remoteValues.ports,
+                    protocolNames: [metadata.protocolName],
+                    clients: [client.displayName],
+                    domains: metadata.domain.map { [$0] } ?? []
+                ),
+                totals: directionalTotals(bytes: bytes, direction: metadata.direction),
+                operation: operation
+            )
+        }
+        if let domain = metadata.domain {
+            applyContribution(
+                id: EndpointStatisticsRowID(group: .domains, key: domain),
+                identity: PacketStatisticsIdentity(domain: domain),
+                related: PacketStatisticsRelatedValues(
+                    addresses: remoteValues.addresses,
+                    ports: remoteValues.ports,
+                    protocolNames: [metadata.protocolName],
+                    clients: metadata.client.map { [$0.displayName] } ?? []
+                ),
+                totals: directionalTotals(bytes: bytes, direction: metadata.direction, reversesDirection: true),
+                operation: operation
+            )
+        }
+
+        applyEndpointContributions(
+            endpoints,
+            group: nil,
+            bytes: bytes,
+            metadata: metadata,
+            operation: operation
+        )
+        if let transportGroup = EndpointStatisticsClassifier.transportGroup(for: packet) {
+            applyEndpointContributions(
+                endpoints.filter { $0.port != nil },
+                group: transportGroup,
+                bytes: bytes,
+                metadata: metadata,
+                operation: operation
+            )
+        }
+    }
+
+    private func applyEndpointContributions(
+        _ endpoints: [PacketStatisticsEndpoint],
+        group transportGroup: EndpointStatisticsGroup?,
+        bytes: UInt64,
+        metadata: PacketStatisticsMetadata,
+        operation: PacketStatisticsOperation
+    ) {
+        let source = endpoints.first { $0.role == .source }
+        let destination = endpoints.first { $0.role == .destination }
+        let sourceID = source.map { endpointRowID($0, transportGroup: transportGroup) }
+        let destinationID = destination.map { endpointRowID($0, transportGroup: transportGroup) }
+
+        if let source, let sourceID, let destination, sourceID == destinationID {
+            applyContribution(
+                id: sourceID,
+                identity: endpointIdentity(source, transportGroup: transportGroup),
+                related: endpointRelatedValues([source, destination], metadata: metadata, transportGroup: transportGroup),
+                totals: endpointTotals(bytes: bytes, isSource: true, isDestination: true),
+                operation: operation
+            )
+            return
+        }
+
+        if let source, let sourceID {
+            applyContribution(
+                id: sourceID,
+                identity: endpointIdentity(source, transportGroup: transportGroup),
+                related: endpointRelatedValues([source], metadata: metadata, transportGroup: transportGroup),
+                totals: endpointTotals(bytes: bytes, isSource: true, isDestination: false),
+                operation: operation
+            )
+        }
+        if let destination, let destinationID {
+            applyContribution(
+                id: destinationID,
+                identity: endpointIdentity(destination, transportGroup: transportGroup),
+                related: endpointRelatedValues([destination], metadata: metadata, transportGroup: transportGroup),
+                totals: endpointTotals(bytes: bytes, isSource: false, isDestination: true),
+                operation: operation
+            )
+        }
+    }
+
+    private func endpointRowID(
+        _ endpoint: PacketStatisticsEndpoint,
+        transportGroup: EndpointStatisticsGroup?
+    ) -> EndpointStatisticsRowID {
+        if let transportGroup, let port = endpoint.port {
+            return EndpointStatisticsRowID(
+                group: transportGroup,
+                key: EndpointStatisticsClassifier.transportKey(address: endpoint.address, port: port)
+            )
+        }
+        return EndpointStatisticsRowID(group: endpoint.group, key: endpoint.address)
+    }
+
+    private func endpointIdentity(
+        _ endpoint: PacketStatisticsEndpoint,
+        transportGroup: EndpointStatisticsGroup?
+    ) -> PacketStatisticsIdentity {
+        PacketStatisticsIdentity(
+            address: endpoint.address,
+            port: transportGroup == nil ? nil : endpoint.port.map(String.init)
+        )
+    }
+
+    private func endpointRelatedValues(
+        _ endpoints: [PacketStatisticsEndpoint],
+        metadata: PacketStatisticsMetadata,
+        transportGroup: EndpointStatisticsGroup?
+    ) -> PacketStatisticsRelatedValues {
+        PacketStatisticsRelatedValues(
+            ports: transportGroup == nil ? unique(endpoints.compactMap { $0.port.map(String.init) }) : [],
+            protocolNames: [metadata.protocolName],
+            clients: metadata.client.map { [$0.displayName] } ?? [],
+            domains: metadata.domain.map { [$0] } ?? []
+        )
+    }
+
+    private func applyContribution(
+        id: EndpointStatisticsRowID,
+        identity: PacketStatisticsIdentity,
+        related: PacketStatisticsRelatedValues,
+        totals: EndpointStatisticsTotals,
+        operation: PacketStatisticsOperation
+    ) {
+        switch operation {
+        case .add:
+            // Mutate the stored bucket in place so high-cardinality related values do not copy their dictionaries per packet.
+            bucketsByGroup[id.group, default: [:]][
+                id,
+                default: PacketStatisticsBucket(id: id, identity: identity)
+            ].add(totals: totals, related: related)
+        case .remove:
+            // Removing the value first gives the bucket unique ownership before its related-value counts change.
+            guard var bucket = bucketsByGroup[id.group]?.removeValue(forKey: id) else {
+                return
+            }
+            bucket.remove(totals: totals, related: related)
+            if bucket.totals.packets > 0 {
+                bucketsByGroup[id.group, default: [:]][id] = bucket
+            }
+        }
+    }
+
+    private func storeState(for update: EndpointStatisticsIngestUpdate) {
+        packetRevision = update.packetRevision
+        packetLineageRevision = update.packetLineageRevision
+        sourcePacketCount = update.totalPacketCount
+        markRowsDirty()
+    }
+
+    private func makeSnapshot() -> EndpointStatisticsSnapshot {
+        var rowsByGroup: [EndpointStatisticsGroup: [EndpointStatisticsRow]] = [:]
+        for group in EndpointStatisticsGroup.allCases {
+            rowsByGroup[group] = materializedRows(for: group)
+        }
+        return EndpointStatisticsSnapshot(rowsByGroup: rowsByGroup, footerTotals: footerTotals)
+    }
+
+    private func materializedRows(for group: EndpointStatisticsGroup) -> [EndpointStatisticsRow] {
+        materializedRows(for: group, cancellationToken: nil) ?? []
+    }
+
+    private func materializedRows(
+        for group: EndpointStatisticsGroup,
+        cancellationToken: EndpointStatisticsCancellationToken?
+    ) -> [EndpointStatisticsRow]? {
+        guard cancellationToken?.isCancelled() != true else {
+            return nil
+        }
+        if !dirtyGroups.contains(group), let cachedRows = cachedRowsByGroup[group] {
+            return cachedRows
+        }
+        let buckets = bucketsByGroup[group] ?? [:]
+        var rows: [EndpointStatisticsRow] = []
+        rows.reserveCapacity(buckets.count)
+        for (index, bucket) in buckets.values.enumerated() {
+            if index.isMultiple(of: 256), cancellationToken?.isCancelled() == true {
+                return nil
+            }
+            rows.append(bucket.row)
+        }
+        guard cancellationToken?.isCancelled() != true else {
+            return nil
+        }
+        cachedRowsByGroup[group] = rows
+        dirtyGroups.remove(group)
+        #if DEBUG
+        rowMaterializationCountByGroup[group, default: 0] += 1
+        materializedRowCount += rows.count
+        #endif
+        return rows
+    }
+
+    private func makeEndpointCounts() -> [EndpointStatisticsGroup: Int] {
+        Dictionary(uniqueKeysWithValues: EndpointStatisticsGroup.allCases.map { group in
+            (group, bucketsByGroup[group]?.count ?? 0)
+        })
+    }
+
+    private func markRowsDirty() {
+        dirtyGroups.formUnion(EndpointStatisticsGroup.allCases)
+        cachedSnapshot = nil
+    }
+
+    private func directionalTotals(
+        bytes: UInt64,
+        direction: PacketDirection?,
+        reversesDirection: Bool = false
+    ) -> EndpointStatisticsTotals {
+        var totals = EndpointStatisticsTotals.zero
+        totals.packets = 1
+        totals.bytes = bytes
+        switch direction {
+        case .outbound:
+            if reversesDirection {
+                totals.rxPackets = 1
+                totals.rxBytes = bytes
+            } else {
+                totals.txPackets = 1
+                totals.txBytes = bytes
+            }
+        case .inbound:
+            if reversesDirection {
+                totals.txPackets = 1
+                totals.txBytes = bytes
+            } else {
+                totals.rxPackets = 1
+                totals.rxBytes = bytes
+            }
+        case .local, .unknown, nil:
+            totals.unclassifiedPackets = 1
+            totals.unclassifiedBytes = bytes
+        @unknown default:
+            totals.unclassifiedPackets = 1
+            totals.unclassifiedBytes = bytes
+        }
+        return totals
+    }
+
+    // Count endpoint occurrences so Packets and Bytes stay equal to their Tx and Rx columns.
+    private func endpointTotals(
+        bytes: UInt64,
+        isSource: Bool,
+        isDestination: Bool
+    ) -> EndpointStatisticsTotals {
+        let endpointOccurrenceCount = UInt64((isSource ? 1 : 0) + (isDestination ? 1 : 0))
+        return EndpointStatisticsTotals(
+            packets: endpointOccurrenceCount,
+            bytes: bytes * endpointOccurrenceCount,
+            txPackets: isSource ? 1 : 0,
+            txBytes: isSource ? bytes : 0,
+            rxPackets: isDestination ? 1 : 0,
+            rxBytes: isDestination ? bytes : 0,
+            unclassifiedPackets: 0,
+            unclassifiedBytes: 0
+        )
+    }
+
+    private func remoteEndpointValues(
+        _ endpoints: [PacketStatisticsEndpoint],
+        direction: PacketDirection?
+    ) -> (addresses: [String], ports: [String]) {
+        let remoteEndpoints: [PacketStatisticsEndpoint]
+        switch direction {
+        case .outbound:
+            remoteEndpoints = endpoints.filter { $0.role == .destination }
+        case .inbound:
+            remoteEndpoints = endpoints.filter { $0.role == .source }
+        case .local, .unknown, nil:
+            remoteEndpoints = endpoints
+        @unknown default:
+            remoteEndpoints = endpoints
+        }
+        return (
+            unique(remoteEndpoints.map(\.address)),
+            unique(remoteEndpoints.compactMap { $0.port.map(String.init) })
+        )
+    }
+
+    private func unique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+}
+
+private enum PacketStatisticsOperation {
+    case add
+    case remove
+
+    func apply(_ value: EndpointStatisticsTotals, to totals: inout EndpointStatisticsTotals) {
+        switch self {
+        case .add:
+            totals.add(value)
+        case .remove:
+            totals.remove(value)
+        }
+    }
+}
+
+private struct PacketStatisticsClient: Equatable {
+    let key: String
+    let displayName: String
+}
+
+fileprivate struct PacketStatisticsMetadata: Equatable {
+    let client: PacketStatisticsClient?
+    let domain: String?
+    let direction: PacketDirection?
+    let protocolName: String
+}
+
+fileprivate struct PacketStatisticsEndpoint {
+    enum Role {
+        case source
+        case destination
+    }
+
+    let address: String
+    let port: UInt16?
+    let group: EndpointStatisticsGroup
+    let role: Role
+}
+
+private struct PacketStatisticsIdentity {
+    var address: String?
+    var port: String?
+    var protocolName: String?
+    var client: String?
+    var domain: String?
+
+    init(
+        address: String? = nil,
+        port: String? = nil,
+        protocolName: String? = nil,
+        client: String? = nil,
+        domain: String? = nil
+    ) {
+        self.address = address
+        self.port = port
+        self.protocolName = protocolName
+        self.client = client
+        self.domain = domain
+    }
+}
+
+private struct PacketStatisticsRelatedValues {
+    var addresses: [String] = []
+    var ports: [String] = []
+    var protocolNames: [String] = []
+    var clients: [String] = []
+    var domains: [String] = []
+}
+
+private struct PacketStatisticsValueCounts {
+    private var counts: [String: UInt64] = [:]
+
+    var displayValue: String? {
+        if counts.count > 1 {
+            return EndpointStatisticsRow.multipleValue
+        }
+        return counts.keys.first
+    }
+
+    var isMultiple: Bool {
+        counts.count > 1
+    }
+
+    mutating func add(_ values: [String]) {
+        for value in values {
+            counts[value, default: 0] += 1
+        }
+    }
+
+    mutating func remove(_ values: [String]) {
+        for value in values {
+            guard let count = counts[value] else {
+                continue
+            }
+            if count > 1 {
+                counts[value] = count - 1
+            } else {
+                counts.removeValue(forKey: value)
+            }
+        }
+    }
+}
+
+private struct PacketStatisticsBucket {
+    let id: EndpointStatisticsRowID
+    let identity: PacketStatisticsIdentity
+    var totals = EndpointStatisticsTotals.zero
+    private var addresses = PacketStatisticsValueCounts()
+    private var ports = PacketStatisticsValueCounts()
+    private var protocolNames = PacketStatisticsValueCounts()
+    private var clients = PacketStatisticsValueCounts()
+    private var domains = PacketStatisticsValueCounts()
+
+    init(id: EndpointStatisticsRowID, identity: PacketStatisticsIdentity) {
+        self.id = id
+        self.identity = identity
+    }
+
+    var row: EndpointStatisticsRow {
+        EndpointStatisticsRow(
+            id: id,
+            address: identity.address ?? addresses.displayValue,
+            port: identity.port ?? ports.displayValue,
+            protocolName: identity.protocolName ?? protocolNames.displayValue,
+            client: identity.client ?? clients.displayValue,
+            domain: identity.domain ?? domains.displayValue,
+            isAddressMultiple: identity.address == nil && addresses.isMultiple,
+            isPortMultiple: identity.port == nil && ports.isMultiple,
+            isProtocolMultiple: identity.protocolName == nil && protocolNames.isMultiple,
+            isClientMultiple: identity.client == nil && clients.isMultiple,
+            isDomainMultiple: identity.domain == nil && domains.isMultiple,
+            packets: totals.packets,
+            bytes: totals.bytes,
+            txPackets: totals.txPackets,
+            txBytes: totals.txBytes,
+            rxPackets: totals.rxPackets,
+            rxBytes: totals.rxBytes,
+            unclassifiedPackets: totals.unclassifiedPackets,
+            unclassifiedBytes: totals.unclassifiedBytes
+        )
+    }
+
+    mutating func add(totals: EndpointStatisticsTotals, related: PacketStatisticsRelatedValues) {
+        self.totals.add(totals)
+        addresses.add(related.addresses)
+        ports.add(related.ports)
+        protocolNames.add(related.protocolNames)
+        clients.add(related.clients)
+        domains.add(related.domains)
+    }
+
+    mutating func remove(totals: EndpointStatisticsTotals, related: PacketStatisticsRelatedValues) {
+        self.totals.remove(totals)
+        addresses.remove(related.addresses)
+        ports.remove(related.ports)
+        protocolNames.remove(related.protocolNames)
+        clients.remove(related.clients)
+        domains.remove(related.domains)
+    }
+}
+
+private extension EndpointStatisticsTotals {
+    mutating func add(_ value: EndpointStatisticsTotals) {
+        packets += value.packets
+        bytes += value.bytes
+        txPackets += value.txPackets
+        txBytes += value.txBytes
+        rxPackets += value.rxPackets
+        rxBytes += value.rxBytes
+        unclassifiedPackets += value.unclassifiedPackets
+        unclassifiedBytes += value.unclassifiedBytes
+    }
+
+    mutating func remove(_ value: EndpointStatisticsTotals) {
+        packets -= value.packets
+        bytes -= value.bytes
+        txPackets -= value.txPackets
+        txBytes -= value.txBytes
+        rxPackets -= value.rxPackets
+        rxBytes -= value.rxBytes
+        unclassifiedPackets -= value.unclassifiedPackets
+        unclassifiedBytes -= value.unclassifiedBytes
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsService.swift
@@ -254,14 +254,7 @@ enum EndpointStatisticsClassifier {
     }
 
     private static func canonicalDomain(_ value: String?) -> String? {
-        let normalized = value?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
-            .lowercased()
-        guard let normalized, !normalized.isEmpty, normalized.utf8.count <= 253 else {
-            return nil
-        }
-        return normalized
+        PacketSourceListClassifier.canonicalDomainName(value)
     }
 
     private static func canonicalIPAddress(_ rawValue: String?) -> (address: String, group: EndpointStatisticsGroup)? {
@@ -295,7 +288,7 @@ enum EndpointStatisticsClassifier {
         return nil
     }
 
-    private static func protocolName(for packet: PacketSummary) -> String {
+    static func protocolName(for packet: PacketSummary) -> String {
         switch packet.transportHint {
         case .ethernet: return "Ethernet"
         case .arp: return "ARP"

--- a/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsService.swift
@@ -199,7 +199,11 @@ enum EndpointStatisticsClassifier {
 
     fileprivate static func metadata(for packet: PacketSummary) -> PacketStatisticsMetadata {
         let clientIdentity = PacketSourceListClassifier.clientIdentity(for: packet).map {
-            PacketStatisticsClient(key: $0.key.rawValue, displayName: $0.displayName)
+            PacketStatisticsClient(
+                key: $0.key.rawValue,
+                displayName: $0.displayName,
+                iconFilePath: $0.iconFilePath
+            )
         }
         return PacketStatisticsMetadata(
             client: clientIdentity,
@@ -636,6 +640,7 @@ final class EndpointStatisticsService {
                     ports: remoteValues.ports,
                     protocolNames: [metadata.protocolName],
                     clients: [client.displayName],
+                    clientIconFilePaths: client.iconFilePath.map { [$0] } ?? [],
                     domains: metadata.domain.map { [$0] } ?? []
                 ),
                 totals: directionalTotals(bytes: bytes, direction: metadata.direction),
@@ -650,7 +655,8 @@ final class EndpointStatisticsService {
                     addresses: remoteValues.addresses,
                     ports: remoteValues.ports,
                     protocolNames: [metadata.protocolName],
-                    clients: metadata.client.map { [$0.displayName] } ?? []
+                    clients: metadata.client.map { [$0.displayName] } ?? [],
+                    clientIconFilePaths: metadata.client.flatMap(\.iconFilePath).map { [$0] } ?? []
                 ),
                 totals: directionalTotals(bytes: bytes, direction: metadata.direction, reversesDirection: true),
                 operation: operation
@@ -750,6 +756,7 @@ final class EndpointStatisticsService {
             ports: transportGroup == nil ? unique(endpoints.compactMap { $0.port.map(String.init) }) : [],
             protocolNames: [metadata.protocolName],
             clients: metadata.client.map { [$0.displayName] } ?? [],
+            clientIconFilePaths: metadata.client.flatMap(\.iconFilePath).map { [$0] } ?? [],
             domains: metadata.domain.map { [$0] } ?? []
         )
     }
@@ -939,6 +946,7 @@ private enum PacketStatisticsOperation {
 private struct PacketStatisticsClient: Equatable {
     let key: String
     let displayName: String
+    let iconFilePath: String?
 }
 
 fileprivate struct PacketStatisticsMetadata: Equatable {
@@ -987,6 +995,7 @@ private struct PacketStatisticsRelatedValues {
     var ports: [String] = []
     var protocolNames: [String] = []
     var clients: [String] = []
+    var clientIconFilePaths: [String] = []
     var domains: [String] = []
 }
 
@@ -1002,6 +1011,10 @@ private struct PacketStatisticsValueCounts {
 
     var isMultiple: Bool {
         counts.count > 1
+    }
+
+    var singleValue: String? {
+        counts.count == 1 ? counts.keys.first : nil
     }
 
     mutating func add(_ values: [String]) {
@@ -1032,6 +1045,7 @@ private struct PacketStatisticsBucket {
     private var ports = PacketStatisticsValueCounts()
     private var protocolNames = PacketStatisticsValueCounts()
     private var clients = PacketStatisticsValueCounts()
+    private var clientIconFilePaths = PacketStatisticsValueCounts()
     private var domains = PacketStatisticsValueCounts()
 
     init(id: EndpointStatisticsRowID, identity: PacketStatisticsIdentity) {
@@ -1046,6 +1060,7 @@ private struct PacketStatisticsBucket {
             port: identity.port ?? ports.displayValue,
             protocolName: identity.protocolName ?? protocolNames.displayValue,
             client: identity.client ?? clients.displayValue,
+            clientIconFilePath: clients.isMultiple ? nil : clientIconFilePaths.singleValue,
             domain: identity.domain ?? domains.displayValue,
             isAddressMultiple: identity.address == nil && addresses.isMultiple,
             isPortMultiple: identity.port == nil && ports.isMultiple,
@@ -1069,6 +1084,7 @@ private struct PacketStatisticsBucket {
         ports.add(related.ports)
         protocolNames.add(related.protocolNames)
         clients.add(related.clients)
+        clientIconFilePaths.add(related.clientIconFilePaths)
         domains.add(related.domains)
     }
 
@@ -1078,6 +1094,7 @@ private struct PacketStatisticsBucket {
         ports.remove(related.ports)
         protocolNames.remove(related.protocolNames)
         clients.remove(related.clients)
+        clientIconFilePaths.remove(related.clientIconFilePaths)
         domains.remove(related.domains)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsUpdateDrainCoordinator.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/EndpointStatisticsUpdateDrainCoordinator.swift
@@ -1,0 +1,213 @@
+//
+//  EndpointStatisticsUpdateDrainCoordinator.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+
+struct EndpointStatisticsUpdateDrainCoordinator {
+    enum Action {
+        case none
+        case drain(EndpointStatisticsIngestUpdate)
+        case paused
+    }
+
+    private let maximumPendingPacketCount: Int
+    private var pendingUpdate: PendingEndpointStatisticsUpdate?
+    private(set) var isDrainInFlight = false
+    private(set) var isPaused = false
+
+    var retainedPendingPacketCount: Int {
+        pendingUpdate?.retainedPacketCount ?? 0
+    }
+
+    init(maximumPendingPacketCount: Int = 10_000) {
+        precondition(maximumPendingPacketCount >= 0)
+        self.maximumPendingPacketCount = maximumPendingPacketCount
+    }
+
+    // Call on the owning queue; only the returned update crosses to the processing queue.
+    mutating func enqueue(_ update: EndpointStatisticsIngestUpdate) -> Action {
+        guard !isPaused else {
+            return .none
+        }
+        guard isDrainInFlight else {
+            isDrainInFlight = true
+            return .drain(update)
+        }
+
+        let incomingPacketCount = update.pendingPacketCountUpperBound
+        if pendingUpdate == nil {
+            guard incomingPacketCount <= maximumPendingPacketCount else {
+                return pause()
+            }
+            pendingUpdate = PendingEndpointStatisticsUpdate(update: update)
+        } else if let retainedPacketCount = pendingUpdate?.retainedPacketCount,
+                  incomingPacketCount <= maximumPendingPacketCount - retainedPacketCount {
+            guard pendingUpdate?.append(update) == true else {
+                return pause()
+            }
+        } else {
+            return pause()
+        }
+        guard let pendingUpdate,
+              pendingUpdate.retainedPacketCount <= maximumPendingPacketCount else {
+            return pause()
+        }
+        return .none
+    }
+
+    mutating func drainCompleted(didConsume: Bool) -> Action {
+        guard isDrainInFlight else {
+            return .none
+        }
+        if !didConsume {
+            _ = pause()
+        }
+        if isPaused {
+            pendingUpdate = nil
+            isDrainInFlight = false
+            return .paused
+        }
+        if let pendingUpdate {
+            self.pendingUpdate = nil
+            return .drain(pendingUpdate.makeUpdate())
+        }
+        isDrainInFlight = false
+        return .none
+    }
+
+    // Manual Refresh supplies one latest owned replacement and explicitly resumes aggregation.
+    mutating func resume(withReplacement update: EndpointStatisticsIngestUpdate) -> Action {
+        guard isPaused, !isDrainInFlight, update.previousPacketRevision == nil else {
+            return isPaused ? .paused : .none
+        }
+        pendingUpdate = nil
+        isPaused = false
+        isDrainInFlight = true
+        return .drain(update)
+    }
+
+    mutating func cancel() {
+        pendingUpdate = nil
+        isPaused = false
+        isDrainInFlight = false
+    }
+
+    private mutating func pause() -> Action {
+        pendingUpdate = nil
+        isPaused = true
+        return .paused
+    }
+}
+
+private extension EndpointStatisticsIngestUpdate {
+    var pendingPacketCountUpperBound: Int {
+        switch kind {
+        case .replace(let packets), .append(let packets), .metadata(let packets):
+            return packets.count
+        case .appendWithMetadata(let newPackets, let updatedPackets):
+            return newPackets.count + updatedPackets.count
+        }
+    }
+}
+
+private struct PendingEndpointStatisticsUpdate {
+    private let previousPacketRevision: UInt64
+    private var packetRevision: UInt64
+    private let packetLineageRevision: UInt64
+    private var totalPacketCount: Int
+    private var newPackets: [PacketSummary]
+    private var updatedPacketsByID: [PacketSummary.ID: PacketSummary]
+    private var updatedPacketOrder: [PacketSummary.ID]
+
+    var retainedPacketCount: Int {
+        newPackets.count + updatedPacketsByID.count
+    }
+
+    init?(update: EndpointStatisticsIngestUpdate) {
+        guard let previousPacketRevision = update.previousPacketRevision else {
+            return nil
+        }
+        self.previousPacketRevision = previousPacketRevision
+        packetRevision = update.packetRevision
+        packetLineageRevision = update.packetLineageRevision
+        totalPacketCount = update.totalPacketCount
+        newPackets = []
+        updatedPacketsByID = [:]
+        updatedPacketOrder = []
+        guard appendPayload(from: update.kind) else {
+            return nil
+        }
+    }
+
+    mutating func append(_ update: EndpointStatisticsIngestUpdate) -> Bool {
+        guard update.packetLineageRevision == packetLineageRevision,
+              update.previousPacketRevision == packetRevision,
+              expectedTotalPacketCount(after: update.kind) == update.totalPacketCount,
+              appendPayload(from: update.kind) else {
+            return false
+        }
+        packetRevision = update.packetRevision
+        totalPacketCount = update.totalPacketCount
+        return true
+    }
+
+    func makeUpdate() -> EndpointStatisticsIngestUpdate {
+        let updatedPackets = updatedPacketOrder.compactMap { updatedPacketsByID[$0] }
+        let kind: EndpointStatisticsIngestUpdate.Kind
+        if newPackets.isEmpty {
+            kind = .metadata(updatedPackets)
+        } else if updatedPackets.isEmpty {
+            kind = .append(newPackets)
+        } else {
+            kind = .appendWithMetadata(newPackets: newPackets, updatedPackets: updatedPackets)
+        }
+        return EndpointStatisticsIngestUpdate(
+            packetRevision: packetRevision,
+            packetLineageRevision: packetLineageRevision,
+            totalPacketCount: totalPacketCount,
+            kind: kind,
+            previousPacketRevision: previousPacketRevision
+        )
+    }
+
+    private func expectedTotalPacketCount(after kind: EndpointStatisticsIngestUpdate.Kind) -> Int? {
+        switch kind {
+        case .append(let packets):
+            return totalPacketCount + packets.count
+        case .appendWithMetadata(let newPackets, _):
+            return totalPacketCount + newPackets.count
+        case .metadata:
+            return totalPacketCount
+        case .replace:
+            return nil
+        }
+    }
+
+    private mutating func appendPayload(from kind: EndpointStatisticsIngestUpdate.Kind) -> Bool {
+        switch kind {
+        case .append(let packets):
+            newPackets.append(contentsOf: packets)
+        case .appendWithMetadata(let newPackets, let updatedPackets):
+            self.newPackets.append(contentsOf: newPackets)
+            appendUpdatedPackets(updatedPackets)
+        case .metadata(let packets):
+            appendUpdatedPackets(packets)
+        case .replace:
+            return false
+        }
+        return true
+    }
+
+    private mutating func appendUpdatedPackets(_ packets: [PacketSummary]) {
+        for packet in packets {
+            if updatedPacketsByID.updateValue(packet, forKey: packet.id) == nil {
+                updatedPacketOrder.append(packet.id)
+            }
+        }
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/PacketSourceListService.swift
@@ -75,10 +75,37 @@ struct PacketSourceListItem: Identifiable, Equatable, Sendable {
     let count: Int?
     let kind: PacketSourceListItemKind
     let selection: PacketSourceListSelection?
+    let workspaceMode: NetworkInspectorWorkspaceMode?
     let children: [PacketSourceListItem]
+
+    init(
+        id: String,
+        title: String,
+        systemImageName: String?,
+        iconFilePath: String?,
+        count: Int?,
+        kind: PacketSourceListItemKind,
+        selection: PacketSourceListSelection?,
+        workspaceMode: NetworkInspectorWorkspaceMode? = nil,
+        children: [PacketSourceListItem]
+    ) {
+        self.id = id
+        self.title = title
+        self.systemImageName = systemImageName
+        self.iconFilePath = iconFilePath
+        self.count = count
+        self.kind = kind
+        self.selection = selection
+        self.workspaceMode = workspaceMode
+        self.children = children
+    }
 
     var isGroup: Bool {
         kind == .group
+    }
+
+    var isNavigable: Bool {
+        selection != nil || workspaceMode != nil
     }
 
     var countText: String? {
@@ -139,6 +166,10 @@ struct PacketSourceListSnapshot: Equatable, Sendable {
     }
 
     private static func filtered(item: PacketSourceListItem, matching filterText: String) -> PacketSourceListItem? {
+        // Capture navigation stays available while the text field filters packet sources.
+        if item.id == PacketSourceListTreeBuilder.captureGroupID {
+            return item
+        }
         if item.title.localizedCaseInsensitiveContains(filterText) {
             return item
         }
@@ -158,6 +189,7 @@ struct PacketSourceListSnapshot: Equatable, Sendable {
             count: item.count,
             kind: item.kind,
             selection: item.selection,
+            workspaceMode: item.workspaceMode,
             children: filteredChildren
         )
     }
@@ -405,14 +437,25 @@ enum PacketSourceListClassifier {
     }
 
     static func domainIdentity(for packet: PacketSummary) -> PacketSourceDomainIdentity {
-        guard let domainName = trimmed(packet.domainName) else {
+        guard let domainName = canonicalDomainName(packet.domainName) else {
             return PacketSourceDomainIdentity(key: .ipAddresses, displayName: "IP Addresses")
         }
 
         return PacketSourceDomainIdentity(
-            key: PacketSourceDomainKey(rawValue: domainName.lowercased(), isMissingDomain: false),
+            key: PacketSourceDomainKey(rawValue: domainName, isMissingDomain: false),
             displayName: domainName
         )
+    }
+
+    static func canonicalDomainName(_ value: String?) -> String? {
+        let normalized = value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        guard let normalized, !normalized.isEmpty, normalized.utf8.count <= 253 else {
+            return nil
+        }
+        return normalized
     }
 
     static func ipAddressIdentities(for packet: PacketSummary) -> [PacketSourceIPAddressIdentity] {
@@ -1137,6 +1180,8 @@ enum PacketSourceListTreeBuilder {
     }
 
     static let favoritesGroupID = "group:favorites"
+    static let captureGroupID = "group:capture"
+    static let overviewItemID = "capture:overview"
     static let filesGroupID = "group:files"
     static let allGroupID = "group:all"
     static let pinnedFolderID = "favorite:pinned"
@@ -1144,6 +1189,7 @@ enum PacketSourceListTreeBuilder {
     static let domainsFolderID = "folder:domains"
 
     static let defaultExpandedItemIDs: Set<String> = [
+        captureGroupID,
         favoritesGroupID,
         filesGroupID,
         allGroupID,
@@ -1288,6 +1334,28 @@ enum PacketSourceListTreeBuilder {
         }
 
         var roots = [
+            PacketSourceListItem(
+                id: captureGroupID,
+                title: "Capture",
+                systemImageName: nil,
+                iconFilePath: nil,
+                count: nil,
+                kind: .group,
+                selection: nil,
+                children: [
+                    PacketSourceListItem(
+                        id: overviewItemID,
+                        title: "Overview",
+                        systemImageName: "chart.bar.xaxis",
+                        iconFilePath: nil,
+                        count: nil,
+                        kind: .favorite,
+                        selection: nil,
+                        workspaceMode: .overview,
+                        children: []
+                    ),
+                ]
+            ),
             PacketSourceListItem(
                 id: favoritesGroupID,
                 title: "Favorites",

--- a/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
+++ b/TCPViewer/Features/NetworkInspector/Services/SavedPacketService.swift
@@ -21,7 +21,11 @@ final class SavedPacketService {
     private let userDataDirectory: TCPViewerUserDataDirectory
     private let usesUserDataDirectoryStorage: Bool
     private var cachedRecords: [SavedPacketRecord]
+    private var cachedPacketsByID: [PacketSummary.ID: PacketSummary]?
     private var isDocumentScoped = false
+    #if DEBUG
+    private(set) var packetLookupIndexBuildCount = 0
+    #endif
 
     init(
         storageURL: URL? = nil,
@@ -33,6 +37,7 @@ final class SavedPacketService {
         self.storageURL = storageURL ?? SavedPacketService.defaultStorageURL(userDataDirectory: userDataDirectory)
         self.fileManager = fileManager
         self.cachedRecords = (try? Self.loadRecords(from: self.storageURL, fileManager: fileManager)) ?? []
+        self.cachedPacketsByID = nil
     }
 
     func records() -> [SavedPacketRecord] {
@@ -42,15 +47,27 @@ final class SavedPacketService {
     func useDocumentRecords(_ records: [SavedPacketRecord]) {
         isDocumentScoped = true
         cachedRecords = records
+        cachedPacketsByID = nil
     }
 
     func reloadPersistentRecords() {
         isDocumentScoped = false
         cachedRecords = (try? Self.loadRecords(from: storageURL, fileManager: fileManager)) ?? []
+        cachedPacketsByID = nil
     }
 
     func packets() -> [PacketSummary] {
         cachedRecords.map(\.packet)
+    }
+
+    // Reuse one packet index across chunked consumers instead of rescanning every saved record per batch.
+    func packets(withIDs packetIDs: [PacketSummary.ID]) -> [PacketSummary] {
+        let packetsByID = packetLookupIndex()
+        return packetIDs.compactMap { packetsByID[$0] }
+    }
+
+    func packet(withID packetID: PacketSummary.ID) -> PacketSummary? {
+        packetLookupIndex()[packetID]
     }
 
     // Persist selected packet summaries without storing raw packet bytes.
@@ -60,6 +77,7 @@ final class SavedPacketService {
             return []
         }
 
+        cachedPacketsByID = nil
         var savedRecords: [SavedPacketRecord] = []
         for packet in packets {
             if let index = cachedRecords.firstIndex(where: { $0.packet.id == packet.id }) {
@@ -83,6 +101,7 @@ final class SavedPacketService {
             return
         }
 
+        cachedPacketsByID = nil
         cachedRecords.removeAll { packetIDs.contains($0.packet.id) }
         try persist()
     }
@@ -107,6 +126,7 @@ final class SavedPacketService {
         }
 
         if didChange {
+            cachedPacketsByID = nil
             do {
                 try persist()
             } catch {
@@ -138,6 +158,7 @@ final class SavedPacketService {
         }
 
         if didChange {
+            cachedPacketsByID = nil
             do {
                 try persist()
             } catch {
@@ -162,6 +183,21 @@ final class SavedPacketService {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         try encoder.encode(cachedRecords).write(to: storageURL, options: .atomic)
+    }
+
+    private func packetLookupIndex() -> [PacketSummary.ID: PacketSummary] {
+        if let cachedPacketsByID {
+            return cachedPacketsByID
+        }
+        let packetsByID = Dictionary(
+            cachedRecords.map { ($0.packet.id, $0.packet) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        cachedPacketsByID = packetsByID
+        #if DEBUG
+        packetLookupIndexBuildCount += 1
+        #endif
+        return packetsByID
     }
 
     private static func loadRecords(from url: URL, fileManager: FileManager) throws -> [SavedPacketRecord] {

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -186,6 +186,7 @@ private struct PacketTableFilterSignature: Equatable, Sendable {
     let displayFilterText: String
     let quickFilterSelection: PacketQuickFilterSelection
     let structuredFilterGroup: PacketStructuredFilterGroup
+    let endpointStatisticsFilter: EndpointStatisticsRow.ID?
     let sourceListSelection: PacketSourceListSelection
     let pinnedItems: [PacketPin]
     let savedRecords: [SavedPacketRecord]
@@ -255,6 +256,7 @@ private enum PacketTableContentBuilder {
                   displayFilter.isEmpty || displayFilter.matches(packet),
                   quickFilterService.matches(packet, selection: input.signature.quickFilterSelection),
                   structuredFilterService.matches(packet, context: structuredFilterContext),
+                  input.signature.endpointStatisticsFilter?.matches(packet) != false,
                   input.signature.wiresharkFilterMembership?.matches(packet, in: input.ingestState) != false else {
                 continue
             }
@@ -329,6 +331,7 @@ private struct PacketTableContentCache {
     private var displayFilterText: String?
     private var quickFilterSelection: PacketQuickFilterSelection?
     private var structuredFilterGroup: PacketStructuredFilterGroup?
+    private var endpointStatisticsFilter: EndpointStatisticsRow.ID?
     private var sourceListSelection: PacketSourceListSelection?
     private var pinnedItems: [PacketPin] = []
     private var savedRecords: [SavedPacketRecord] = []
@@ -345,6 +348,7 @@ private struct PacketTableContentCache {
         displayFilterText = nil
         quickFilterSelection = nil
         structuredFilterGroup = nil
+        endpointStatisticsFilter = nil
         sourceListSelection = nil
         pinnedItems = []
         savedRecords = []
@@ -371,6 +375,7 @@ private struct PacketTableContentCache {
         quickFilterService: PacketQuickFilterService,
         structuredFilterGroup: PacketStructuredFilterGroup,
         structuredFilterService: PacketStructuredFilterService,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
@@ -383,6 +388,7 @@ private struct PacketTableContentCache {
             displayFilterText: displayFilterText,
             quickFilterSelection: quickFilterSelection,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -397,6 +403,7 @@ private struct PacketTableContentCache {
             self.displayFilterText == displayFilterText &&
             self.quickFilterSelection == quickFilterSelection &&
             self.structuredFilterGroup == structuredFilterGroup &&
+            self.endpointStatisticsFilter == endpointStatisticsFilter &&
             self.sourceListSelection == sourceListSelection &&
             self.pinnedItems == pinnedItems &&
             self.savedRecords == savedRecords &&
@@ -421,6 +428,7 @@ private struct PacketTableContentCache {
                     quickFilterService: quickFilterService,
                     structuredFilterGroup: structuredFilterGroup,
                     structuredFilterService: structuredFilterService,
+                    endpointStatisticsFilter: endpointStatisticsFilter,
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
                     savedRecords: savedRecords,
@@ -439,6 +447,7 @@ private struct PacketTableContentCache {
                     quickFilterService: quickFilterService,
                     structuredFilterGroup: structuredFilterGroup,
                     structuredFilterService: structuredFilterService,
+                    endpointStatisticsFilter: endpointStatisticsFilter,
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
                     savedRecords: savedRecords,
@@ -456,6 +465,7 @@ private struct PacketTableContentCache {
                     quickFilterService: quickFilterService,
                     structuredFilterGroup: structuredFilterGroup,
                     structuredFilterService: structuredFilterService,
+                    endpointStatisticsFilter: endpointStatisticsFilter,
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
                     savedRecords: savedRecords,
@@ -474,6 +484,7 @@ private struct PacketTableContentCache {
                     quickFilterService: quickFilterService,
                     structuredFilterGroup: structuredFilterGroup,
                     structuredFilterService: structuredFilterService,
+                    endpointStatisticsFilter: endpointStatisticsFilter,
                     sourceListSelection: sourceListSelection,
                     pinnedItems: pinnedItems,
                     savedRecords: savedRecords,
@@ -490,6 +501,7 @@ private struct PacketTableContentCache {
             displayFilterText: displayFilterText,
             quickFilterSelection: quickFilterSelection,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -512,6 +524,7 @@ private struct PacketTableContentCache {
         displayFilterText: String,
         quickFilterSelection: PacketQuickFilterSelection,
         structuredFilterGroup: PacketStructuredFilterGroup,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
@@ -522,6 +535,7 @@ private struct PacketTableContentCache {
             self.displayFilterText != displayFilterText ||
             self.quickFilterSelection != quickFilterSelection ||
             self.structuredFilterGroup != structuredFilterGroup ||
+            self.endpointStatisticsFilter != endpointStatisticsFilter ||
             self.sourceListSelection != sourceListSelection ||
             self.pinnedItems != pinnedItems ||
             self.savedRecords != savedRecords ||
@@ -580,6 +594,7 @@ private struct PacketTableContentCache {
         quickFilterService: PacketQuickFilterService,
         structuredFilterGroup: PacketStructuredFilterGroup,
         structuredFilterService: PacketStructuredFilterService,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
@@ -593,6 +608,7 @@ private struct PacketTableContentCache {
                 displayFilterText: displayFilterText,
                 quickFilterSelection: quickFilterSelection,
                 structuredFilterGroup: structuredFilterGroup,
+                endpointStatisticsFilter: endpointStatisticsFilter,
                 sourceListSelection: sourceListSelection,
                 pinnedItems: pinnedItems,
                 savedRecords: savedRecords,
@@ -622,6 +638,7 @@ private struct PacketTableContentCache {
                   displayFilter.isEmpty || displayFilter.matches(packet),
                   quickFilterService.matches(packet, selection: quickFilterSelection),
                   structuredFilterService.matches(packet, context: structuredFilterContext),
+                  endpointStatisticsFilter?.matches(packet) != false,
                   wiresharkFilterMembership?.matches(packet, in: ingestState) != false else {
                 continue
             }
@@ -657,6 +674,7 @@ private struct PacketTableContentCache {
             displayFilterText: displayFilterText,
             quickFilterSelection: quickFilterSelection,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -676,6 +694,7 @@ private struct PacketTableContentCache {
         quickFilterService: PacketQuickFilterService,
         structuredFilterGroup: PacketStructuredFilterGroup,
         structuredFilterService: PacketStructuredFilterService,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
@@ -689,6 +708,7 @@ private struct PacketTableContentCache {
             quickFilterService: quickFilterService,
             structuredFilterGroup: structuredFilterGroup,
             structuredFilterService: structuredFilterService,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             wiresharkFilterMembership: wiresharkFilterMembership,
@@ -717,6 +737,7 @@ private struct PacketTableContentCache {
             displayFilterText: displayFilterText,
             quickFilterSelection: quickFilterSelection,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -735,6 +756,7 @@ private struct PacketTableContentCache {
         quickFilterService: PacketQuickFilterService,
         structuredFilterGroup: PacketStructuredFilterGroup,
         structuredFilterService: PacketStructuredFilterService,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
@@ -751,6 +773,7 @@ private struct PacketTableContentCache {
             quickFilterService: quickFilterService,
             structuredFilterGroup: structuredFilterGroup,
             structuredFilterService: structuredFilterService,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -770,6 +793,7 @@ private struct PacketTableContentCache {
             quickFilterService: quickFilterService,
             structuredFilterGroup: structuredFilterGroup,
             structuredFilterService: structuredFilterService,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             wiresharkFilterMembership: wiresharkFilterMembership,
@@ -817,6 +841,7 @@ private struct PacketTableContentCache {
             displayFilterText: displayFilterText,
             quickFilterSelection: quickFilterSelection,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: sourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -842,6 +867,7 @@ private struct PacketTableContentCache {
         quickFilterService: PacketQuickFilterService,
         structuredFilterGroup: PacketStructuredFilterGroup,
         structuredFilterService: PacketStructuredFilterService,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         wiresharkFilterMembership: PacketWiresharkFilterMembership?,
@@ -860,6 +886,7 @@ private struct PacketTableContentCache {
                 (displayFilter.isEmpty || displayFilter.matches(packet)) &&
                 quickFilterService.matches(packet, selection: quickFilterSelection) &&
                 structuredFilterService.matches(packet, context: structuredFilterContext) &&
+                endpointStatisticsFilter?.matches(packet) != false &&
                 wiresharkFilterMembership?.matches(packet, in: ingestState) != false
             let wasVisible = store.visiblePacketRowIndexByID[packetID] != nil
             guard wasVisible == isVisibleNow else {
@@ -892,6 +919,7 @@ private struct PacketTableContentCache {
         displayFilterText = input.signature.displayFilterText
         quickFilterSelection = input.signature.quickFilterSelection
         structuredFilterGroup = input.signature.structuredFilterGroup
+        endpointStatisticsFilter = input.signature.endpointStatisticsFilter
         sourceListSelection = input.signature.sourceListSelection
         pinnedItems = input.signature.pinnedItems
         savedRecords = input.signature.savedRecords
@@ -907,6 +935,7 @@ private struct PacketTableContentCache {
         displayFilterText: String,
         quickFilterSelection: PacketQuickFilterSelection,
         structuredFilterGroup: PacketStructuredFilterGroup,
+        endpointStatisticsFilter: EndpointStatisticsRow.ID?,
         sourceListSelection: PacketSourceListSelection,
         pinnedItems: [PacketPin],
         savedRecords: [SavedPacketRecord],
@@ -919,6 +948,7 @@ private struct PacketTableContentCache {
         self.displayFilterText = displayFilterText
         self.quickFilterSelection = quickFilterSelection
         self.structuredFilterGroup = structuredFilterGroup
+        self.endpointStatisticsFilter = endpointStatisticsFilter
         self.sourceListSelection = sourceListSelection
         self.pinnedItems = pinnedItems
         self.savedRecords = savedRecords
@@ -1022,6 +1052,7 @@ extension NetworkInspectorViewModelDelegate {
 
 final class NetworkInspectorViewModel {
     weak var delegate: NetworkInspectorViewModelDelegate?
+    var endpointStatisticsIngestHandler: ((PacketIngestState) -> Void)?
 
     private(set) var snapshot: NetworkInspectorSnapshot {
         didSet {
@@ -1053,7 +1084,7 @@ final class NetworkInspectorViewModel {
     private var activePacketTableFilterJob: PacketTableFilterJob?
     private var packetTableFilterGeneration = 0
     private var isPacketTableFiltering = false
-    private var selectsFirstVisiblePacketAfterFiltering = false
+    private var shouldSelectFirstVisiblePacketWhenFilteringCompletes = false
     private var pendingSessionImportReport: TCPViewSessionImportReport?
     private var pendingDisplayFilterValidationWorkItem: DispatchWorkItem?
     private var displayFilterValidationGeneration: UInt64 = 0
@@ -1086,9 +1117,25 @@ final class NetworkInspectorViewModel {
     private var wiresharkFilterMembershipLineageRevision: UInt64?
     private var displayFilterText: String
     private var structuredFilterGroup: PacketStructuredFilterGroup
+    private var endpointStatisticsFilter: EndpointStatisticsRow.ID?
     private var selectedCustomFilterID: PacketCustomFilter.ID?
     private var helperOnboardingDismissed = false
     private var isUsingSessionDocumentState = false
+
+    private var endpointStatisticsFilterLabel: String? {
+        guard let endpointStatisticsFilter else {
+            return nil
+        }
+
+        let displayKey: String
+        if endpointStatisticsFilter.group == .apps,
+           let separator = endpointStatisticsFilter.key.firstIndex(of: ":") {
+            displayKey = String(endpointStatisticsFilter.key[endpointStatisticsFilter.key.index(after: separator)...])
+        } else {
+            displayKey = endpointStatisticsFilter.key
+        }
+        return "\(endpointStatisticsFilter.group.title): \(displayKey)"
+    }
 
     convenience init(userDefaults: UserDefaults = .standard) {
         self.init(services: .foundation, userDefaults: userDefaults)
@@ -1138,6 +1185,7 @@ final class NetworkInspectorViewModel {
         self.structuredFilterGroup = preferences.filterMode == .wireshark
             ? .wireshark(expression: preferences.wiresharkFilterDraft)
             : structuredFilterStore.load()
+        self.endpointStatisticsFilter = nil
         let sourceListSnapshot = sourceListService.snapshot(
             for: controller.snapshot.packetIngestState,
             pinnedItems: pinService.pins(),
@@ -1151,6 +1199,7 @@ final class NetworkInspectorViewModel {
             quickFilterService: quickFilterService,
             structuredFilterGroup: activeStructuredFilterGroup,
             structuredFilterService: structuredFilterService,
+            endpointStatisticsFilter: nil,
             sourceListSelection: selectedSourceListSelection,
             pinnedItems: pinService.pins(),
             savedRecords: savedPacketService.records(),
@@ -1184,6 +1233,7 @@ final class NetworkInspectorViewModel {
             wiresharkFilterState: wiresharkFilterState,
             displayFilterText: displayFilterText,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilterLabel: nil,
             isPacketTableFiltering: isPacketTableFiltering,
             packetTableContent: packetTableContent
         )
@@ -1556,13 +1606,58 @@ final class NetworkInspectorViewModel {
     func toggleQuickFilter(_ id: PacketQuickFilterID) {
         cancelPendingInspectorFilterApplication()
         quickFilterService.toggle(id)
-        rebuildSnapshot(selectsFirstVisiblePacketForQuickFilter: true)
+        rebuildSnapshot(selectsFirstVisiblePacketAfterFiltering: true)
     }
 
     func resetQuickFilters() {
         cancelPendingInspectorFilterApplication()
         quickFilterService.reset()
         rebuildSnapshot(clearsSelectedPacket: true)
+    }
+
+    // Keep endpoint drill-down separate so it composes with every existing packet filter.
+    func showRelatedPackets(forEndpoint rowID: EndpointStatisticsRow.ID) {
+        cancelPendingInspectorFilterApplication()
+        endpointStatisticsFilter = rowID
+        workspaceMode = .packets
+        if case .view = selectedSidebar {
+            selectedSidebar = .liveCapture
+        }
+        rebuildSnapshot(selectsFirstVisiblePacketAfterFiltering: true)
+    }
+
+    func clearEndpointStatisticsFilter() {
+        guard endpointStatisticsFilter != nil else {
+            return
+        }
+
+        endpointStatisticsFilter = nil
+        rebuildSnapshot()
+    }
+
+    func packetSummariesForEndpointStatistics(_ identifiers: [PacketSummary.ID]) -> [PacketSummary] {
+        let ingestState = controller.snapshot.packetIngestState
+        if selectedSourceListSelection == .saved {
+            return savedPacketService.packets(withIDs: identifiers)
+        }
+
+        // Live append batches normally resolve from the indexed ingest state, so avoid rescanning saved packets.
+        var activePackets: [PacketSummary] = []
+        activePackets.reserveCapacity(identifiers.count)
+        for identifier in identifiers {
+            guard let packet = ingestState.packet(withID: identifier) else {
+                return identifiers.compactMap { identifier in
+                    ingestState.packet(withID: identifier) ?? savedPacketService.packet(withID: identifier)
+                }
+            }
+            activePackets.append(packet)
+        }
+        return activePackets
+    }
+
+    // Statistics recovery must read the workspace directly because the rendered snapshot is coalesced.
+    func currentPacketIngestStateForEndpointStatistics() -> PacketIngestState {
+        controller.snapshot.packetIngestState
     }
 
     // Save the current structured filter group as a reusable custom titlebar filter.
@@ -1797,6 +1892,7 @@ final class NetworkInspectorViewModel {
         workspaceMode = .packets
         displayFilterText = ""
         quickFilterService.reset()
+        endpointStatisticsFilter = nil
         selectedCustomFilterID = nil
     }
 
@@ -2094,6 +2190,7 @@ final class NetworkInspectorViewModel {
         #endif
         cancelWiresharkFilterEvaluation(clearMembership: true)
         cancelActivePacketTableFilterJob()
+        endpointStatisticsFilter = nil
         controller.clearPackets()
         packetTableContentCache.reset()
         sourceListService.reset()
@@ -2571,6 +2668,7 @@ final class NetworkInspectorViewModel {
 
     func openDocument(at fileURL: URL, completion: (() -> Void)? = nil) {
         cancelWiresharkFilterEvaluation(clearMembership: true)
+        endpointStatisticsFilter = nil
         let standardizedURL = TCPViewerCaptureFileImportPolicy.standardizedFileURL(fileURL)
         let isSessionFile = TCPViewerCaptureFileImportPolicy.isSessionFileURL(standardizedURL)
         controller.openDocument(at: fileURL) { [weak self] in
@@ -2608,6 +2706,7 @@ final class NetworkInspectorViewModel {
         completion: @escaping (TCPViewerCaptureImportResult) -> Void
     ) {
         cancelWiresharkFilterEvaluation(clearMembership: true)
+        endpointStatisticsFilter = nil
         let hasSessionFile = fileURLs
             .map(TCPViewerCaptureFileImportPolicy.standardizedFileURL)
             .contains(where: TCPViewerCaptureFileImportPolicy.isSessionFileURL)
@@ -2644,6 +2743,7 @@ final class NetworkInspectorViewModel {
     }
 
     private func finishImportedDocuments(fileURLs: [URL], completion: (() -> Void)? = nil) {
+        endpointStatisticsFilter = nil
         workspaceMode = .packets
         selectedSourceListSelection = importedFileSelection(for: fileURLs)
         rebuildSnapshot()
@@ -2652,6 +2752,7 @@ final class NetworkInspectorViewModel {
 
     private func applySessionDocumentState(_ state: TCPViewSessionState) {
         isUsingSessionDocumentState = true
+        endpointStatisticsFilter = nil
         pinService.useDocumentPins(state.pins)
         savedPacketService.useDocumentRecords(remappedSavedRecordsForCurrentDocument(state.savedPackets))
         customFilterService.useDocumentFilters(state.customFilters)
@@ -2705,6 +2806,7 @@ final class NetworkInspectorViewModel {
         savedPacketService.reloadPersistentRecords()
         customFilterService.reloadPersistentFilters()
         quickFilterService.reset()
+        endpointStatisticsFilter = nil
         selectedCustomFilterID = nil
         sourceListFilterText = ""
         displayFilterText = preferences.displayFilterText
@@ -3126,7 +3228,7 @@ final class NetworkInspectorViewModel {
     }
 
     private func rebuildSnapshot(
-        selectsFirstVisiblePacketForQuickFilter: Bool = false,
+        selectsFirstVisiblePacketAfterFiltering: Bool = false,
         clearsSelectedPacket: Bool = false
     ) {
         cancelPendingRebuild()
@@ -3164,6 +3266,7 @@ final class NetworkInspectorViewModel {
                 quickFilterService: quickFilterService,
                 structuredFilterGroup: activeStructuredFilterGroup,
                 structuredFilterService: structuredFilterService,
+                endpointStatisticsFilter: endpointStatisticsFilter,
                 sourceListSelection: selectedSourceListSelection,
                 pinnedItems: pinnedItems,
                 savedRecords: savedRecords,
@@ -3180,13 +3283,14 @@ final class NetworkInspectorViewModel {
                 isPacketTableFiltering = true
             }
         }
-        if isPacketTableFiltering, selectsFirstVisiblePacketForQuickFilter {
-            selectsFirstVisiblePacketAfterFiltering = true
+        if isPacketTableFiltering, selectsFirstVisiblePacketAfterFiltering {
+            shouldSelectFirstVisiblePacketWhenFilteringCompletes = true
         }
         if clearsSelectedPacket {
             applyPacketSelectionDuringRebuild(nil)
-        } else if selectsFirstVisiblePacketForQuickFilter, !isPacketTableFiltering {
-            let firstVisiblePacketID = quickFilterService.selection.isActive ? packetTableContent.rows.first?.id : nil
+        } else if selectsFirstVisiblePacketAfterFiltering, !isPacketTableFiltering {
+            let shouldSelectFirstPacket = quickFilterService.selection.isActive || endpointStatisticsFilter != nil
+            let firstVisiblePacketID = shouldSelectFirstPacket ? packetTableContent.rows.first?.id : nil
             applyPacketSelectionDuringRebuild(firstVisiblePacketID)
             if firstVisiblePacketID != nil {
                 inspectorTab = .summary
@@ -3210,6 +3314,7 @@ final class NetworkInspectorViewModel {
             wiresharkFilterState: wiresharkFilterState,
             displayFilterText: displayFilterText,
             structuredFilterGroup: structuredFilterGroup,
+            endpointStatisticsFilterLabel: endpointStatisticsFilterLabel,
             isPacketTableFiltering: isPacketTableFiltering,
             packetTableContent: packetTableContent
         )
@@ -3241,6 +3346,7 @@ final class NetworkInspectorViewModel {
             displayFilterText: displayFilterText,
             quickFilterSelection: quickFilterService.selection,
             structuredFilterGroup: activeStructuredFilterGroup,
+            endpointStatisticsFilter: endpointStatisticsFilter,
             sourceListSelection: selectedSourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
@@ -3348,16 +3454,16 @@ final class NetworkInspectorViewModel {
         _ = packetTableContentCache.storeAsyncRebuild(output, input: job.input)
         activePacketTableFilterJob = nil
         isPacketTableFiltering = false
-        let shouldSelectFirst = selectsFirstVisiblePacketAfterFiltering
-        selectsFirstVisiblePacketAfterFiltering = false
-        rebuildSnapshot(selectsFirstVisiblePacketForQuickFilter: shouldSelectFirst)
+        let shouldSelectFirst = shouldSelectFirstVisiblePacketWhenFilteringCompletes
+        shouldSelectFirstVisiblePacketWhenFilteringCompletes = false
+        rebuildSnapshot(selectsFirstVisiblePacketAfterFiltering: shouldSelectFirst)
     }
 
     private func cancelActivePacketTableFilterJob() {
         activePacketTableFilterJob?.cancellationToken.cancel()
         activePacketTableFilterJob = nil
         isPacketTableFiltering = false
-        selectsFirstVisiblePacketAfterFiltering = false
+        shouldSelectFirstVisiblePacketWhenFilteringCompletes = false
     }
 
     private func applyPacketSelectionDuringRebuild(_ identifier: PacketSummary.ID?) {
@@ -3522,6 +3628,7 @@ final class NetworkInspectorViewModel {
 
 extension NetworkInspectorViewModel: TCPViewerWorkspaceControllerDelegate {
     func tcpViewerWorkspaceControllerDidChange(_ controller: TCPViewerWorkspaceController) {
+        endpointStatisticsIngestHandler?(controller.snapshot.packetIngestState)
         recordStatusMetrics(from: controller.snapshot)
         let ingestState = controller.snapshot.packetIngestState
         let pendingInspectorCaptureChanged = pendingInspectorFilterApplicationGeneration != nil

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1382,6 +1382,27 @@ final class NetworkInspectorViewModel {
         rebuildSnapshot()
     }
 
+    // Leave Overview without discarding the user's packet filters.
+    func showPacketsFromOverview() {
+        cancelPendingInspectorFilterApplication()
+        endpointStatisticsFilter = nil
+        selectedSourceListSelection = .allPackets
+        workspaceMode = .packets
+        selectedSidebar = .liveCapture
+        rebuildSnapshot()
+    }
+
+    // Use the sidebar's exact identity so an Overview row opens the same packet scope as a normal click.
+    func showSourceListSelectionFromOverview(_ selection: PacketSourceListSelection) {
+        cancelPendingInspectorFilterApplication()
+        sourceListFilterText = ""
+        endpointStatisticsFilter = nil
+        selectedSourceListSelection = selection
+        workspaceMode = .packets
+        selectedSidebar = .liveCapture
+        rebuildSnapshot()
+    }
+
     func selectInterface(_ identifier: String) {
         cancelPendingInspectorFilterApplication()
         selectedSidebar = .interface(identifier)

--- a/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
+++ b/TCPViewer/Features/NetworkInspector/ViewModels/NetworkInspectorViewModel.swift
@@ -1636,15 +1636,38 @@ final class NetworkInspectorViewModel {
         rebuildSnapshot(clearsSelectedPacket: true)
     }
 
-    // Keep endpoint drill-down separate so it composes with every existing packet filter.
-    func showRelatedPackets(forEndpoint rowID: EndpointStatisticsRow.ID) {
+    // Select the closest sidebar scope while the endpoint filter keeps the packet match exact.
+    @discardableResult
+    func showRelatedPackets(forEndpoint rowID: EndpointStatisticsRow.ID) -> PacketSourceListSelection {
         cancelPendingInspectorFilterApplication()
+        sourceListFilterText = ""
         endpointStatisticsFilter = rowID
+        selectedSourceListSelection = sourceListSelection(forEndpoint: rowID)
         workspaceMode = .packets
         if case .view = selectedSidebar {
             selectedSidebar = .liveCapture
         }
         rebuildSnapshot(selectsFirstVisiblePacketAfterFiltering: true)
+        return selectedSourceListSelection
+    }
+
+    private func sourceListSelection(forEndpoint rowID: EndpointStatisticsRow.ID) -> PacketSourceListSelection {
+        let exactSelection: PacketSourceListSelection
+        switch rowID.group {
+        case .apps:
+            exactSelection = .app(PacketSourceClientKey(rawValue: rowID.key))
+        case .domains:
+            exactSelection = .domain(PacketSourceDomainKey(rawValue: rowID.key, isMissingDomain: false))
+        case .ipv4, .ipv6:
+            exactSelection = .ipAddress(PacketSourceIPAddressKey(rawValue: rowID.key))
+        case .tcp, .udp:
+            return .allPackets
+        }
+
+        if snapshot.sourceListSnapshot.contains(selection: exactSelection) {
+            return exactSelection
+        }
+        return rowID.group == .apps ? .apps : .domains
     }
 
     func clearEndpointStatisticsFilter() {
@@ -3288,7 +3311,7 @@ final class NetworkInspectorViewModel {
                 structuredFilterGroup: activeStructuredFilterGroup,
                 structuredFilterService: structuredFilterService,
                 endpointStatisticsFilter: endpointStatisticsFilter,
-                sourceListSelection: selectedSourceListSelection,
+                sourceListSelection: packetTableSourceListSelection,
                 pinnedItems: pinnedItems,
                 savedRecords: savedRecords,
                 wiresharkFilterMembership: activeWiresharkFilterMembership,
@@ -3368,7 +3391,7 @@ final class NetworkInspectorViewModel {
             quickFilterSelection: quickFilterService.selection,
             structuredFilterGroup: activeStructuredFilterGroup,
             endpointStatisticsFilter: endpointStatisticsFilter,
-            sourceListSelection: selectedSourceListSelection,
+            sourceListSelection: packetTableSourceListSelection,
             pinnedItems: pinnedItems,
             savedRecords: savedRecords,
             wiresharkFilterMembership: isStructuredFilterVisible && filterMode == .wireshark
@@ -3379,6 +3402,11 @@ final class NetworkInspectorViewModel {
             ingestState: controller.snapshot.packetIngestState,
             signature: signature
         )
+    }
+
+    // The endpoint identity is canonical and exact; the sidebar selection only reveals its nearest navigation row.
+    private var packetTableSourceListSelection: PacketSourceListSelection {
+        endpointStatisticsFilter == nil ? selectedSourceListSelection : .allPackets
     }
 
     private func shouldKeepActivePacketTableFilterJob(for input: PacketTableBuildInput) -> Bool {

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
@@ -71,6 +71,22 @@ struct CaptureOverviewChartPoint: Identifiable, Equatable {
         case sent = "Sent"
         case received = "Received"
         case total = "Total"
+
+        var color: Color {
+            switch self {
+            case .sent: .blue
+            case .received: .cyan
+            case .total: .orange
+            }
+        }
+
+        var sortOrder: Int {
+            switch self {
+            case .sent: 0
+            case .received: 1
+            case .total: 2
+            }
+        }
     }
 
     let id: ID
@@ -117,6 +133,59 @@ struct CaptureOverviewProtocolPresentation: Identifiable, Equatable {
     let percentageText: String
     let fraction: Double
     let colorIndex: Int
+}
+
+enum CaptureOverviewChartHoverSelection {
+    static func nearestDate(to date: Date, in points: [CaptureOverviewChartPoint]) -> Date? {
+        points.reduce(nil) { nearestDate, point in
+            guard let nearestDate else {
+                return point.date
+            }
+            let nearestDistance = abs(nearestDate.timeIntervalSince(date))
+            let pointDistance = abs(point.date.timeIntervalSince(date))
+            if pointDistance == nearestDistance {
+                return min(nearestDate, point.date)
+            }
+            return pointDistance < nearestDistance ? point.date : nearestDate
+        }
+    }
+
+    static func protocolRow(
+        at location: CGPoint,
+        in size: CGSize,
+        innerRadiusRatio: CGFloat,
+        rows: [CaptureOverviewProtocolPresentation]
+    ) -> CaptureOverviewProtocolPresentation? {
+        let radius = min(size.width, size.height) / 2
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        let offsetX = location.x - center.x
+        let offsetY = location.y - center.y
+        let distance = hypot(offsetX, offsetY)
+        guard radius > 0,
+              distance >= radius * innerRadiusRatio,
+              distance <= radius else {
+            return nil
+        }
+
+        var clockwiseAngle = atan2(offsetX, -offsetY)
+        if clockwiseAngle < 0 {
+            clockwiseAngle += 2 * .pi
+        }
+        let totalFraction = rows.reduce(0) { $0 + max(0, $1.fraction) }
+        guard totalFraction > 0 else {
+            return nil
+        }
+
+        let targetFraction = clockwiseAngle / (2 * .pi) * totalFraction
+        var accumulatedFraction = 0.0
+        for row in rows {
+            accumulatedFraction += max(0, row.fraction)
+            if targetFraction <= accumulatedFraction {
+                return row
+            }
+        }
+        return rows.last
+    }
 }
 
 struct CaptureOverviewDashboardModel: Equatable {
@@ -533,6 +602,17 @@ private struct CaptureOverviewTrafficChartView: View {
     let sentText: String
     let receivedText: String
 
+    @State private var hoveredDate: Date?
+
+    private var hoveredPoints: [CaptureOverviewChartPoint] {
+        guard let hoveredDate else {
+            return []
+        }
+        return points
+            .filter { $0.date == hoveredDate }
+            .sorted { $0.direction.sortOrder < $1.direction.sortOrder }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .firstTextBaseline) {
@@ -552,30 +632,63 @@ private struct CaptureOverviewTrafficChartView: View {
                 }
             }
 
-            Chart(points) { point in
-                AreaMark(
-                    x: .value("Time", point.date),
-                    y: .value("Bytes", point.bytes),
-                    stacking: .unstacked
-                )
-                .foregroundStyle(by: .value("Direction", point.direction.rawValue))
-                .interpolationMethod(.catmullRom)
-                .opacity(0.1)
+            Chart {
+                ForEach(points) { point in
+                    AreaMark(
+                        x: .value("Time", point.date),
+                        y: .value("Bytes", point.bytes),
+                        stacking: .unstacked
+                    )
+                    .foregroundStyle(by: .value("Direction", point.direction.rawValue))
+                    .interpolationMethod(.catmullRom)
+                    .opacity(0.1)
 
-                LineMark(
-                    x: .value("Time", point.date),
-                    y: .value("Bytes", point.bytes)
-                )
-                .foregroundStyle(by: .value("Direction", point.direction.rawValue))
-                .interpolationMethod(.catmullRom)
-                .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
+                    LineMark(
+                        x: .value("Time", point.date),
+                        y: .value("Bytes", point.bytes)
+                    )
+                    .foregroundStyle(by: .value("Direction", point.direction.rawValue))
+                    .interpolationMethod(.catmullRom)
+                    .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
 
-                PointMark(
-                    x: .value("Time", point.date),
-                    y: .value("Bytes", point.bytes)
-                )
-                .foregroundStyle(by: .value("Direction", point.direction.rawValue))
-                .symbolSize(16)
+                    PointMark(
+                        x: .value("Time", point.date),
+                        y: .value("Bytes", point.bytes)
+                    )
+                    .foregroundStyle(by: .value("Direction", point.direction.rawValue))
+                    .symbolSize(16)
+                }
+
+                if let hoveredDate, !hoveredPoints.isEmpty {
+                    RuleMark(x: .value("Hovered time", hoveredDate))
+                        .foregroundStyle(Color.primary.opacity(0.24))
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                        .annotation(
+                            position: .top,
+                            overflowResolution: .init(x: .fit(to: .chart), y: .disabled)
+                        ) {
+                            CaptureOverviewChartTooltip(
+                                title: hoveredDate.formatted(.dateTime.hour().minute().second()),
+                                rows: hoveredPoints.map {
+                                    CaptureOverviewChartTooltipRow(
+                                        id: $0.direction.rawValue,
+                                        title: $0.direction.rawValue,
+                                        value: CaptureOverviewByteFormatting.string($0.bytes),
+                                        color: $0.direction.color
+                                    )
+                                }
+                            )
+                        }
+
+                    ForEach(hoveredPoints) { point in
+                        PointMark(
+                            x: .value("Hovered time", point.date),
+                            y: .value("Hovered bytes", point.bytes)
+                        )
+                        .foregroundStyle(point.direction.color)
+                        .symbolSize(50)
+                    }
+                }
             }
             .chartForegroundStyleScale([
                 CaptureOverviewChartPoint.Direction.sent.rawValue: Color.blue,
@@ -603,6 +716,37 @@ private struct CaptureOverviewTrafficChartView: View {
             }
             .chartPlotStyle { plotArea in
                 plotArea.background(Color.primary.opacity(0.018))
+            }
+            .chartOverlay { proxy in
+                GeometryReader { geometry in
+                    Rectangle()
+                        .fill(.clear)
+                        .contentShape(Rectangle())
+                        .onContinuousHover { phase in
+                            switch phase {
+                            case let .active(location):
+                                guard let plotFrame = proxy.plotFrame else {
+                                    hoveredDate = nil
+                                    return
+                                }
+                                let plotRect = geometry[plotFrame]
+                                guard plotRect.contains(location),
+                                      let date = proxy.value(
+                                          atX: location.x - plotRect.minX,
+                                          as: Date.self
+                                      ) else {
+                                    hoveredDate = nil
+                                    return
+                                }
+                                hoveredDate = CaptureOverviewChartHoverSelection.nearestDate(
+                                    to: date,
+                                    in: points
+                                )
+                            case .ended:
+                                hoveredDate = nil
+                            }
+                        }
+                }
             }
             .accessibilityLabel(
                 hasDirectionalTraffic ? "Sent and received traffic over time" : "Total traffic over time"
@@ -639,12 +783,21 @@ private struct CaptureOverviewChartLegend: View {
 private struct CaptureOverviewProtocolView: View {
     let rows: [CaptureOverviewProtocolPresentation]
 
+    @State private var hoverState: CaptureOverviewProtocolHoverState?
+
     private var protocolNames: [String] {
         rows.map(\.title)
     }
 
     private var protocolColors: [Color] {
         rows.map { CaptureOverviewPalette.protocolColor(at: $0.colorIndex) }
+    }
+
+    private var hoveredRow: CaptureOverviewProtocolPresentation? {
+        guard let hoverState else {
+            return nil
+        }
+        return rows.first { $0.id == hoverState.rowID }
     }
 
     var body: some View {
@@ -666,9 +819,72 @@ private struct CaptureOverviewProtocolView: View {
                     )
                     .cornerRadius(4)
                     .foregroundStyle(by: .value("Protocol", row.title))
+                    .opacity(hoverState == nil || hoverState?.rowID == row.id ? 1 : 0.42)
                 }
                 .chartForegroundStyleScale(domain: protocolNames, range: protocolColors)
                 .chartLegend(.hidden)
+                .chartOverlay { proxy in
+                    GeometryReader { geometry in
+                        ZStack(alignment: .topLeading) {
+                            Rectangle()
+                                .fill(.clear)
+                                .contentShape(Rectangle())
+                                .onContinuousHover { phase in
+                                    switch phase {
+                                    case let .active(location):
+                                        guard let plotFrame = proxy.plotFrame else {
+                                            hoverState = nil
+                                            return
+                                        }
+                                        let plotRect = geometry[plotFrame]
+                                        let plotLocation = CGPoint(
+                                            x: location.x - plotRect.minX,
+                                            y: location.y - plotRect.minY
+                                        )
+                                        guard plotRect.contains(location),
+                                              let row = CaptureOverviewChartHoverSelection.protocolRow(
+                                                  at: plotLocation,
+                                                  in: plotRect.size,
+                                                  innerRadiusRatio: 0.67,
+                                                  rows: rows
+                                              ) else {
+                                            hoverState = nil
+                                            return
+                                        }
+                                        hoverState = CaptureOverviewProtocolHoverState(
+                                            rowID: row.id,
+                                            location: location
+                                        )
+                                    case .ended:
+                                        hoverState = nil
+                                    }
+                                }
+
+                            if let hoverState, let hoveredRow {
+                                CaptureOverviewChartTooltip(
+                                    title: hoveredRow.title,
+                                    rows: [
+                                        CaptureOverviewChartTooltipRow(
+                                            id: hoveredRow.id,
+                                            title: hoveredRow.percentageText,
+                                            value: hoveredRow.totalText,
+                                            color: CaptureOverviewPalette.protocolColor(
+                                                at: hoveredRow.colorIndex
+                                            )
+                                        ),
+                                    ]
+                                )
+                                .position(
+                                    x: min(max(hoverState.location.x, 48), geometry.size.width - 48),
+                                    y: hoverState.location.y < geometry.size.height / 2
+                                        ? min(geometry.size.height - 24, hoverState.location.y + 34)
+                                        : max(24, hoverState.location.y - 34)
+                                )
+                                .allowsHitTesting(false)
+                            }
+                        }
+                    }
+                }
                 .overlay {
                     VStack(spacing: 2) {
                         Text("\(rows.count)")
@@ -678,6 +894,7 @@ private struct CaptureOverviewProtocolView: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
+                    .allowsHitTesting(false)
                 }
                 .frame(width: 122, height: 122)
                 .accessibilityLabel("Protocol traffic breakdown")
@@ -692,6 +909,54 @@ private struct CaptureOverviewProtocolView: View {
         }
         .frame(maxWidth: .infinity, minHeight: 258, maxHeight: 258, alignment: .topLeading)
         .padding(16)
+    }
+}
+
+private struct CaptureOverviewProtocolHoverState {
+    let rowID: String
+    let location: CGPoint
+}
+
+private struct CaptureOverviewChartTooltipRow: Identifiable {
+    let id: String
+    let title: String
+    let value: String
+    let color: Color
+}
+
+private struct CaptureOverviewChartTooltip: View {
+    let title: String
+    let rows: [CaptureOverviewChartTooltipRow]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(.caption2.weight(.semibold))
+                .monospacedDigit()
+            ForEach(rows) { row in
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(row.color)
+                        .frame(width: 6, height: 6)
+                    Text(row.title)
+                        .foregroundStyle(.secondary)
+                    Text(row.value)
+                        .fontWeight(.semibold)
+                        .monospacedDigit()
+                }
+                .font(.caption2)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+        }
+        .shadow(color: Color.black.opacity(0.14), radius: 4, y: 2)
+        .fixedSize()
+        .accessibilityHidden(true)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
@@ -161,29 +161,58 @@ struct CaptureOverviewDashboardView: View {
         ZStack {
             CaptureOverviewBackgroundView()
             ScrollView {
-                dashboard
-                    .frame(maxWidth: 1_720)
+                CaptureOverviewDashboardContent(
+                    model: model,
+                    onViewPackets: onViewPackets,
+                    onShowEndpoints: onShowEndpoints,
+                    onSelectTrafficRow: onSelectTrafficRow
+                )
+                    .frame(maxWidth: 1_900)
                     .frame(maxWidth: .infinity)
-                    .padding(.horizontal, 28)
-                    .padding(.top, 24)
-                    .padding(.bottom, 36)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 16)
+                    .padding(.bottom, 24)
             }
         }
     }
+}
+
+private struct CaptureOverviewDashboardContent: View {
+    let model: CaptureOverviewDashboardModel
+    let onViewPackets: () -> Void
+    let onShowEndpoints: () -> Void
+    let onSelectTrafficRow: (PacketSourceListSelection) -> Void
 
     @ViewBuilder
-    private var dashboard: some View {
+    var body: some View {
         if #available(macOS 26.0, *) {
-            GlassEffectContainer(spacing: 18) {
-                content
+            GlassEffectContainer(spacing: 12) {
+                CaptureOverviewSections(
+                    model: model,
+                    onViewPackets: onViewPackets,
+                    onShowEndpoints: onShowEndpoints,
+                    onSelectTrafficRow: onSelectTrafficRow
+                )
             }
         } else {
-            content
+            CaptureOverviewSections(
+                model: model,
+                onViewPackets: onViewPackets,
+                onShowEndpoints: onShowEndpoints,
+                onSelectTrafficRow: onSelectTrafficRow
+            )
         }
     }
+}
 
-    private var content: some View {
-        VStack(spacing: 18) {
+private struct CaptureOverviewSections: View {
+    let model: CaptureOverviewDashboardModel
+    let onViewPackets: () -> Void
+    let onShowEndpoints: () -> Void
+    let onSelectTrafficRow: (PacketSourceListSelection) -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
             CaptureOverviewHeaderView(
                 title: model.title,
                 subtitle: model.subtitle,
@@ -216,21 +245,19 @@ struct CaptureOverviewDashboardView: View {
 }
 
 private struct CaptureOverviewBackgroundView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         Color(nsColor: .windowBackgroundColor)
-            .overlay(alignment: .topLeading) {
-                Circle()
-                    .fill(Color.orange.opacity(0.11))
-                    .frame(width: 620, height: 620)
-                    .blur(radius: 150)
-                    .offset(x: -220, y: -300)
-            }
-            .overlay(alignment: .bottomTrailing) {
-                Circle()
-                    .fill(Color.cyan.opacity(0.08))
-                    .frame(width: 720, height: 720)
-                    .blur(radius: 170)
-                    .offset(x: 260, y: 320)
+            .overlay {
+                LinearGradient(
+                    colors: [
+                        Color.accentColor.opacity(colorScheme == .dark ? 0.035 : 0.02),
+                        .clear,
+                    ],
+                    startPoint: .top,
+                    endPoint: .center
+                )
             }
             .ignoresSafeArea()
     }
@@ -246,19 +273,19 @@ private struct CaptureOverviewHeaderView: View {
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
-            HStack(spacing: 20) {
-                identity
-                Spacer(minLength: 24)
+            HStack(spacing: 14) {
+                CaptureOverviewHeaderIdentity(title: title, subtitle: subtitle, status: status)
+                Spacer(minLength: 20)
                 CaptureOverviewHeaderActions(
                     hasTraffic: hasTraffic,
                     onViewPackets: onViewPackets,
                     onShowEndpoints: onShowEndpoints
                 )
             }
-            .frame(minWidth: 700)
+            .frame(minWidth: 640)
 
-            VStack(alignment: .leading, spacing: 18) {
-                identity
+            VStack(alignment: .leading, spacing: 12) {
+                CaptureOverviewHeaderIdentity(title: title, subtitle: subtitle, status: status)
                 CaptureOverviewHeaderActions(
                     hasTraffic: hasTraffic,
                     onViewPackets: onViewPackets,
@@ -266,37 +293,55 @@ private struct CaptureOverviewHeaderView: View {
                 )
             }
         }
-        .padding(22)
-        .captureOverviewSurface(tint: .orange)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
     }
+}
 
-    private var identity: some View {
-        HStack(spacing: 16) {
-            Image(systemName: "chart.xyaxis.line")
-                .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(.orange)
-                .frame(width: 54, height: 54)
-                .background(Color.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .strokeBorder(Color.orange.opacity(0.24), lineWidth: 1)
-                }
-                .accessibilityHidden(true)
+private struct CaptureOverviewHeaderIdentity: View {
+    let title: String
+    let subtitle: String
+    let status: CaptureOverviewStatusPresentation
 
-            VStack(alignment: .leading, spacing: 5) {
-                HStack(spacing: 10) {
+    var body: some View {
+        HStack(spacing: 12) {
+            CaptureOverviewHeaderIcon()
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
                     Text(title)
-                        .font(.title2.weight(.semibold))
+                        .font(.headline)
                         .lineLimit(1)
                     CaptureOverviewStatusPill(status: status)
                 }
                 Text(subtitle)
-                    .font(.subheadline)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
         }
         .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CaptureOverviewHeaderIcon: View {
+    @ViewBuilder
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            icon
+                .glassEffect(.regular.tint(.orange.opacity(0.12)), in: .rect(cornerRadius: 10))
+        } else {
+            icon
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+    }
+
+    private var icon: some View {
+        Image(systemName: "chart.xyaxis.line")
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(.orange)
+            .frame(width: 38, height: 38)
+            .accessibilityHidden(true)
     }
 }
 
@@ -307,17 +352,14 @@ private struct CaptureOverviewStatusPill: View {
         HStack(spacing: 6) {
             Circle()
                 .fill(status.tone.color)
-                .frame(width: 7, height: 7)
+                .frame(width: 6, height: 6)
             Text(status.title)
-                .font(.caption.weight(.semibold))
+                .font(.caption2.weight(.semibold))
         }
         .foregroundStyle(status.tone.color)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
         .background(status.tone.color.opacity(0.12), in: Capsule())
-        .overlay {
-            Capsule().strokeBorder(status.tone.color.opacity(0.2), lineWidth: 1)
-        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Capture status, \(status.title)")
     }
@@ -331,7 +373,7 @@ private struct CaptureOverviewHeaderActions: View {
     @ViewBuilder
     var body: some View {
         if #available(macOS 26.0, *) {
-            HStack(spacing: 10) {
+            HStack(spacing: 8) {
                 Button(action: onViewPackets) {
                     Label("View Packets", systemImage: "list.bullet.rectangle")
                 }
@@ -342,9 +384,9 @@ private struct CaptureOverviewHeaderActions: View {
                 .buttonStyle(.glass)
                 .disabled(!hasTraffic)
             }
-            .controlSize(.large)
+            .controlSize(.regular)
         } else {
-            HStack(spacing: 10) {
+            HStack(spacing: 8) {
                 Button(action: onViewPackets) {
                     Label("View Packets", systemImage: "list.bullet.rectangle")
                 }
@@ -355,7 +397,7 @@ private struct CaptureOverviewHeaderActions: View {
                 .buttonStyle(.bordered)
                 .disabled(!hasTraffic)
             }
-            .controlSize(.large)
+            .controlSize(.regular)
         }
     }
 }
@@ -365,65 +407,78 @@ private struct CaptureOverviewMetricsView: View {
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
-            HStack(spacing: 14) {
-                cards
-            }
-            .frame(minWidth: 1_080)
-
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(minimum: 160), spacing: 14), count: 3),
-                spacing: 14
-            ) {
-                cards
-            }
-
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(minimum: 150), spacing: 14), count: 2),
-                spacing: 14
-            ) {
-                cards
-            }
+            CaptureOverviewMetricStrip(metrics: metrics)
+                .frame(minWidth: 1_020)
+            CaptureOverviewMetricGrid(metrics: metrics, columnCount: 3)
+            CaptureOverviewMetricGrid(metrics: metrics, columnCount: 2)
         }
+        .padding(.vertical, 4)
+        .captureOverviewPanel()
     }
+}
 
-    private var cards: some View {
-        ForEach(metrics) { metric in
-            CaptureOverviewMetricCard(metric: metric)
-                .frame(maxWidth: .infinity)
+private struct CaptureOverviewMetricStrip: View {
+    let metrics: [CaptureOverviewMetricPresentation]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(metrics) { metric in
+                CaptureOverviewMetricCell(metric: metric)
+                    .overlay(alignment: .trailing) {
+                        if metric.id != metrics.last?.id {
+                            Divider()
+                                .padding(.vertical, 10)
+                        }
+                    }
+            }
         }
     }
 }
 
-private struct CaptureOverviewMetricCard: View {
+private struct CaptureOverviewMetricGrid: View {
+    let metrics: [CaptureOverviewMetricPresentation]
+    let columnCount: Int
+
+    var body: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(minimum: 150), spacing: 0), count: columnCount),
+            spacing: 0
+        ) {
+            ForEach(metrics) { metric in
+                CaptureOverviewMetricCell(metric: metric)
+            }
+        }
+    }
+}
+
+private struct CaptureOverviewMetricCell: View {
     let metric: CaptureOverviewMetricPresentation
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 13) {
-            HStack {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
                 Image(systemName: metric.symbol)
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(metric.tone.color)
-                    .frame(width: 30, height: 30)
-                    .background(metric.tone.color.opacity(0.14), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
                     .accessibilityHidden(true)
                 Text(metric.title)
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.secondary)
             }
             Text(metric.value)
-                .font(.title3.weight(.semibold))
+                .font(.headline)
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
             Text(metric.detail)
-                .font(.caption)
+                .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
         }
-        .frame(maxWidth: .infinity, minHeight: 92, alignment: .leading)
-        .padding(16)
-        .captureOverviewSurface(tint: metric.tone.color)
+        .frame(maxWidth: .infinity, minHeight: 66, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
         .accessibilityElement(children: .combine)
     }
 }
@@ -438,7 +493,7 @@ private struct CaptureOverviewPrimaryDataView: View {
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
-            HStack(alignment: .top, spacing: 18) {
+            HStack(alignment: .top, spacing: 0) {
                 CaptureOverviewTrafficChartView(
                     points: trafficPoints,
                     hasDirectionalTraffic: hasDirectionalTraffic,
@@ -447,12 +502,14 @@ private struct CaptureOverviewPrimaryDataView: View {
                     receivedText: receivedText
                 )
                 .frame(maxWidth: .infinity)
+                Divider()
+                    .padding(.vertical, 16)
                 CaptureOverviewProtocolView(rows: protocols)
-                    .frame(width: 410)
+                    .frame(width: 370)
             }
-            .frame(minWidth: 1_040)
+            .frame(minWidth: 980)
 
-            VStack(spacing: 18) {
+            VStack(spacing: 0) {
                 CaptureOverviewTrafficChartView(
                     points: trafficPoints,
                     hasDirectionalTraffic: hasDirectionalTraffic,
@@ -460,9 +517,12 @@ private struct CaptureOverviewPrimaryDataView: View {
                     sentText: sentText,
                     receivedText: receivedText
                 )
+                Divider()
+                    .padding(.horizontal, 16)
                 CaptureOverviewProtocolView(rows: protocols)
             }
         }
+        .captureOverviewPanel()
     }
 }
 
@@ -474,7 +534,7 @@ private struct CaptureOverviewTrafficChartView: View {
     let receivedText: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Traffic over time")
@@ -542,15 +602,14 @@ private struct CaptureOverviewTrafficChartView: View {
                 }
             }
             .chartPlotStyle { plotArea in
-                plotArea.background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                plotArea.background(Color.primary.opacity(0.018))
             }
             .accessibilityLabel(
                 hasDirectionalTraffic ? "Sent and received traffic over time" : "Total traffic over time"
             )
         }
-        .frame(maxWidth: .infinity, minHeight: 292, maxHeight: 292, alignment: .topLeading)
-        .padding(20)
-        .captureOverviewSurface(tint: .blue)
+        .frame(maxWidth: .infinity, minHeight: 258, maxHeight: 258, alignment: .topLeading)
+        .padding(16)
     }
 }
 
@@ -589,7 +648,7 @@ private struct CaptureOverviewProtocolView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Protocols")
                     .font(.headline)
@@ -598,7 +657,7 @@ private struct CaptureOverviewProtocolView: View {
                     .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: 18) {
+            HStack(spacing: 14) {
                 Chart(rows) { row in
                     SectorMark(
                         angle: .value("Bytes", row.fraction),
@@ -620,10 +679,10 @@ private struct CaptureOverviewProtocolView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .frame(width: 142, height: 142)
+                .frame(width: 122, height: 122)
                 .accessibilityLabel("Protocol traffic breakdown")
 
-                VStack(spacing: 11) {
+                VStack(spacing: 9) {
                     ForEach(rows) { row in
                         CaptureOverviewProtocolLegendRow(row: row)
                     }
@@ -631,9 +690,8 @@ private struct CaptureOverviewProtocolView: View {
                 .frame(maxWidth: .infinity)
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 292, maxHeight: 292, alignment: .topLeading)
-        .padding(20)
-        .captureOverviewSurface(tint: .purple)
+        .frame(maxWidth: .infinity, minHeight: 258, maxHeight: 258, alignment: .topLeading)
+        .padding(16)
     }
 }
 
@@ -683,19 +741,19 @@ private struct CaptureOverviewTopTrafficView: View {
             HStack(alignment: .top, spacing: 0) {
                 appRanking
                 Divider()
-                    .padding(.horizontal, 20)
+                    .padding(.horizontal, 16)
                 destinationRanking
             }
             .frame(minWidth: 900)
 
-            VStack(spacing: 20) {
+            VStack(spacing: 16) {
                 appRanking
                 Divider()
                 destinationRanking
             }
         }
-        .padding(20)
-        .captureOverviewSurface(tint: .orange)
+        .padding(16)
+        .captureOverviewPanel()
     }
 
     private var appRanking: some View {
@@ -741,7 +799,7 @@ private struct CaptureOverviewTrafficRankingView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            .padding(.bottom, 10)
+            .padding(.bottom, 8)
 
             if rows.isEmpty {
                 VStack(spacing: 10) {
@@ -756,7 +814,7 @@ private struct CaptureOverviewTrafficRankingView: View {
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                 }
-                .frame(maxWidth: .infinity, minHeight: 220)
+                .frame(maxWidth: .infinity, minHeight: 180)
                 .accessibilityElement(children: .combine)
             } else {
                 VStack(spacing: 0) {
@@ -819,9 +877,9 @@ private struct CaptureOverviewCompactTrafficRow: View {
                 )
             }
         }
-        .padding(.vertical, 7)
+        .padding(.vertical, 5)
         .padding(.horizontal, 4)
-        .frame(maxWidth: .infinity, minHeight: 43, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 39, alignment: .leading)
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(Color.primary.opacity(0.07))
@@ -864,9 +922,10 @@ private struct CaptureOverviewStackedTrafficBar: View {
 private struct CaptureOverviewTrafficRowButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .opacity(configuration.isPressed ? 0.78 : 1)
-            .scaleEffect(configuration.isPressed ? 0.992 : 1)
-            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .background(
+                configuration.isPressed ? Color.primary.opacity(0.06) : .clear,
+                in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+            )
     }
 }
 
@@ -877,46 +936,36 @@ private struct CaptureOverviewEmptyStateView: View {
             systemImage: "waveform.path.ecg",
             description: Text("Start a capture or open a capture file. This overview will fill in as packets arrive.")
         )
-        .frame(maxWidth: .infinity, minHeight: 360)
-        .captureOverviewSurface(tint: .orange)
+        .frame(maxWidth: .infinity, minHeight: 280)
+        .captureOverviewPanel()
     }
 }
 
-private struct CaptureOverviewSurfaceModifier: ViewModifier {
+private struct CaptureOverviewPanelModifier: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
-
-    let tint: Color
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        let shape = RoundedRectangle(cornerRadius: 22, style: .continuous)
+        let shape = RoundedRectangle(cornerRadius: 14, style: .continuous)
         if #available(macOS 26.0, *) {
             content
-                .background(tint.opacity(colorScheme == .dark ? 0.055 : 0.035), in: shape)
-                .overlay {
-                    shape.strokeBorder(
-                        colorScheme == .dark ? Color.white.opacity(0.13) : Color.black.opacity(0.09),
-                        lineWidth: 1
-                    )
-                }
-                .glassEffect(.regular.tint(tint.opacity(0.045)), in: .rect(cornerRadius: 22))
+                .background(
+                    Color(nsColor: .controlBackgroundColor)
+                        .opacity(colorScheme == .dark ? 0.24 : 0.42),
+                    in: shape
+                )
+                .glassEffect(.regular, in: .rect(cornerRadius: 14))
         } else {
             content
                 .background(.regularMaterial, in: shape)
-                .overlay {
-                    shape.strokeBorder(
-                        colorScheme == .dark ? Color.white.opacity(0.13) : Color.black.opacity(0.09),
-                        lineWidth: 1
-                    )
-                }
-                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.16 : 0.07), radius: 16, y: 6)
+                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.12 : 0.05), radius: 8, y: 2)
         }
     }
 }
 
 private extension View {
-    func captureOverviewSurface(tint: Color) -> some View {
-        modifier(CaptureOverviewSurfaceModifier(tint: tint))
+    func captureOverviewPanel() -> some View {
+        modifier(CaptureOverviewPanelModifier())
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
@@ -119,12 +119,6 @@ struct CaptureOverviewProtocolPresentation: Identifiable, Equatable {
     let colorIndex: Int
 }
 
-struct CaptureOverviewDetailPresentation: Identifiable, Equatable {
-    let id: String
-    let label: String
-    let value: String
-}
-
 struct CaptureOverviewDashboardModel: Equatable {
     let title: String
     let subtitle: String
@@ -139,9 +133,6 @@ struct CaptureOverviewDashboardModel: Equatable {
     let topApps: [CaptureOverviewTopTrafficPresentation]
     let topDestinations: [CaptureOverviewTopTrafficPresentation]
     let protocolRows: [CaptureOverviewProtocolPresentation]
-    let warningText: String?
-    let details: [CaptureOverviewDetailPresentation]
-    let isDetailsExpanded: Bool
 
     static let empty = CaptureOverviewDashboardModel(
         title: "Capture overview",
@@ -156,10 +147,7 @@ struct CaptureOverviewDashboardModel: Equatable {
         receivedText: "0 bytes",
         topApps: [],
         topDestinations: [],
-        protocolRows: [],
-        warningText: nil,
-        details: [],
-        isDetailsExpanded: false
+        protocolRows: []
     )
 }
 
@@ -168,7 +156,6 @@ struct CaptureOverviewDashboardView: View {
     let onViewPackets: () -> Void
     let onShowEndpoints: () -> Void
     let onSelectTrafficRow: (PacketSourceListSelection) -> Void
-    let onToggleDetails: () -> Void
 
     var body: some View {
         ZStack {
@@ -224,16 +211,6 @@ struct CaptureOverviewDashboardView: View {
             } else {
                 CaptureOverviewEmptyStateView()
             }
-
-            if let warningText = model.warningText {
-                CaptureOverviewWarningView(text: warningText)
-            }
-
-            CaptureOverviewDetailsView(
-                details: model.details,
-                isExpanded: model.isDetailsExpanded,
-                onToggle: onToggleDetails
-            )
         }
     }
 }
@@ -902,78 +879,6 @@ private struct CaptureOverviewEmptyStateView: View {
         )
         .frame(maxWidth: .infinity, minHeight: 360)
         .captureOverviewSurface(tint: .orange)
-    }
-}
-
-private struct CaptureOverviewWarningView: View {
-    let text: String
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-                .accessibilityHidden(true)
-            Text(text)
-                .font(.subheadline.weight(.medium))
-            Spacer()
-        }
-        .padding(16)
-        .captureOverviewSurface(tint: .orange)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Capture warning, \(text)")
-    }
-}
-
-private struct CaptureOverviewDetailsView: View {
-    let details: [CaptureOverviewDetailPresentation]
-    let isExpanded: Bool
-    let onToggle: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Button(action: onToggle) {
-                HStack(spacing: 9) {
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    Text("Capture details")
-                        .font(.subheadline.weight(.semibold))
-                    Spacer()
-                    Text("\(details.count) items")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-
-            if isExpanded {
-                Divider()
-                LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 250), spacing: 12)],
-                    alignment: .leading,
-                    spacing: 12
-                ) {
-                    ForEach(details) { detail in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(detail.label)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(detail.value)
-                                .font(.callout.weight(.medium))
-                                .textSelection(.enabled)
-                                .lineLimit(2)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(12)
-                        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    }
-                }
-            }
-        }
-        .padding(16)
-        .captureOverviewSurface(tint: .secondary)
-        .animation(.easeInOut(duration: 0.18), value: isExpanded)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
@@ -81,6 +81,7 @@ struct CaptureOverviewChartPoint: Identifiable, Equatable {
 
 struct CaptureOverviewTopTrafficPresentation: Identifiable, Equatable {
     let id: String
+    let rank: Int
     let title: String
     let icon: NSImage
     let iconFilePath: String?
@@ -95,6 +96,7 @@ struct CaptureOverviewTopTrafficPresentation: Identifiable, Equatable {
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id &&
+            lhs.rank == rhs.rank &&
             lhs.title == rhs.title &&
             lhs.iconFilePath == rhs.iconFilePath &&
             lhs.selection == rhs.selection &&
@@ -134,8 +136,8 @@ struct CaptureOverviewDashboardModel: Equatable {
     let totalText: String
     let sentText: String
     let receivedText: String
-    let selectedTopGroup: CaptureOverviewTopGroup
-    let topRows: [CaptureOverviewTopTrafficPresentation]
+    let topApps: [CaptureOverviewTopTrafficPresentation]
+    let topDestinations: [CaptureOverviewTopTrafficPresentation]
     let protocolRows: [CaptureOverviewProtocolPresentation]
     let warningText: String?
     let details: [CaptureOverviewDetailPresentation]
@@ -152,8 +154,8 @@ struct CaptureOverviewDashboardModel: Equatable {
         totalText: "0 bytes",
         sentText: "0 bytes",
         receivedText: "0 bytes",
-        selectedTopGroup: .apps,
-        topRows: [],
+        topApps: [],
+        topDestinations: [],
         protocolRows: [],
         warningText: nil,
         details: [],
@@ -165,7 +167,6 @@ struct CaptureOverviewDashboardView: View {
     let model: CaptureOverviewDashboardModel
     let onViewPackets: () -> Void
     let onShowEndpoints: () -> Void
-    let onSelectTopGroup: (CaptureOverviewTopGroup) -> Void
     let onSelectTrafficRow: (PacketSourceListSelection) -> Void
     let onToggleDetails: () -> Void
 
@@ -216,9 +217,8 @@ struct CaptureOverviewDashboardView: View {
                     protocols: model.protocolRows
                 )
                 CaptureOverviewTopTrafficView(
-                    selectedGroup: model.selectedTopGroup,
-                    rows: model.topRows,
-                    onSelectGroup: onSelectTopGroup,
+                    apps: model.topApps,
+                    destinations: model.topDestinations,
                     onSelectRow: onSelectTrafficRow
                 )
             } else {
@@ -697,129 +697,142 @@ private struct CaptureOverviewProtocolLegendRow: View {
 }
 
 private struct CaptureOverviewTopTrafficView: View {
-    let selectedGroup: CaptureOverviewTopGroup
-    let rows: [CaptureOverviewTopTrafficPresentation]
-    let onSelectGroup: (CaptureOverviewTopGroup) -> Void
+    let apps: [CaptureOverviewTopTrafficPresentation]
+    let destinations: [CaptureOverviewTopTrafficPresentation]
     let onSelectRow: (PacketSourceListSelection) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Top traffic")
-                        .font(.headline)
-                    Text("Ranked by total bytes across the capture")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                CaptureOverviewSegmentedControl(selection: selectedGroup, onSelect: onSelectGroup)
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 0) {
+                appRanking
+                Divider()
+                    .padding(.horizontal, 20)
+                destinationRanking
             }
+            .frame(minWidth: 900)
 
-            if rows.isEmpty {
-                ContentUnavailableView(
-                    selectedGroup == .apps ? "No app traffic" : "No resolved domains",
-                    systemImage: selectedGroup == .apps ? "app.dashed" : "globe.desk",
-                    description: Text(
-                        selectedGroup == .apps
-                            ? "App attribution will appear when TCP Viewer can identify the local process."
-                            : "Resolved domains will appear as packet metadata becomes available."
-                    )
-                )
-                .frame(minHeight: 210)
-            } else {
-                ViewThatFits(in: .horizontal) {
-                    CaptureOverviewTopTrafficGrid(rows: rows, columnCount: 2, onSelect: onSelectRow)
-                        .frame(minWidth: 880)
-                    CaptureOverviewTopTrafficGrid(rows: rows, columnCount: 1, onSelect: onSelectRow)
-                }
+            VStack(spacing: 20) {
+                appRanking
+                Divider()
+                destinationRanking
             }
         }
         .padding(20)
         .captureOverviewSurface(tint: .orange)
     }
-}
 
-private struct CaptureOverviewSegmentedControl: View {
-    let selection: CaptureOverviewTopGroup
-    let onSelect: (CaptureOverviewTopGroup) -> Void
+    private var appRanking: some View {
+        CaptureOverviewTrafficRankingView(
+            title: "Top apps",
+            subtitle: "Top 10 by total traffic",
+            emptyTitle: "No app traffic",
+            emptyDescription: "Apps appear when TCP Viewer identifies the local process.",
+            emptySymbol: "app.dashed",
+            rows: apps,
+            onSelect: onSelectRow
+        )
+    }
 
-    var body: some View {
-        HStack(spacing: 3) {
-            ForEach(CaptureOverviewTopGroup.allCases, id: \.rawValue) { group in
-                Button(group.title) {
-                    onSelect(group)
-                }
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(selection == group ? Color.white : Color.secondary)
-                .padding(.horizontal, 13)
-                .padding(.vertical, 7)
-                .background(selection == group ? Color.orange : Color.clear, in: Capsule())
-                .buttonStyle(.plain)
-                .accessibilityAddTraits(selection == group ? .isSelected : [])
-            }
-        }
-        .padding(3)
-        .background(Color.primary.opacity(0.06), in: Capsule())
-        .overlay {
-            Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Top traffic category")
+    private var destinationRanking: some View {
+        CaptureOverviewTrafficRankingView(
+            title: "Top domains & IPs",
+            subtitle: "Top 10 by total traffic",
+            emptyTitle: "No domains or IP addresses",
+            emptyDescription: "Destinations appear as traffic is captured.",
+            emptySymbol: "globe.desk",
+            rows: destinations,
+            onSelect: onSelectRow
+        )
     }
 }
 
-private struct CaptureOverviewTopTrafficGrid: View {
+private struct CaptureOverviewTrafficRankingView: View {
+    let title: String
+    let subtitle: String
+    let emptyTitle: String
+    let emptyDescription: String
+    let emptySymbol: String
     let rows: [CaptureOverviewTopTrafficPresentation]
-    let columnCount: Int
     let onSelect: (PacketSourceListSelection) -> Void
 
     var body: some View {
-        LazyVGrid(
-            columns: Array(repeating: GridItem(.flexible(minimum: 360), spacing: 12), count: columnCount),
-            spacing: 12
-        ) {
-            ForEach(rows) { row in
-                Button {
-                    onSelect(row.selection)
-                } label: {
-                    CaptureOverviewTopTrafficRow(row: row)
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.bottom, 10)
+
+            if rows.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: emptySymbol)
+                        .font(.title2)
+                        .foregroundStyle(.tertiary)
+                        .accessibilityHidden(true)
+                    Text(emptyTitle)
+                        .font(.subheadline.weight(.semibold))
+                    Text(emptyDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
                 }
-                .buttonStyle(CaptureOverviewTrafficRowButtonStyle())
-                .accessibilityLabel("\(row.title), \(row.totalText), \(row.percentageText) of capture")
-                .accessibilityHint("Shows matching packets in the main table")
+                .frame(maxWidth: .infinity, minHeight: 220)
+                .accessibilityElement(children: .combine)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(rows) { row in
+                        Button {
+                            onSelect(row.selection)
+                        } label: {
+                            CaptureOverviewCompactTrafficRow(row: row)
+                        }
+                        .buttonStyle(CaptureOverviewTrafficRowButtonStyle())
+                        .accessibilityLabel(
+                            "Number \(row.rank), \(row.title), \(row.totalText), \(row.percentageText) of capture"
+                        )
+                        .accessibilityHint("Shows matching packets in the main table")
+                    }
+                }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 
-private struct CaptureOverviewTopTrafficRow: View {
+private struct CaptureOverviewCompactTrafficRow: View {
     let row: CaptureOverviewTopTrafficPresentation
 
     var body: some View {
-        HStack(spacing: 13) {
+        HStack(spacing: 10) {
+            Text("\(row.rank)")
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+                .frame(width: 18, alignment: .trailing)
+
             Image(nsImage: row.icon)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(width: 32, height: 32)
-                .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                .frame(width: 24, height: 24)
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 5) {
                 HStack(alignment: .firstTextBaseline) {
                     Text(row.title)
-                        .font(.subheadline.weight(.semibold))
+                        .font(.caption.weight(.semibold))
                         .lineLimit(1)
+                    Spacer(minLength: 8)
+                    Text(row.totalText)
+                        .font(.caption.weight(.semibold))
+                        .monospacedDigit()
                     Text(row.percentageText)
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.orange)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 2)
-                        .background(Color.orange.opacity(0.12), in: Capsule())
-                    Spacer(minLength: 8)
-                    Text(row.totalText)
-                        .font(.subheadline.weight(.semibold))
                         .monospacedDigit()
+                        .frame(minWidth: 30, alignment: .trailing)
                 }
 
                 CaptureOverviewStackedTrafficBar(
@@ -827,25 +840,17 @@ private struct CaptureOverviewTopTrafficRow: View {
                     receivedFraction: row.receivedFraction,
                     unknownFraction: row.unknownFraction
                 )
-
-                HStack(spacing: 14) {
-                    Label(row.sentText, systemImage: "arrow.up.right")
-                        .foregroundStyle(.blue)
-                    Label(row.receivedText, systemImage: "arrow.down.left")
-                        .foregroundStyle(.cyan)
-                }
-                .font(.caption2.weight(.medium))
-                .monospacedDigit()
             }
         }
-        .padding(13)
-        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
-        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 15, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 15, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.075), lineWidth: 1)
+        .padding(.vertical, 7)
+        .padding(.horizontal, 4)
+        .frame(maxWidth: .infinity, minHeight: 43, alignment: .leading)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.primary.opacity(0.07))
+                .frame(height: 1)
         }
-        .contentShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+        .contentShape(Rectangle())
     }
 }
 
@@ -874,7 +879,7 @@ private struct CaptureOverviewStackedTrafficBar: View {
                 .compositingGroup()
                 .clipShape(Capsule())
         }
-        .frame(height: 6)
+        .frame(height: 4)
         .accessibilityHidden(true)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewDashboardView.swift
@@ -1,0 +1,1044 @@
+//
+//  CaptureOverviewDashboardView.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/9/26.
+//
+
+import AppKit
+import Charts
+import SwiftUI
+
+enum CaptureOverviewVisualTone: Equatable {
+    case orange
+    case blue
+    case cyan
+    case green
+    case indigo
+    case purple
+
+    var color: Color {
+        switch self {
+        case .orange: .orange
+        case .blue: .blue
+        case .cyan: .cyan
+        case .green: .green
+        case .indigo: .indigo
+        case .purple: .purple
+        }
+    }
+}
+
+enum CaptureOverviewStatusTone: Equatable {
+    case active
+    case positive
+    case attention
+    case error
+    case neutral
+
+    var color: Color {
+        switch self {
+        case .active: .blue
+        case .positive: .green
+        case .attention: .orange
+        case .error: .red
+        case .neutral: .secondary
+        }
+    }
+}
+
+struct CaptureOverviewStatusPresentation: Equatable {
+    let title: String
+    let tone: CaptureOverviewStatusTone
+}
+
+struct CaptureOverviewMetricPresentation: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: String
+    let detail: String
+    let symbol: String
+    let tone: CaptureOverviewVisualTone
+}
+
+struct CaptureOverviewChartPoint: Identifiable, Equatable {
+    struct ID: Hashable {
+        let date: Date
+        let direction: Direction
+    }
+
+    enum Direction: String, Hashable {
+        case sent = "Sent"
+        case received = "Received"
+        case total = "Total"
+    }
+
+    let id: ID
+    let date: Date
+    let direction: Direction
+    let bytes: Double
+}
+
+struct CaptureOverviewTopTrafficPresentation: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let icon: NSImage
+    let iconFilePath: String?
+    let selection: PacketSourceListSelection
+    let totalText: String
+    let sentText: String
+    let receivedText: String
+    let percentageText: String
+    let sentFraction: Double
+    let receivedFraction: Double
+    let unknownFraction: Double
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.iconFilePath == rhs.iconFilePath &&
+            lhs.selection == rhs.selection &&
+            lhs.totalText == rhs.totalText &&
+            lhs.sentText == rhs.sentText &&
+            lhs.receivedText == rhs.receivedText &&
+            lhs.percentageText == rhs.percentageText &&
+            lhs.sentFraction == rhs.sentFraction &&
+            lhs.receivedFraction == rhs.receivedFraction &&
+            lhs.unknownFraction == rhs.unknownFraction
+    }
+}
+
+struct CaptureOverviewProtocolPresentation: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let totalText: String
+    let percentageText: String
+    let fraction: Double
+    let colorIndex: Int
+}
+
+struct CaptureOverviewDetailPresentation: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let value: String
+}
+
+struct CaptureOverviewDashboardModel: Equatable {
+    let title: String
+    let subtitle: String
+    let status: CaptureOverviewStatusPresentation
+    let metrics: [CaptureOverviewMetricPresentation]
+    let hasTraffic: Bool
+    let hasDirectionalTraffic: Bool
+    let trafficPoints: [CaptureOverviewChartPoint]
+    let totalText: String
+    let sentText: String
+    let receivedText: String
+    let selectedTopGroup: CaptureOverviewTopGroup
+    let topRows: [CaptureOverviewTopTrafficPresentation]
+    let protocolRows: [CaptureOverviewProtocolPresentation]
+    let warningText: String?
+    let details: [CaptureOverviewDetailPresentation]
+    let isDetailsExpanded: Bool
+
+    static let empty = CaptureOverviewDashboardModel(
+        title: "Capture overview",
+        subtitle: "No capture source selected",
+        status: CaptureOverviewStatusPresentation(title: "Ready", tone: .neutral),
+        metrics: [],
+        hasTraffic: false,
+        hasDirectionalTraffic: false,
+        trafficPoints: [],
+        totalText: "0 bytes",
+        sentText: "0 bytes",
+        receivedText: "0 bytes",
+        selectedTopGroup: .apps,
+        topRows: [],
+        protocolRows: [],
+        warningText: nil,
+        details: [],
+        isDetailsExpanded: false
+    )
+}
+
+struct CaptureOverviewDashboardView: View {
+    let model: CaptureOverviewDashboardModel
+    let onViewPackets: () -> Void
+    let onShowEndpoints: () -> Void
+    let onSelectTopGroup: (CaptureOverviewTopGroup) -> Void
+    let onSelectTrafficRow: (PacketSourceListSelection) -> Void
+    let onToggleDetails: () -> Void
+
+    var body: some View {
+        ZStack {
+            CaptureOverviewBackgroundView()
+            ScrollView {
+                dashboard
+                    .frame(maxWidth: 1_720)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 24)
+                    .padding(.bottom, 36)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dashboard: some View {
+        if #available(macOS 26.0, *) {
+            GlassEffectContainer(spacing: 18) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
+        VStack(spacing: 18) {
+            CaptureOverviewHeaderView(
+                title: model.title,
+                subtitle: model.subtitle,
+                status: model.status,
+                hasTraffic: model.hasTraffic,
+                onViewPackets: onViewPackets,
+                onShowEndpoints: onShowEndpoints
+            )
+
+            if model.hasTraffic {
+                CaptureOverviewMetricsView(metrics: model.metrics)
+                CaptureOverviewPrimaryDataView(
+                    trafficPoints: model.trafficPoints,
+                    hasDirectionalTraffic: model.hasDirectionalTraffic,
+                    totalText: model.totalText,
+                    sentText: model.sentText,
+                    receivedText: model.receivedText,
+                    protocols: model.protocolRows
+                )
+                CaptureOverviewTopTrafficView(
+                    selectedGroup: model.selectedTopGroup,
+                    rows: model.topRows,
+                    onSelectGroup: onSelectTopGroup,
+                    onSelectRow: onSelectTrafficRow
+                )
+            } else {
+                CaptureOverviewEmptyStateView()
+            }
+
+            if let warningText = model.warningText {
+                CaptureOverviewWarningView(text: warningText)
+            }
+
+            CaptureOverviewDetailsView(
+                details: model.details,
+                isExpanded: model.isDetailsExpanded,
+                onToggle: onToggleDetails
+            )
+        }
+    }
+}
+
+private struct CaptureOverviewBackgroundView: View {
+    var body: some View {
+        Color(nsColor: .windowBackgroundColor)
+            .overlay(alignment: .topLeading) {
+                Circle()
+                    .fill(Color.orange.opacity(0.11))
+                    .frame(width: 620, height: 620)
+                    .blur(radius: 150)
+                    .offset(x: -220, y: -300)
+            }
+            .overlay(alignment: .bottomTrailing) {
+                Circle()
+                    .fill(Color.cyan.opacity(0.08))
+                    .frame(width: 720, height: 720)
+                    .blur(radius: 170)
+                    .offset(x: 260, y: 320)
+            }
+            .ignoresSafeArea()
+    }
+}
+
+private struct CaptureOverviewHeaderView: View {
+    let title: String
+    let subtitle: String
+    let status: CaptureOverviewStatusPresentation
+    let hasTraffic: Bool
+    let onViewPackets: () -> Void
+    let onShowEndpoints: () -> Void
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 20) {
+                identity
+                Spacer(minLength: 24)
+                CaptureOverviewHeaderActions(
+                    hasTraffic: hasTraffic,
+                    onViewPackets: onViewPackets,
+                    onShowEndpoints: onShowEndpoints
+                )
+            }
+            .frame(minWidth: 700)
+
+            VStack(alignment: .leading, spacing: 18) {
+                identity
+                CaptureOverviewHeaderActions(
+                    hasTraffic: hasTraffic,
+                    onViewPackets: onViewPackets,
+                    onShowEndpoints: onShowEndpoints
+                )
+            }
+        }
+        .padding(22)
+        .captureOverviewSurface(tint: .orange)
+    }
+
+    private var identity: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "chart.xyaxis.line")
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(.orange)
+                .frame(width: 54, height: 54)
+                .background(Color.orange.opacity(0.15), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .strokeBorder(Color.orange.opacity(0.24), lineWidth: 1)
+                }
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 10) {
+                    Text(title)
+                        .font(.title2.weight(.semibold))
+                        .lineLimit(1)
+                    CaptureOverviewStatusPill(status: status)
+                }
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CaptureOverviewStatusPill: View {
+    let status: CaptureOverviewStatusPresentation
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(status.tone.color)
+                .frame(width: 7, height: 7)
+            Text(status.title)
+                .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(status.tone.color)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(status.tone.color.opacity(0.12), in: Capsule())
+        .overlay {
+            Capsule().strokeBorder(status.tone.color.opacity(0.2), lineWidth: 1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Capture status, \(status.title)")
+    }
+}
+
+private struct CaptureOverviewHeaderActions: View {
+    let hasTraffic: Bool
+    let onViewPackets: () -> Void
+    let onShowEndpoints: () -> Void
+
+    @ViewBuilder
+    var body: some View {
+        if #available(macOS 26.0, *) {
+            HStack(spacing: 10) {
+                Button(action: onViewPackets) {
+                    Label("View Packets", systemImage: "list.bullet.rectangle")
+                }
+                .buttonStyle(.glassProminent)
+                Button(action: onShowEndpoints) {
+                    Label("Endpoints…", systemImage: "point.3.connected.trianglepath.dotted")
+                }
+                .buttonStyle(.glass)
+                .disabled(!hasTraffic)
+            }
+            .controlSize(.large)
+        } else {
+            HStack(spacing: 10) {
+                Button(action: onViewPackets) {
+                    Label("View Packets", systemImage: "list.bullet.rectangle")
+                }
+                .buttonStyle(.borderedProminent)
+                Button(action: onShowEndpoints) {
+                    Label("Endpoints…", systemImage: "point.3.connected.trianglepath.dotted")
+                }
+                .buttonStyle(.bordered)
+                .disabled(!hasTraffic)
+            }
+            .controlSize(.large)
+        }
+    }
+}
+
+private struct CaptureOverviewMetricsView: View {
+    let metrics: [CaptureOverviewMetricPresentation]
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 14) {
+                cards
+            }
+            .frame(minWidth: 1_080)
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(minimum: 160), spacing: 14), count: 3),
+                spacing: 14
+            ) {
+                cards
+            }
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(minimum: 150), spacing: 14), count: 2),
+                spacing: 14
+            ) {
+                cards
+            }
+        }
+    }
+
+    private var cards: some View {
+        ForEach(metrics) { metric in
+            CaptureOverviewMetricCard(metric: metric)
+                .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+private struct CaptureOverviewMetricCard: View {
+    let metric: CaptureOverviewMetricPresentation
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            HStack {
+                Image(systemName: metric.symbol)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(metric.tone.color)
+                    .frame(width: 30, height: 30)
+                    .background(metric.tone.color.opacity(0.14), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                    .accessibilityHidden(true)
+                Text(metric.title)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+            Text(metric.value)
+                .font(.title3.weight(.semibold))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Text(metric.detail)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity, minHeight: 92, alignment: .leading)
+        .padding(16)
+        .captureOverviewSurface(tint: metric.tone.color)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CaptureOverviewPrimaryDataView: View {
+    let trafficPoints: [CaptureOverviewChartPoint]
+    let hasDirectionalTraffic: Bool
+    let totalText: String
+    let sentText: String
+    let receivedText: String
+    let protocols: [CaptureOverviewProtocolPresentation]
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 18) {
+                CaptureOverviewTrafficChartView(
+                    points: trafficPoints,
+                    hasDirectionalTraffic: hasDirectionalTraffic,
+                    totalText: totalText,
+                    sentText: sentText,
+                    receivedText: receivedText
+                )
+                .frame(maxWidth: .infinity)
+                CaptureOverviewProtocolView(rows: protocols)
+                    .frame(width: 410)
+            }
+            .frame(minWidth: 1_040)
+
+            VStack(spacing: 18) {
+                CaptureOverviewTrafficChartView(
+                    points: trafficPoints,
+                    hasDirectionalTraffic: hasDirectionalTraffic,
+                    totalText: totalText,
+                    sentText: sentText,
+                    receivedText: receivedText
+                )
+                CaptureOverviewProtocolView(rows: protocols)
+            }
+        }
+    }
+}
+
+private struct CaptureOverviewTrafficChartView: View {
+    let points: [CaptureOverviewChartPoint]
+    let hasDirectionalTraffic: Bool
+    let totalText: String
+    let sentText: String
+    let receivedText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Traffic over time")
+                        .font(.headline)
+                    Text(hasDirectionalTraffic ? "Packet bytes by local direction" : "Total packet bytes")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if hasDirectionalTraffic {
+                    CaptureOverviewChartLegend(title: "Sent", value: sentText, color: .blue)
+                    CaptureOverviewChartLegend(title: "Received", value: receivedText, color: .cyan)
+                } else {
+                    CaptureOverviewChartLegend(title: "Total", value: totalText, color: .orange)
+                }
+            }
+
+            Chart(points) { point in
+                AreaMark(
+                    x: .value("Time", point.date),
+                    y: .value("Bytes", point.bytes),
+                    stacking: .unstacked
+                )
+                .foregroundStyle(by: .value("Direction", point.direction.rawValue))
+                .interpolationMethod(.catmullRom)
+                .opacity(0.1)
+
+                LineMark(
+                    x: .value("Time", point.date),
+                    y: .value("Bytes", point.bytes)
+                )
+                .foregroundStyle(by: .value("Direction", point.direction.rawValue))
+                .interpolationMethod(.catmullRom)
+                .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
+
+                PointMark(
+                    x: .value("Time", point.date),
+                    y: .value("Bytes", point.bytes)
+                )
+                .foregroundStyle(by: .value("Direction", point.direction.rawValue))
+                .symbolSize(16)
+            }
+            .chartForegroundStyleScale([
+                CaptureOverviewChartPoint.Direction.sent.rawValue: Color.blue,
+                CaptureOverviewChartPoint.Direction.received.rawValue: Color.cyan,
+                CaptureOverviewChartPoint.Direction.total.rawValue: Color.orange,
+            ])
+            .chartLegend(.hidden)
+            .chartXAxis {
+                AxisMarks(values: .automatic(desiredCount: 5)) {
+                    AxisGridLine().foregroundStyle(Color.secondary.opacity(0.08))
+                    AxisValueLabel(format: .dateTime.hour().minute().second())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading, values: .automatic(desiredCount: 4)) { value in
+                    AxisGridLine().foregroundStyle(Color.secondary.opacity(0.12))
+                    AxisValueLabel {
+                        if let bytes = value.as(Double.self) {
+                            Text(CaptureOverviewByteFormatting.string(bytes))
+                        }
+                    }
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .chartPlotStyle { plotArea in
+                plotArea.background(Color.primary.opacity(0.025), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .accessibilityLabel(
+                hasDirectionalTraffic ? "Sent and received traffic over time" : "Total traffic over time"
+            )
+        }
+        .frame(maxWidth: .infinity, minHeight: 292, maxHeight: 292, alignment: .topLeading)
+        .padding(20)
+        .captureOverviewSurface(tint: .blue)
+    }
+}
+
+private struct CaptureOverviewChartLegend: View {
+    let title: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.caption.weight(.semibold))
+                    .monospacedDigit()
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CaptureOverviewProtocolView: View {
+    let rows: [CaptureOverviewProtocolPresentation]
+
+    private var protocolNames: [String] {
+        rows.map(\.title)
+    }
+
+    private var protocolColors: [Color] {
+        rows.map { CaptureOverviewPalette.protocolColor(at: $0.colorIndex) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Protocols")
+                    .font(.headline)
+                Text("Share of captured bytes")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 18) {
+                Chart(rows) { row in
+                    SectorMark(
+                        angle: .value("Bytes", row.fraction),
+                        innerRadius: .ratio(0.67),
+                        angularInset: 1.5
+                    )
+                    .cornerRadius(4)
+                    .foregroundStyle(by: .value("Protocol", row.title))
+                }
+                .chartForegroundStyleScale(domain: protocolNames, range: protocolColors)
+                .chartLegend(.hidden)
+                .overlay {
+                    VStack(spacing: 2) {
+                        Text("\(rows.count)")
+                            .font(.title2.weight(.semibold))
+                            .monospacedDigit()
+                        Text(rows.count == 1 ? "protocol" : "protocols")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 142, height: 142)
+                .accessibilityLabel("Protocol traffic breakdown")
+
+                VStack(spacing: 11) {
+                    ForEach(rows) { row in
+                        CaptureOverviewProtocolLegendRow(row: row)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 292, maxHeight: 292, alignment: .topLeading)
+        .padding(20)
+        .captureOverviewSurface(tint: .purple)
+    }
+}
+
+private struct CaptureOverviewProtocolLegendRow: View {
+    let row: CaptureOverviewProtocolPresentation
+
+    var body: some View {
+        VStack(spacing: 5) {
+            HStack(spacing: 7) {
+                Circle()
+                    .fill(CaptureOverviewPalette.protocolColor(at: row.colorIndex))
+                    .frame(width: 7, height: 7)
+                Text(row.title)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                Text(row.percentageText)
+                    .font(.caption.weight(.semibold))
+                    .monospacedDigit()
+                Text(row.totalText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            GeometryReader { geometry in
+                Capsule()
+                    .fill(Color.primary.opacity(0.08))
+                    .overlay(alignment: .leading) {
+                        Capsule()
+                            .fill(CaptureOverviewPalette.protocolColor(at: row.colorIndex))
+                            .frame(width: geometry.size.width * row.fraction)
+                    }
+            }
+            .frame(height: 4)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CaptureOverviewTopTrafficView: View {
+    let selectedGroup: CaptureOverviewTopGroup
+    let rows: [CaptureOverviewTopTrafficPresentation]
+    let onSelectGroup: (CaptureOverviewTopGroup) -> Void
+    let onSelectRow: (PacketSourceListSelection) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Top traffic")
+                        .font(.headline)
+                    Text("Ranked by total bytes across the capture")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                CaptureOverviewSegmentedControl(selection: selectedGroup, onSelect: onSelectGroup)
+            }
+
+            if rows.isEmpty {
+                ContentUnavailableView(
+                    selectedGroup == .apps ? "No app traffic" : "No resolved domains",
+                    systemImage: selectedGroup == .apps ? "app.dashed" : "globe.desk",
+                    description: Text(
+                        selectedGroup == .apps
+                            ? "App attribution will appear when TCP Viewer can identify the local process."
+                            : "Resolved domains will appear as packet metadata becomes available."
+                    )
+                )
+                .frame(minHeight: 210)
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    CaptureOverviewTopTrafficGrid(rows: rows, columnCount: 2, onSelect: onSelectRow)
+                        .frame(minWidth: 880)
+                    CaptureOverviewTopTrafficGrid(rows: rows, columnCount: 1, onSelect: onSelectRow)
+                }
+            }
+        }
+        .padding(20)
+        .captureOverviewSurface(tint: .orange)
+    }
+}
+
+private struct CaptureOverviewSegmentedControl: View {
+    let selection: CaptureOverviewTopGroup
+    let onSelect: (CaptureOverviewTopGroup) -> Void
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(CaptureOverviewTopGroup.allCases, id: \.rawValue) { group in
+                Button(group.title) {
+                    onSelect(group)
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(selection == group ? Color.white : Color.secondary)
+                .padding(.horizontal, 13)
+                .padding(.vertical, 7)
+                .background(selection == group ? Color.orange : Color.clear, in: Capsule())
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(selection == group ? .isSelected : [])
+            }
+        }
+        .padding(3)
+        .background(Color.primary.opacity(0.06), in: Capsule())
+        .overlay {
+            Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Top traffic category")
+    }
+}
+
+private struct CaptureOverviewTopTrafficGrid: View {
+    let rows: [CaptureOverviewTopTrafficPresentation]
+    let columnCount: Int
+    let onSelect: (PacketSourceListSelection) -> Void
+
+    var body: some View {
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(minimum: 360), spacing: 12), count: columnCount),
+            spacing: 12
+        ) {
+            ForEach(rows) { row in
+                Button {
+                    onSelect(row.selection)
+                } label: {
+                    CaptureOverviewTopTrafficRow(row: row)
+                }
+                .buttonStyle(CaptureOverviewTrafficRowButtonStyle())
+                .accessibilityLabel("\(row.title), \(row.totalText), \(row.percentageText) of capture")
+                .accessibilityHint("Shows matching packets in the main table")
+            }
+        }
+    }
+}
+
+private struct CaptureOverviewTopTrafficRow: View {
+    let row: CaptureOverviewTopTrafficPresentation
+
+    var body: some View {
+        HStack(spacing: 13) {
+            Image(nsImage: row.icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 32, height: 32)
+                .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(row.title)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                    Text(row.percentageText)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(Color.orange.opacity(0.12), in: Capsule())
+                    Spacer(minLength: 8)
+                    Text(row.totalText)
+                        .font(.subheadline.weight(.semibold))
+                        .monospacedDigit()
+                }
+
+                CaptureOverviewStackedTrafficBar(
+                    sentFraction: row.sentFraction,
+                    receivedFraction: row.receivedFraction,
+                    unknownFraction: row.unknownFraction
+                )
+
+                HStack(spacing: 14) {
+                    Label(row.sentText, systemImage: "arrow.up.right")
+                        .foregroundStyle(.blue)
+                    Label(row.receivedText, systemImage: "arrow.down.left")
+                        .foregroundStyle(.cyan)
+                }
+                .font(.caption2.weight(.medium))
+                .monospacedDigit()
+            }
+        }
+        .padding(13)
+        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 15, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 15, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.075), lineWidth: 1)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+    }
+}
+
+private struct CaptureOverviewStackedTrafficBar: View {
+    let sentFraction: Double
+    let receivedFraction: Double
+    let unknownFraction: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            Capsule()
+                .fill(Color.primary.opacity(0.08))
+                .overlay(alignment: .leading) {
+                    HStack(spacing: 0) {
+                        Rectangle()
+                            .fill(Color.blue)
+                            .frame(width: geometry.size.width * sentFraction)
+                        Rectangle()
+                            .fill(Color.cyan)
+                            .frame(width: geometry.size.width * receivedFraction)
+                        Rectangle()
+                            .fill(Color.secondary.opacity(0.55))
+                            .frame(width: geometry.size.width * unknownFraction)
+                    }
+                }
+                .compositingGroup()
+                .clipShape(Capsule())
+        }
+        .frame(height: 6)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct CaptureOverviewTrafficRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? 0.78 : 1)
+            .scaleEffect(configuration.isPressed ? 0.992 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
+private struct CaptureOverviewEmptyStateView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "No traffic captured yet",
+            systemImage: "waveform.path.ecg",
+            description: Text("Start a capture or open a capture file. This overview will fill in as packets arrive.")
+        )
+        .frame(maxWidth: .infinity, minHeight: 360)
+        .captureOverviewSurface(tint: .orange)
+    }
+}
+
+private struct CaptureOverviewWarningView: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(.subheadline.weight(.medium))
+            Spacer()
+        }
+        .padding(16)
+        .captureOverviewSurface(tint: .orange)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Capture warning, \(text)")
+    }
+}
+
+private struct CaptureOverviewDetailsView: View {
+    let details: [CaptureOverviewDetailPresentation]
+    let isExpanded: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Button(action: onToggle) {
+                HStack(spacing: 9) {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    Text("Capture details")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(details.count) items")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                Divider()
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 250), spacing: 12)],
+                    alignment: .leading,
+                    spacing: 12
+                ) {
+                    ForEach(details) { detail in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(detail.label)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(detail.value)
+                                .font(.callout.weight(.medium))
+                                .textSelection(.enabled)
+                                .lineLimit(2)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .captureOverviewSurface(tint: .secondary)
+        .animation(.easeInOut(duration: 0.18), value: isExpanded)
+    }
+}
+
+private struct CaptureOverviewSurfaceModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let tint: Color
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 22, style: .continuous)
+        if #available(macOS 26.0, *) {
+            content
+                .background(tint.opacity(colorScheme == .dark ? 0.055 : 0.035), in: shape)
+                .overlay {
+                    shape.strokeBorder(
+                        colorScheme == .dark ? Color.white.opacity(0.13) : Color.black.opacity(0.09),
+                        lineWidth: 1
+                    )
+                }
+                .glassEffect(.regular.tint(tint.opacity(0.045)), in: .rect(cornerRadius: 22))
+        } else {
+            content
+                .background(.regularMaterial, in: shape)
+                .overlay {
+                    shape.strokeBorder(
+                        colorScheme == .dark ? Color.white.opacity(0.13) : Color.black.opacity(0.09),
+                        lineWidth: 1
+                    )
+                }
+                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.16 : 0.07), radius: 16, y: 6)
+        }
+    }
+}
+
+private extension View {
+    func captureOverviewSurface(tint: Color) -> some View {
+        modifier(CaptureOverviewSurfaceModifier(tint: tint))
+    }
+}
+
+private enum CaptureOverviewPalette {
+    static let protocolColors: [Color] = [
+        .blue,
+        .cyan,
+        .purple,
+        .orange,
+        .green,
+        .pink,
+    ]
+
+    static func protocolColor(at index: Int) -> Color {
+        protocolColors[index % protocolColors.count]
+    }
+}
+
+private enum CaptureOverviewByteFormatting {
+    static let formatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.allowedUnits = .useAll
+        formatter.includesUnit = true
+        return formatter
+    }()
+
+    static func string(_ bytes: Double) -> String {
+        let byteCount = UInt64(max(0, bytes))
+        guard byteCount > 0 else {
+            return "0 bytes"
+        }
+        return formatter.string(fromByteCount: Int64(clamping: byteCount))
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
@@ -68,7 +68,6 @@ final class CaptureOverviewViewController: NSViewController {
     private var hostingController: NSHostingController<CaptureOverviewDashboardView>?
     private var latestNetworkSnapshot: NetworkInspectorSnapshot?
     private var overviewSnapshot = CaptureOverviewSnapshot.empty
-    private var selectedTopGroup = CaptureOverviewTopGroup.apps
     private var isCaptureDetailsExpanded = false
     private var renderedBackingIdentity: String?
     private var renderedPacketLineageRevision: UInt64?
@@ -181,11 +180,6 @@ final class CaptureOverviewViewController: NSViewController {
                 guard let self else { return }
                 delegate?.captureOverviewViewControllerDidRequestEndpoints(self)
             },
-            onSelectTopGroup: { [weak self] group in
-                guard let self, selectedTopGroup != group else { return }
-                selectedTopGroup = group
-                renderDashboard()
-            },
             onSelectTrafficRow: { [weak self] selection in
                 guard let self else { return }
                 delegate?.captureOverviewViewController(self, didSelect: selection)
@@ -213,8 +207,8 @@ final class CaptureOverviewViewController: NSViewController {
 
     private func makeDashboardModel(network: NetworkInspectorSnapshot) -> CaptureOverviewDashboardModel {
         let totals = overviewSnapshot.totals
-        let topRows = overviewSnapshot.topRows(for: selectedTopGroup)
-        let maximumTopBytes = topRows.map(\.totals.bytes).max() ?? 0
+        let maximumAppBytes = overviewSnapshot.topApps.map(\.totals.bytes).max() ?? 0
+        let maximumDestinationBytes = overviewSnapshot.topDestinations.map(\.totals.bytes).max() ?? 0
         let hasDirectionalTraffic = totals.sentBytes > 0 || totals.receivedBytes > 0
         let chartPoints = overviewSnapshot.timeline.flatMap { point -> [CaptureOverviewChartPoint] in
             let directions: [(CaptureOverviewChartPoint.Direction, UInt64)] = hasDirectionalTraffic
@@ -241,8 +235,12 @@ final class CaptureOverviewViewController: NSViewController {
             totalText: formattedBytes(totals.bytes),
             sentText: formattedBytes(totals.sentBytes),
             receivedText: formattedBytes(totals.receivedBytes),
-            selectedTopGroup: selectedTopGroup,
-            topRows: topRows.map { rowPresentation($0, maximumBytes: maximumTopBytes) },
+            topApps: overviewSnapshot.topApps.enumerated().map { index, row in
+                rowPresentation(row, rank: index + 1, maximumBytes: maximumAppBytes)
+            },
+            topDestinations: overviewSnapshot.topDestinations.enumerated().map { index, row in
+                rowPresentation(row, rank: index + 1, maximumBytes: maximumDestinationBytes)
+            },
             protocolRows: overviewSnapshot.protocols.enumerated().map { index, row in
                 CaptureOverviewProtocolPresentation(
                     id: row.id,
@@ -322,10 +320,12 @@ final class CaptureOverviewViewController: NSViewController {
 
     private func rowPresentation(
         _ row: CaptureOverviewTopRow,
+        rank: Int,
         maximumBytes: UInt64
     ) -> CaptureOverviewTopTrafficPresentation {
         CaptureOverviewTopTrafficPresentation(
             id: row.id,
+            rank: rank,
             title: row.title,
             icon: icon(for: row),
             iconFilePath: row.iconFilePath,
@@ -341,14 +341,13 @@ final class CaptureOverviewViewController: NSViewController {
     }
 
     private func icon(for row: CaptureOverviewTopRow) -> NSImage {
-        if let path = row.iconFilePath {
+        if let path = PacketClientIconCache.normalizedIconPath(row.iconFilePath) {
             if let cached = iconCache[path] {
                 return cached
             }
-            if let image = NSImage(contentsOfFile: path) {
-                iconCache[path] = image
-                return image
-            }
+            let image = PacketClientIconImageLoader.image(forNormalizedPath: path)
+            iconCache[path] = image
+            return image
         }
         let symbol: String
         switch row.selection {
@@ -356,6 +355,8 @@ final class CaptureOverviewViewController: NSViewController {
             symbol = "app.fill"
         case .domain:
             symbol = "globe"
+        case .ipAddress:
+            symbol = "network"
         default:
             symbol = "network"
         }

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
@@ -24,18 +24,12 @@ private struct CaptureOverviewNetworkFingerprint: Equatable {
     let packetLineageRevision: UInt64
     let source: CaptureSource?
     let sessionPhase: CaptureSessionState.Phase
-    let interfaceID: String?
     let interfaceName: String?
     let interfaceTechnicalName: String?
-    let interfaceLinkType: CaptureLinkType?
     let documentPhase: CaptureDocumentState.Phase
     let documentFileName: String?
     let importedFileCount: Int
     let firstImportedFileName: String?
-    let captureFilter: String?
-    let droppedPacketCount: UInt64
-    let truncatedPacketCount: Int
-    let decodeIssueCount: Int
 
     init(snapshot: NetworkInspectorSnapshot) {
         let ingest = snapshot.base.packetIngestState
@@ -45,18 +39,12 @@ private struct CaptureOverviewNetworkFingerprint: Equatable {
         packetLineageRevision = ingest.packetLineageRevision
         source = ingest.source
         sessionPhase = snapshot.base.sessionState.phase
-        interfaceID = interface?.id
         interfaceName = interface?.displayName
         interfaceTechnicalName = interface?.technicalName
-        interfaceLinkType = interface?.linkType
         documentPhase = snapshot.base.documentState.phase
         documentFileName = snapshot.base.documentState.fileURL?.lastPathComponent
         importedFileCount = ingest.importedFiles.count
         firstImportedFileName = ingest.importedFiles.first?.displayName
-        captureFilter = snapshot.base.filterState.normalizedCaptureFilter
-        droppedPacketCount = snapshot.droppedPacketCount
-        truncatedPacketCount = ingest.truncatedPacketCount
-        decodeIssueCount = ingest.decodeIssueCount
     }
 }
 
@@ -68,7 +56,6 @@ final class CaptureOverviewViewController: NSViewController {
     private var hostingController: NSHostingController<CaptureOverviewDashboardView>?
     private var latestNetworkSnapshot: NetworkInspectorSnapshot?
     private var overviewSnapshot = CaptureOverviewSnapshot.empty
-    private var isCaptureDetailsExpanded = false
     private var renderedBackingIdentity: String?
     private var renderedPacketLineageRevision: UInt64?
     private var renderedNetworkFingerprint: CaptureOverviewNetworkFingerprint?
@@ -183,11 +170,6 @@ final class CaptureOverviewViewController: NSViewController {
             onSelectTrafficRow: { [weak self] selection in
                 guard let self else { return }
                 delegate?.captureOverviewViewController(self, didSelect: selection)
-            },
-            onToggleDetails: { [weak self] in
-                guard let self else { return }
-                isCaptureDetailsExpanded.toggle()
-                renderDashboard()
             }
         )
     }
@@ -250,10 +232,7 @@ final class CaptureOverviewViewController: NSViewController {
                     fraction: fraction(row.totals.bytes, of: totals.bytes),
                     colorIndex: index
                 )
-            },
-            warningText: warningText(network),
-            details: captureDetails(network),
-            isDetailsExpanded: isCaptureDetailsExpanded
+            }
         )
     }
 
@@ -411,45 +390,6 @@ final class CaptureOverviewViewController: NSViewController {
             tone = .neutral
         }
         return CaptureOverviewStatusPresentation(title: phase.rawValue.capitalized, tone: tone)
-    }
-
-    private func warningText(_ snapshot: NetworkInspectorSnapshot) -> String? {
-        var warnings: [String] = []
-        if snapshot.droppedPacketCount > 0 {
-            warnings.append("\(formattedNumber(snapshot.droppedPacketCount)) packets dropped")
-        }
-        if overviewSnapshot.malformedPacketCount > 0 {
-            warnings.append("\(formattedNumber(overviewSnapshot.malformedPacketCount)) malformed packets")
-        }
-        let ingest = snapshot.base.packetIngestState
-        if ingest.truncatedPacketCount > 0 {
-            warnings.append("\(formattedNumber(UInt64(ingest.truncatedPacketCount))) truncated packets")
-        }
-        if ingest.decodeIssueCount > 0 {
-            warnings.append("\(formattedNumber(UInt64(ingest.decodeIssueCount))) decode issues")
-        }
-        return warnings.isEmpty ? nil : warnings.joined(separator: " · ")
-    }
-
-    private func captureDetails(_ snapshot: NetworkInspectorSnapshot) -> [CaptureOverviewDetailPresentation] {
-        let session = snapshot.base.sessionState
-        let ingest = snapshot.base.packetIngestState
-        var details: [CaptureOverviewDetailPresentation] = []
-        if ingest.source != .offline, let interface = session.selectedInterface {
-            details.append(.init(id: "interface", label: "Interface", value: "\(interface.displayName) (\(interface.technicalName))"))
-            details.append(.init(id: "link", label: "Link type", value: interface.linkType.rawValue.capitalized))
-        }
-        if let fileName = snapshot.base.documentState.fileURL?.lastPathComponent {
-            details.append(.init(id: "file", label: "File", value: fileName))
-        }
-        if !ingest.importedFiles.isEmpty {
-            details.append(.init(id: "imports", label: "Imported files", value: formattedNumber(UInt64(ingest.importedFiles.count))))
-        }
-        if let captureFilter = snapshot.base.filterState.normalizedCaptureFilter, !captureFilter.isEmpty {
-            details.append(.init(id: "filter", label: "Capture filter", value: captureFilter))
-        }
-        details.append(.init(id: "source", label: "Source", value: ingest.source?.rawValue.capitalized ?? "None"))
-        return details
     }
 
     private var durationText: String {

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
@@ -1,0 +1,982 @@
+//
+//  CaptureOverviewViewController.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/9/26.
+//
+
+import AppKit
+import PcapPlusPlusCore
+
+protocol CaptureOverviewViewControllerDelegate: AnyObject {
+    func captureOverviewViewControllerDidRequestPackets(_ controller: CaptureOverviewViewController)
+    func captureOverviewViewControllerDidRequestEndpoints(_ controller: CaptureOverviewViewController)
+    func captureOverviewViewController(
+        _ controller: CaptureOverviewViewController,
+        didSelect selection: PacketSourceListSelection
+    )
+}
+
+private class CaptureOverviewCardView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 10
+        layer?.borderWidth = 1
+        updateColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateColors()
+    }
+
+    private func updateColors() {
+        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.55).cgColor
+    }
+}
+
+private final class CaptureOverviewMetricView: CaptureOverviewCardView {
+    private let titleLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.smallSystemFontSize),
+        color: .secondaryLabelColor
+    )
+    private let valueLabel = TCPViewerUI.label(
+        "",
+        font: .monospacedDigitSystemFont(ofSize: 19, weight: .semibold)
+    )
+    private let detailLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.smallSystemFontSize),
+        color: .tertiaryLabelColor
+    )
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        let stack = NSStackView(views: [titleLabel, valueLabel, detailLabel])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 5
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+        ])
+        valueLabel.lineBreakMode = .byTruncatingTail
+        detailLabel.lineBreakMode = .byTruncatingTail
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func render(title: String, value: String, detail: String = "") {
+        titleLabel.stringValue = title
+        valueLabel.stringValue = value
+        detailLabel.stringValue = detail
+        detailLabel.isHidden = detail.isEmpty
+    }
+}
+
+private final class CaptureOverviewTrafficBarView: NSView {
+    private var totals = CaptureOverviewTrafficTotals()
+    private var maximumBytes: UInt64 = 0
+
+    override var isFlipped: Bool { true }
+
+    func render(totals: CaptureOverviewTrafficTotals, maximumBytes: UInt64) {
+        self.totals = totals
+        self.maximumBytes = maximumBytes
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let backgroundPath = NSBezierPath(roundedRect: bounds, xRadius: 2, yRadius: 2)
+        NSColor.separatorColor.withAlphaComponent(0.35).setFill()
+        backgroundPath.fill()
+        guard maximumBytes > 0, totals.bytes > 0, bounds.width > 0 else {
+            return
+        }
+
+        let usedWidth = bounds.width * CGFloat(Double(totals.bytes) / Double(maximumBytes))
+        let parts = [
+            (totals.sentBytes, NSColor.systemBlue),
+            (totals.receivedBytes, NSColor.systemTeal),
+            (totals.unclassifiedBytes, NSColor.systemGray),
+        ]
+        var currentX: CGFloat = 0
+        for (bytes, color) in parts where bytes > 0 {
+            let width = usedWidth * CGFloat(Double(bytes) / Double(totals.bytes))
+            color.setFill()
+            NSBezierPath(rect: NSRect(x: currentX, y: 0, width: width, height: bounds.height)).fill()
+            currentX += width
+        }
+    }
+}
+
+private final class CaptureOverviewTopCellView: NSTableCellView {
+    static let identifier = NSUserInterfaceItemIdentifier("CaptureOverviewTopCell")
+
+    private let iconView = NSImageView()
+    private let titleLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
+    )
+    private let trafficLabel = TCPViewerUI.label(
+        "",
+        font: .monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
+        color: .secondaryLabelColor
+    )
+    private let barView = CaptureOverviewTrafficBarView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+        trafficLabel.alignment = .right
+        trafficLabel.lineBreakMode = .byTruncatingTail
+        barView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(iconView)
+        addSubview(titleLabel)
+        addSubview(trafficLabel)
+        addSubview(barView)
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            iconView.topAnchor.constraint(equalTo: topAnchor, constant: 7),
+            iconView.widthAnchor.constraint(equalToConstant: 20),
+            iconView.heightAnchor.constraint(equalToConstant: 20),
+
+            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
+            titleLabel.centerYAnchor.constraint(equalTo: iconView.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trafficLabel.leadingAnchor, constant: -8),
+
+            trafficLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            trafficLabel.centerYAnchor.constraint(equalTo: iconView.centerYAnchor),
+            trafficLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 240),
+
+            barView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            barView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            barView.topAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 5),
+            barView.heightAnchor.constraint(equalToConstant: 4),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func render(
+        row: CaptureOverviewTopRow,
+        icon: NSImage?,
+        maximumBytes: UInt64,
+        captureBytes: UInt64,
+        byteFormatter: ByteCountFormatter
+    ) {
+        titleLabel.stringValue = row.title
+        iconView.image = icon
+        iconView.contentTintColor = icon?.isTemplate == true ? .secondaryLabelColor : nil
+        let percentage = captureBytes > 0 ? Int((Double(row.totals.bytes) / Double(captureBytes) * 100).rounded()) : 0
+        let total = byteFormatter.string(fromByteCount: Int64(clamping: row.totals.bytes))
+        let sent = byteFormatter.string(fromByteCount: Int64(clamping: row.totals.sentBytes))
+        let received = byteFormatter.string(fromByteCount: Int64(clamping: row.totals.receivedBytes))
+        trafficLabel.stringValue = "\(total) · ↑\(sent) ↓\(received) · \(percentage)%"
+        barView.render(totals: row.totals, maximumBytes: maximumBytes)
+        toolTip = "\(row.title)\n\(trafficLabel.stringValue)"
+    }
+}
+
+private final class CaptureOverviewProtocolRowView: NSView {
+    private let titleLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
+    )
+    private let valueLabel = TCPViewerUI.label(
+        "",
+        font: .monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
+        color: .secondaryLabelColor
+    )
+    private let barView = CaptureOverviewTrafficBarView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.alignment = .right
+        barView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+        addSubview(valueLabel)
+        addSubview(barView)
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 38),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            valueLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            valueLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: valueLabel.leadingAnchor, constant: -8),
+            barView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            barView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            barView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 7),
+            barView.heightAnchor.constraint(equalToConstant: 5),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func render(
+        row: CaptureOverviewProtocolRow,
+        totalBytes: UInt64,
+        byteFormatter: ByteCountFormatter
+    ) {
+        titleLabel.stringValue = row.title
+        let percentage = totalBytes > 0 ? Int((Double(row.totals.bytes) / Double(totalBytes) * 100).rounded()) : 0
+        valueLabel.stringValue = "\(percentage)% · \(byteFormatter.string(fromByteCount: Int64(clamping: row.totals.bytes)))"
+        barView.render(totals: row.totals, maximumBytes: totalBytes)
+    }
+}
+
+private final class CaptureOverviewTrafficChartView: NSView, NSViewToolTipOwner {
+    private var points: [CaptureOverviewTimelinePoint] = []
+    private let byteFormatter: ByteCountFormatter
+    private let timeFormatter: DateFormatter
+    private var toolTipTag: NSView.ToolTipTag = 0
+
+    init(byteFormatter: ByteCountFormatter) {
+        self.byteFormatter = byteFormatter
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        timeFormatter = formatter
+        super.init(frame: .zero)
+        toolTipTag = addToolTip(bounds, owner: self, userData: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isFlipped: Bool { true }
+
+    func render(points: [CaptureOverviewTimelinePoint]) {
+        self.points = points
+        needsDisplay = true
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        if toolTipTag != 0 {
+            removeToolTip(toolTipTag)
+        }
+        toolTipTag = addToolTip(bounds, owner: self, userData: nil)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let plot = plotRect
+        NSColor.separatorColor.withAlphaComponent(0.3).setStroke()
+        for index in 0...3 {
+            let y = plot.minY + plot.height * CGFloat(index) / 3
+            let path = NSBezierPath()
+            path.move(to: NSPoint(x: plot.minX, y: y))
+            path.line(to: NSPoint(x: plot.maxX, y: y))
+            path.lineWidth = 0.5
+            path.stroke()
+        }
+        guard !points.isEmpty else {
+            return
+        }
+        let maximum = points.reduce(UInt64(0)) { currentMaximum, point in
+            max(currentMaximum, point.totals.sentBytes, point.totals.receivedBytes)
+        }
+        drawPath(for: \CaptureOverviewTrafficTotals.sentBytes, maximum: maximum, color: .systemBlue, in: plot)
+        drawPath(for: \CaptureOverviewTrafficTotals.receivedBytes, maximum: maximum, color: .systemTeal, in: plot)
+    }
+
+    func view(
+        _ view: NSView,
+        stringForToolTip tag: NSView.ToolTipTag,
+        point: NSPoint,
+        userData data: UnsafeMutableRawPointer?
+    ) -> String {
+        guard let item = nearestPoint(to: point) else {
+            return "No traffic"
+        }
+        return [
+            timeFormatter.string(from: item.date),
+            "Sent \(byteFormatter.string(fromByteCount: Int64(clamping: item.totals.sentBytes)))",
+            "Received \(byteFormatter.string(fromByteCount: Int64(clamping: item.totals.receivedBytes)))",
+            "\(item.totals.packets) packets",
+        ].joined(separator: "\n")
+    }
+
+    private var plotRect: NSRect {
+        bounds.insetBy(dx: 8, dy: 8)
+    }
+
+    private func drawPath(
+        for keyPath: KeyPath<CaptureOverviewTrafficTotals, UInt64>,
+        maximum: UInt64,
+        color: NSColor,
+        in plot: NSRect
+    ) {
+        guard maximum > 0 else {
+            return
+        }
+        let firstDate = points.first?.date.timeIntervalSince1970 ?? 0
+        let lastDate = points.last?.date.timeIntervalSince1970 ?? firstDate
+        let span = max(1, lastDate - firstDate)
+        let path = NSBezierPath()
+        for (index, point) in points.enumerated() {
+            let x = plot.minX + plot.width * CGFloat((point.date.timeIntervalSince1970 - firstDate) / span)
+            let ratio = CGFloat(Double(point.totals[keyPath: keyPath]) / Double(maximum))
+            let y = plot.maxY - plot.height * ratio
+            if index == 0 {
+                path.move(to: NSPoint(x: x, y: y))
+            } else {
+                path.line(to: NSPoint(x: x, y: y))
+            }
+        }
+        color.setStroke()
+        path.lineWidth = 2
+        path.lineJoinStyle = .round
+        path.lineCapStyle = .round
+        path.stroke()
+        if points.count == 1, let point = points.first {
+            let ratio = CGFloat(Double(point.totals[keyPath: keyPath]) / Double(maximum))
+            color.setFill()
+            NSBezierPath(ovalIn: NSRect(x: plot.minX - 2, y: plot.maxY - plot.height * ratio - 2, width: 4, height: 4)).fill()
+        }
+    }
+
+    private func nearestPoint(to point: NSPoint) -> CaptureOverviewTimelinePoint? {
+        guard !points.isEmpty else {
+            return nil
+        }
+        guard let firstDate = points.first?.date.timeIntervalSince1970,
+              let lastDate = points.last?.date.timeIntervalSince1970 else {
+            return nil
+        }
+        let fraction = min(1, max(0, (point.x - plotRect.minX) / max(1, plotRect.width)))
+        let targetDate = firstDate + (lastDate - firstDate) * Double(fraction)
+        return points.min { lhs, rhs in
+            abs(lhs.date.timeIntervalSince1970 - targetDate) < abs(rhs.date.timeIntervalSince1970 - targetDate)
+        }
+    }
+}
+
+final class CaptureOverviewViewController: NSViewController {
+    weak var delegate: CaptureOverviewViewControllerDelegate?
+
+    private let latestIngestStateProvider: () -> PacketIngestState
+    private var service: CaptureOverviewService?
+    private var latestNetworkSnapshot: NetworkInspectorSnapshot?
+    private var overviewSnapshot = CaptureOverviewSnapshot.empty
+    private var selectedTopGroup = CaptureOverviewTopGroup.apps
+    private var renderedBackingIdentity: String?
+    private var renderedPacketLineageRevision: UInt64?
+
+    private let scrollView = NSScrollView()
+    private let documentView = NSView()
+    private let sourceLabel = TCPViewerUI.label("Overview", font: .systemFont(ofSize: 24, weight: .semibold))
+    private let sourceDetailLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.systemFontSize),
+        color: .secondaryLabelColor
+    )
+    private let viewPacketsButton = NSButton(title: "View Packets", target: nil, action: nil)
+    private let endpointsButton = NSButton(title: "Endpoints…", target: nil, action: nil)
+    private let durationMetric = CaptureOverviewMetricView()
+    private let packetMetric = CaptureOverviewMetricView()
+    private let trafficMetric = CaptureOverviewMetricView()
+    private let directionMetric = CaptureOverviewMetricView()
+    private let chartView: CaptureOverviewTrafficChartView
+    private let topSegment = NSSegmentedControl(
+        labels: CaptureOverviewTopGroup.allCases.map(\.title),
+        trackingMode: .selectOne,
+        target: nil,
+        action: nil
+    )
+    private let topTableView = NSTableView()
+    private let topScrollView = NSScrollView()
+    private let topEmptyLabel = TCPViewerUI.label(
+        "No app traffic yet.",
+        font: .systemFont(ofSize: NSFont.systemFontSize),
+        color: .secondaryLabelColor
+    )
+    private let protocolStack = NSStackView()
+    private let protocolEmptyLabel = TCPViewerUI.label(
+        "No protocol traffic yet.",
+        font: .systemFont(ofSize: NSFont.systemFontSize),
+        color: .secondaryLabelColor
+    )
+    private let noTrafficCard = CaptureOverviewCardView()
+    private let noTrafficLabel = TCPViewerUI.label(
+        "No traffic captured yet.",
+        font: .systemFont(ofSize: NSFont.systemFontSize),
+        color: .secondaryLabelColor
+    )
+    private let warningCard = CaptureOverviewCardView()
+    private let warningLabel = TCPViewerUI.label(
+        "",
+        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium),
+        color: .systemOrange
+    )
+    private let detailsButton = NSButton(title: "Capture details", target: nil, action: nil)
+    private let detailsLabel = TCPViewerUI.label(
+        "",
+        font: .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
+        color: .secondaryLabelColor
+    )
+    private let byteFormatter: ByteCountFormatter
+    private let numberFormatter: NumberFormatter
+    private let dateFormatter: DateFormatter
+    private let durationFormatter = DateComponentsFormatter()
+    private var iconCache: [String: NSImage] = [:]
+    private weak var chartCard: NSView?
+    private weak var trafficDetailsView: NSView?
+
+    init(latestIngestStateProvider: @escaping () -> PacketIngestState) {
+        self.latestIngestStateProvider = latestIngestStateProvider
+
+        let byteFormatter = ByteCountFormatter()
+        byteFormatter.countStyle = .file
+        byteFormatter.allowedUnits = .useAll
+        byteFormatter.includesUnit = true
+        self.byteFormatter = byteFormatter
+        chartView = CaptureOverviewTrafficChartView(byteFormatter: byteFormatter)
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = 0
+        self.numberFormatter = numberFormatter
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .medium
+        self.dateFormatter = dateFormatter
+
+        durationFormatter.allowedUnits = [.day, .hour, .minute, .second]
+        durationFormatter.unitsStyle = .abbreviated
+        durationFormatter.maximumUnitCount = 2
+        durationFormatter.zeroFormattingBehavior = .pad
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        service?.cancel()
+    }
+
+    override func loadView() {
+        view = TCPViewerDynamicBackgroundView(backgroundColor: .windowBackgroundColor)
+        setupLayout()
+    }
+
+    func render(snapshot: NetworkInspectorSnapshot) {
+        let ingestState = snapshot.base.packetIngestState
+        if renderedBackingIdentity != ingestState.backingIdentity ||
+            renderedPacketLineageRevision != ingestState.packetLineageRevision {
+            overviewSnapshot = .empty
+            renderedBackingIdentity = ingestState.backingIdentity
+            renderedPacketLineageRevision = ingestState.packetLineageRevision
+        }
+        latestNetworkSnapshot = snapshot
+        if snapshot.workspaceMode == .overview, service == nil {
+            let service = CaptureOverviewService(latestIngestStateProvider: latestIngestStateProvider)
+            service.snapshotHandler = { [weak self] overviewSnapshot in
+                guard let self else {
+                    return
+                }
+                self.overviewSnapshot = overviewSnapshot
+                self.renderContent()
+            }
+            self.service = service
+        }
+        service?.consume(ingestState)
+        renderContent()
+    }
+
+    // Build a scrollable dashboard that keeps the most useful capture metrics visible first.
+    private func setupLayout() {
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        documentView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = documentView
+        view.addSubview(scrollView)
+
+        sourceLabel.lineBreakMode = .byTruncatingMiddle
+        sourceDetailLabel.lineBreakMode = .byTruncatingMiddle
+        viewPacketsButton.target = self
+        viewPacketsButton.action = #selector(showPackets(_:))
+        viewPacketsButton.bezelStyle = .rounded
+        endpointsButton.target = self
+        endpointsButton.action = #selector(showEndpoints(_:))
+        endpointsButton.bezelStyle = .rounded
+
+        let headerText = NSStackView(views: [sourceLabel, sourceDetailLabel])
+        headerText.orientation = .vertical
+        headerText.alignment = .leading
+        headerText.spacing = 4
+        let headerButtons = NSStackView(views: [viewPacketsButton, endpointsButton])
+        headerButtons.orientation = .horizontal
+        headerButtons.alignment = .centerY
+        headerButtons.spacing = 8
+        let header = NSStackView(views: [headerText, headerButtons])
+        header.orientation = .horizontal
+        header.alignment = .centerY
+        header.distribution = .gravityAreas
+
+        let metrics = NSStackView(views: [durationMetric, packetMetric, trafficMetric, directionMetric])
+        metrics.orientation = .horizontal
+        metrics.alignment = .top
+        metrics.distribution = .fillEqually
+        metrics.spacing = 12
+        for metric in [durationMetric, packetMetric, trafficMetric, directionMetric] {
+            metric.heightAnchor.constraint(equalToConstant: 92).isActive = true
+        }
+
+        let chartCard = sectionCard(title: "Traffic over time", accessory: trafficLegend(), content: chartView)
+        self.chartCard = chartCard
+        chartView.translatesAutoresizingMaskIntoConstraints = false
+        chartView.heightAnchor.constraint(equalToConstant: 210).isActive = true
+
+        setupTopTable()
+        topSegment.selectedSegment = selectedTopGroup.rawValue
+        topSegment.target = self
+        topSegment.action = #selector(changeTopGroup(_:))
+        topSegment.controlSize = .small
+        let topContainer = NSView()
+        topContainer.translatesAutoresizingMaskIntoConstraints = false
+        topScrollView.translatesAutoresizingMaskIntoConstraints = false
+        topEmptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        topEmptyLabel.alignment = .center
+        topContainer.addSubview(topScrollView)
+        topContainer.addSubview(topEmptyLabel)
+        NSLayoutConstraint.activate([
+            topContainer.heightAnchor.constraint(equalToConstant: 330),
+            topScrollView.leadingAnchor.constraint(equalTo: topContainer.leadingAnchor),
+            topScrollView.trailingAnchor.constraint(equalTo: topContainer.trailingAnchor),
+            topScrollView.topAnchor.constraint(equalTo: topContainer.topAnchor),
+            topScrollView.bottomAnchor.constraint(equalTo: topContainer.bottomAnchor),
+            topEmptyLabel.centerXAnchor.constraint(equalTo: topContainer.centerXAnchor),
+            topEmptyLabel.centerYAnchor.constraint(equalTo: topContainer.centerYAnchor),
+        ])
+        let topCard = sectionCard(title: "Top traffic", accessory: topSegment, content: topContainer)
+
+        protocolStack.orientation = .vertical
+        protocolStack.alignment = .width
+        protocolStack.spacing = 8
+        protocolStack.translatesAutoresizingMaskIntoConstraints = false
+        protocolEmptyLabel.alignment = .center
+        protocolEmptyLabel.translatesAutoresizingMaskIntoConstraints = false
+        let protocolContainer = NSView()
+        protocolContainer.translatesAutoresizingMaskIntoConstraints = false
+        protocolContainer.addSubview(protocolStack)
+        protocolContainer.addSubview(protocolEmptyLabel)
+        NSLayoutConstraint.activate([
+            protocolContainer.heightAnchor.constraint(equalToConstant: 330),
+            protocolStack.leadingAnchor.constraint(equalTo: protocolContainer.leadingAnchor),
+            protocolStack.trailingAnchor.constraint(equalTo: protocolContainer.trailingAnchor),
+            protocolStack.topAnchor.constraint(equalTo: protocolContainer.topAnchor),
+            protocolEmptyLabel.centerXAnchor.constraint(equalTo: protocolContainer.centerXAnchor),
+            protocolEmptyLabel.centerYAnchor.constraint(equalTo: protocolContainer.centerYAnchor),
+        ])
+        let protocolCard = sectionCard(title: "Traffic by protocol", content: protocolContainer)
+
+        let trafficDetails = NSStackView(views: [topCard, protocolCard])
+        trafficDetailsView = trafficDetails
+        trafficDetails.orientation = .horizontal
+        trafficDetails.alignment = .top
+        trafficDetails.distribution = .fillEqually
+        trafficDetails.spacing = 12
+
+        noTrafficLabel.alignment = .center
+        noTrafficLabel.translatesAutoresizingMaskIntoConstraints = false
+        noTrafficCard.addSubview(noTrafficLabel)
+        NSLayoutConstraint.activate([
+            noTrafficLabel.leadingAnchor.constraint(equalTo: noTrafficCard.leadingAnchor, constant: 14),
+            noTrafficLabel.trailingAnchor.constraint(equalTo: noTrafficCard.trailingAnchor, constant: -14),
+            noTrafficLabel.topAnchor.constraint(equalTo: noTrafficCard.topAnchor, constant: 28),
+            noTrafficLabel.bottomAnchor.constraint(equalTo: noTrafficCard.bottomAnchor, constant: -28),
+        ])
+
+        warningLabel.maximumNumberOfLines = 3
+        warningLabel.lineBreakMode = .byWordWrapping
+        warningLabel.translatesAutoresizingMaskIntoConstraints = false
+        warningCard.addSubview(warningLabel)
+        NSLayoutConstraint.activate([
+            warningLabel.leadingAnchor.constraint(equalTo: warningCard.leadingAnchor, constant: 14),
+            warningLabel.trailingAnchor.constraint(equalTo: warningCard.trailingAnchor, constant: -14),
+            warningLabel.topAnchor.constraint(equalTo: warningCard.topAnchor, constant: 12),
+            warningLabel.bottomAnchor.constraint(equalTo: warningCard.bottomAnchor, constant: -12),
+        ])
+
+        detailsButton.target = self
+        detailsButton.action = #selector(toggleDetails(_:))
+        detailsButton.setButtonType(.onOff)
+        detailsButton.bezelStyle = .disclosure
+        detailsButton.state = .off
+        detailsLabel.maximumNumberOfLines = 0
+        detailsLabel.lineBreakMode = .byWordWrapping
+        detailsLabel.isHidden = true
+        let detailsStack = NSStackView(views: [detailsButton, detailsLabel])
+        detailsStack.orientation = .vertical
+        detailsStack.alignment = .leading
+        detailsStack.spacing = 8
+
+        let rootStack = NSStackView(views: [
+            header,
+            metrics,
+            noTrafficCard,
+            chartCard,
+            trafficDetails,
+            warningCard,
+            detailsStack,
+        ])
+        rootStack.orientation = .vertical
+        rootStack.alignment = .width
+        rootStack.spacing = 16
+        rootStack.translatesAutoresizingMaskIntoConstraints = false
+        documentView.addSubview(rootStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            documentView.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
+            documentView.trailingAnchor.constraint(equalTo: scrollView.contentView.trailingAnchor),
+            documentView.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
+            documentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+
+            rootStack.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: 22),
+            rootStack.trailingAnchor.constraint(equalTo: documentView.trailingAnchor, constant: -22),
+            rootStack.topAnchor.constraint(equalTo: documentView.topAnchor, constant: 22),
+            rootStack.bottomAnchor.constraint(equalTo: documentView.bottomAnchor, constant: -22),
+        ])
+    }
+
+    private func setupTopTable() {
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("topTraffic"))
+        column.title = ""
+        column.resizingMask = .autoresizingMask
+        topTableView.addTableColumn(column)
+        topTableView.headerView = nil
+        topTableView.rowHeight = 42
+        topTableView.backgroundColor = .clear
+        topTableView.selectionHighlightStyle = .regular
+        topTableView.intercellSpacing = NSSize(width: 0, height: 2)
+        topTableView.delegate = self
+        topTableView.dataSource = self
+        topTableView.target = self
+        topTableView.action = #selector(openSelectedTopRow(_:))
+        topScrollView.documentView = topTableView
+        topScrollView.hasVerticalScroller = true
+        topScrollView.drawsBackground = false
+    }
+
+    private func sectionCard(title: String, accessory: NSView? = nil, content: NSView) -> CaptureOverviewCardView {
+        let card = CaptureOverviewCardView()
+        let titleLabel = TCPViewerUI.label(
+            title,
+            font: .systemFont(ofSize: 15, weight: .semibold)
+        )
+        let headerViews = [titleLabel, accessory].compactMap { $0 }
+        let header = NSStackView(views: headerViews)
+        header.orientation = .horizontal
+        header.alignment = .centerY
+        header.distribution = .gravityAreas
+        let stack = NSStackView(views: [header, content])
+        stack.orientation = .vertical
+        stack.alignment = .width
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: card.topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -14),
+        ])
+        return card
+    }
+
+    private func trafficLegend() -> NSView {
+        let sent = legendLabel(title: "Sent", color: .systemBlue)
+        let received = legendLabel(title: "Received", color: .systemTeal)
+        let stack = NSStackView(views: [sent, received])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 12
+        return stack
+    }
+
+    private func legendLabel(title: String, color: NSColor) -> NSView {
+        let dot = NSView()
+        dot.wantsLayer = true
+        dot.layer?.backgroundColor = color.cgColor
+        dot.layer?.cornerRadius = 3
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dot.widthAnchor.constraint(equalToConstant: 6),
+            dot.heightAnchor.constraint(equalToConstant: 6),
+        ])
+        let label = TCPViewerUI.label(
+            title,
+            font: .systemFont(ofSize: NSFont.smallSystemFontSize),
+            color: .secondaryLabelColor
+        )
+        let stack = NSStackView(views: [dot, label])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 5
+        return stack
+    }
+
+    // Render the latest immutable aggregate together with current capture health and source state.
+    private func renderContent() {
+        guard isViewLoaded, let network = latestNetworkSnapshot else {
+            return
+        }
+        sourceLabel.stringValue = sourceTitle(network)
+        sourceDetailLabel.stringValue = sourceDetails(network)
+        endpointsButton.isEnabled = overviewSnapshot.totals.packets > 0
+        noTrafficCard.isHidden = overviewSnapshot.totals.packets > 0
+        chartCard?.isHidden = overviewSnapshot.totals.packets == 0
+        trafficDetailsView?.isHidden = overviewSnapshot.totals.packets == 0
+
+        durationMetric.render(
+            title: "Duration",
+            value: durationText,
+            detail: overviewSnapshot.firstPacketDate.map { "Started \(dateFormatter.string(from: $0))" } ?? "No packets yet"
+        )
+        packetMetric.render(
+            title: "Packets",
+            value: formattedNumber(overviewSnapshot.totals.packets),
+            detail: "\(overviewSnapshot.appCount) apps · \(overviewSnapshot.domainCount) domains"
+        )
+        trafficMetric.render(
+            title: "Total traffic",
+            value: formattedBytes(overviewSnapshot.totals.bytes),
+            detail: overviewSnapshot.totals.unclassifiedBytes > 0
+                ? "\(formattedBytes(overviewSnapshot.totals.unclassifiedBytes)) unclassified"
+                : "Original packet size"
+        )
+        directionMetric.render(
+            title: "Sent / Received",
+            value: "↑ \(formattedBytes(overviewSnapshot.totals.sentBytes))",
+            detail: "↓ \(formattedBytes(overviewSnapshot.totals.receivedBytes))"
+        )
+        chartView.render(points: overviewSnapshot.timeline)
+        renderTopRows()
+        renderProtocols()
+        renderWarnings(network)
+        renderCaptureDetails(network)
+    }
+
+    private func renderTopRows() {
+        let rows = overviewSnapshot.topRows(for: selectedTopGroup)
+        topEmptyLabel.stringValue = selectedTopGroup == .apps ? "No app traffic yet." : "No resolved domains yet."
+        topEmptyLabel.isHidden = !rows.isEmpty
+        topScrollView.isHidden = rows.isEmpty
+        topTableView.reloadData()
+    }
+
+    private func renderProtocols() {
+        protocolStack.arrangedSubviews.forEach { item in
+            protocolStack.removeArrangedSubview(item)
+            item.removeFromSuperview()
+        }
+        protocolEmptyLabel.isHidden = !overviewSnapshot.protocols.isEmpty
+        for row in overviewSnapshot.protocols {
+            let rowView = CaptureOverviewProtocolRowView()
+            rowView.render(row: row, totalBytes: overviewSnapshot.totals.bytes, byteFormatter: byteFormatter)
+            protocolStack.addArrangedSubview(rowView)
+        }
+    }
+
+    private func renderWarnings(_ snapshot: NetworkInspectorSnapshot) {
+        var warnings: [String] = []
+        if snapshot.droppedPacketCount > 0 {
+            warnings.append("\(formattedNumber(snapshot.droppedPacketCount)) packets dropped")
+        }
+        if overviewSnapshot.malformedPacketCount > 0 {
+            warnings.append("\(formattedNumber(overviewSnapshot.malformedPacketCount)) malformed packets")
+        }
+        if snapshot.base.packetIngestState.truncatedPacketCount > 0 {
+            warnings.append("\(formattedNumber(UInt64(snapshot.base.packetIngestState.truncatedPacketCount))) truncated packets")
+        }
+        if snapshot.base.packetIngestState.decodeIssueCount > 0 {
+            warnings.append("\(formattedNumber(UInt64(snapshot.base.packetIngestState.decodeIssueCount))) decode issues")
+        }
+        warningLabel.stringValue = warnings.joined(separator: " · ")
+        warningCard.isHidden = warnings.isEmpty
+    }
+
+    private func renderCaptureDetails(_ snapshot: NetworkInspectorSnapshot) {
+        let session = snapshot.base.sessionState
+        let ingest = snapshot.base.packetIngestState
+        var details: [String] = []
+        if ingest.source != .offline, let interface = session.selectedInterface {
+            details.append("Interface: \(interface.displayName) (\(interface.technicalName))")
+            details.append("Link type: \(interface.linkType.rawValue)")
+        }
+        if let fileName = snapshot.base.documentState.fileURL?.lastPathComponent {
+            details.append("File: \(fileName)")
+        }
+        if !ingest.importedFiles.isEmpty {
+            details.append("Imported files: \(ingest.importedFiles.count)")
+        }
+        if let captureFilter = snapshot.base.filterState.normalizedCaptureFilter, !captureFilter.isEmpty {
+            details.append("Capture filter: \(captureFilter)")
+        }
+        details.append("Source: \(ingest.source?.rawValue ?? "none")")
+        detailsLabel.stringValue = details.joined(separator: "\n")
+    }
+
+    private func sourceTitle(_ snapshot: NetworkInspectorSnapshot) -> String {
+        if let fileName = snapshot.base.documentState.fileURL?.lastPathComponent {
+            return fileName
+        }
+        if snapshot.base.packetIngestState.source == .offline {
+            let importedFiles = snapshot.base.packetIngestState.importedFiles
+            if importedFiles.count == 1, let importedFile = importedFiles.first {
+                return importedFile.displayName
+            }
+            return importedFiles.isEmpty ? "Imported capture" : "\(importedFiles.count) imported captures"
+        }
+        if let interface = snapshot.base.sessionState.selectedInterface {
+            return interface.displayName
+        }
+        return "Capture overview"
+    }
+
+    private func sourceDetails(_ snapshot: NetworkInspectorSnapshot) -> String {
+        if snapshot.base.packetIngestState.source == .offline {
+            let phase = snapshot.base.documentState.phase
+            return phase == .idle ? "Imported capture" : "Imported capture · \(phase.rawValue.capitalized)"
+        }
+        let status = snapshot.base.sessionState.phase.rawValue.capitalized
+        if let interface = snapshot.base.sessionState.selectedInterface {
+            return "\(interface.technicalName) · \(status)"
+        }
+        return status
+    }
+
+    private var durationText: String {
+        guard let first = overviewSnapshot.firstPacketDate,
+              let last = overviewSnapshot.lastPacketDate else {
+            return "0s"
+        }
+        return durationFormatter.string(from: max(0, last.timeIntervalSince(first))) ?? "0s"
+    }
+
+    private func formattedBytes(_ bytes: UInt64) -> String {
+        byteFormatter.string(fromByteCount: Int64(clamping: bytes))
+    }
+
+    private func formattedNumber(_ value: UInt64) -> String {
+        numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+
+    private func icon(for row: CaptureOverviewTopRow) -> NSImage? {
+        if let iconFilePath = row.iconFilePath {
+            if let cached = iconCache[iconFilePath] {
+                return cached
+            }
+            if let image = NSImage(contentsOfFile: iconFilePath) {
+                iconCache[iconFilePath] = image
+                return image
+            }
+        }
+        switch row.selection {
+        case .app:
+            return TCPViewerUI.image("app")
+        case .domain:
+            return TCPViewerUI.image("globe")
+        default:
+            return TCPViewerUI.image("network")
+        }
+    }
+
+    @objc private func showPackets(_ sender: Any?) {
+        delegate?.captureOverviewViewControllerDidRequestPackets(self)
+    }
+
+    @objc private func showEndpoints(_ sender: Any?) {
+        delegate?.captureOverviewViewControllerDidRequestEndpoints(self)
+    }
+
+    @objc private func changeTopGroup(_ sender: NSSegmentedControl) {
+        guard let group = CaptureOverviewTopGroup(rawValue: sender.selectedSegment) else {
+            return
+        }
+        selectedTopGroup = group
+        renderTopRows()
+    }
+
+    @objc private func toggleDetails(_ sender: NSButton) {
+        detailsLabel.isHidden = sender.state != .on
+    }
+
+    @objc private func openSelectedTopRow(_ sender: Any?) {
+        let selectedRow = topTableView.clickedRow >= 0 ? topTableView.clickedRow : topTableView.selectedRow
+        let rows = overviewSnapshot.topRows(for: selectedTopGroup)
+        guard rows.indices.contains(selectedRow) else {
+            return
+        }
+        delegate?.captureOverviewViewController(self, didSelect: rows[selectedRow].selection)
+    }
+}
+
+extension CaptureOverviewViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        overviewSnapshot.topRows(for: selectedTopGroup).count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let rows = overviewSnapshot.topRows(for: selectedTopGroup)
+        guard rows.indices.contains(row) else {
+            return nil
+        }
+        let cell = tableView.makeView(
+            withIdentifier: CaptureOverviewTopCellView.identifier,
+            owner: self
+        ) as? CaptureOverviewTopCellView ?? CaptureOverviewTopCellView(frame: .zero)
+        cell.identifier = CaptureOverviewTopCellView.identifier
+        let maximumBytes = rows.map(\.totals.bytes).max() ?? 0
+        cell.render(
+            row: rows[row],
+            icon: icon(for: rows[row]),
+            maximumBytes: maximumBytes,
+            captureBytes: overviewSnapshot.totals.bytes,
+            byteFormatter: byteFormatter
+        )
+        return cell
+    }
+
+}

--- a/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/CaptureOverviewViewController.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import PcapPlusPlusCore
+import SwiftUI
 
 protocol CaptureOverviewViewControllerDelegate: AnyObject {
     func captureOverviewViewControllerDidRequestPackets(_ controller: CaptureOverviewViewController)
@@ -17,368 +18,45 @@ protocol CaptureOverviewViewControllerDelegate: AnyObject {
     )
 }
 
-private class CaptureOverviewCardView: NSView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.cornerRadius = 10
-        layer?.borderWidth = 1
-        updateColors()
-    }
+private struct CaptureOverviewNetworkFingerprint: Equatable {
+    let workspaceMode: NetworkInspectorWorkspaceMode
+    let backingIdentity: String?
+    let packetLineageRevision: UInt64
+    let source: CaptureSource?
+    let sessionPhase: CaptureSessionState.Phase
+    let interfaceID: String?
+    let interfaceName: String?
+    let interfaceTechnicalName: String?
+    let interfaceLinkType: CaptureLinkType?
+    let documentPhase: CaptureDocumentState.Phase
+    let documentFileName: String?
+    let importedFileCount: Int
+    let firstImportedFileName: String?
+    let captureFilter: String?
+    let droppedPacketCount: UInt64
+    let truncatedPacketCount: Int
+    let decodeIssueCount: Int
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        updateColors()
-    }
-
-    private func updateColors() {
-        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
-        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.55).cgColor
-    }
-}
-
-private final class CaptureOverviewMetricView: CaptureOverviewCardView {
-    private let titleLabel = TCPViewerUI.label(
-        "",
-        font: .systemFont(ofSize: NSFont.smallSystemFontSize),
-        color: .secondaryLabelColor
-    )
-    private let valueLabel = TCPViewerUI.label(
-        "",
-        font: .monospacedDigitSystemFont(ofSize: 19, weight: .semibold)
-    )
-    private let detailLabel = TCPViewerUI.label(
-        "",
-        font: .systemFont(ofSize: NSFont.smallSystemFontSize),
-        color: .tertiaryLabelColor
-    )
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        let stack = NSStackView(views: [titleLabel, valueLabel, detailLabel])
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = 5
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -14),
-            stack.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
-        ])
-        valueLabel.lineBreakMode = .byTruncatingTail
-        detailLabel.lineBreakMode = .byTruncatingTail
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func render(title: String, value: String, detail: String = "") {
-        titleLabel.stringValue = title
-        valueLabel.stringValue = value
-        detailLabel.stringValue = detail
-        detailLabel.isHidden = detail.isEmpty
-    }
-}
-
-private final class CaptureOverviewTrafficBarView: NSView {
-    private var totals = CaptureOverviewTrafficTotals()
-    private var maximumBytes: UInt64 = 0
-
-    override var isFlipped: Bool { true }
-
-    func render(totals: CaptureOverviewTrafficTotals, maximumBytes: UInt64) {
-        self.totals = totals
-        self.maximumBytes = maximumBytes
-        needsDisplay = true
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        let backgroundPath = NSBezierPath(roundedRect: bounds, xRadius: 2, yRadius: 2)
-        NSColor.separatorColor.withAlphaComponent(0.35).setFill()
-        backgroundPath.fill()
-        guard maximumBytes > 0, totals.bytes > 0, bounds.width > 0 else {
-            return
-        }
-
-        let usedWidth = bounds.width * CGFloat(Double(totals.bytes) / Double(maximumBytes))
-        let parts = [
-            (totals.sentBytes, NSColor.systemBlue),
-            (totals.receivedBytes, NSColor.systemTeal),
-            (totals.unclassifiedBytes, NSColor.systemGray),
-        ]
-        var currentX: CGFloat = 0
-        for (bytes, color) in parts where bytes > 0 {
-            let width = usedWidth * CGFloat(Double(bytes) / Double(totals.bytes))
-            color.setFill()
-            NSBezierPath(rect: NSRect(x: currentX, y: 0, width: width, height: bounds.height)).fill()
-            currentX += width
-        }
-    }
-}
-
-private final class CaptureOverviewTopCellView: NSTableCellView {
-    static let identifier = NSUserInterfaceItemIdentifier("CaptureOverviewTopCell")
-
-    private let iconView = NSImageView()
-    private let titleLabel = TCPViewerUI.label(
-        "",
-        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
-    )
-    private let trafficLabel = TCPViewerUI.label(
-        "",
-        font: .monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
-        color: .secondaryLabelColor
-    )
-    private let barView = CaptureOverviewTrafficBarView()
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        iconView.imageScaling = .scaleProportionallyUpOrDown
-        iconView.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.lineBreakMode = .byTruncatingMiddle
-        trafficLabel.alignment = .right
-        trafficLabel.lineBreakMode = .byTruncatingTail
-        barView.translatesAutoresizingMaskIntoConstraints = false
-
-        addSubview(iconView)
-        addSubview(titleLabel)
-        addSubview(trafficLabel)
-        addSubview(barView)
-        NSLayoutConstraint.activate([
-            iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
-            iconView.topAnchor.constraint(equalTo: topAnchor, constant: 7),
-            iconView.widthAnchor.constraint(equalToConstant: 20),
-            iconView.heightAnchor.constraint(equalToConstant: 20),
-
-            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 8),
-            titleLabel.centerYAnchor.constraint(equalTo: iconView.centerYAnchor),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trafficLabel.leadingAnchor, constant: -8),
-
-            trafficLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
-            trafficLabel.centerYAnchor.constraint(equalTo: iconView.centerYAnchor),
-            trafficLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 240),
-
-            barView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            barView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
-            barView.topAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 5),
-            barView.heightAnchor.constraint(equalToConstant: 4),
-        ])
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func render(
-        row: CaptureOverviewTopRow,
-        icon: NSImage?,
-        maximumBytes: UInt64,
-        captureBytes: UInt64,
-        byteFormatter: ByteCountFormatter
-    ) {
-        titleLabel.stringValue = row.title
-        iconView.image = icon
-        iconView.contentTintColor = icon?.isTemplate == true ? .secondaryLabelColor : nil
-        let percentage = captureBytes > 0 ? Int((Double(row.totals.bytes) / Double(captureBytes) * 100).rounded()) : 0
-        let total = byteFormatter.string(fromByteCount: Int64(clamping: row.totals.bytes))
-        let sent = byteFormatter.string(fromByteCount: Int64(clamping: row.totals.sentBytes))
-        let received = byteFormatter.string(fromByteCount: Int64(clamping: row.totals.receivedBytes))
-        trafficLabel.stringValue = "\(total) · ↑\(sent) ↓\(received) · \(percentage)%"
-        barView.render(totals: row.totals, maximumBytes: maximumBytes)
-        toolTip = "\(row.title)\n\(trafficLabel.stringValue)"
-    }
-}
-
-private final class CaptureOverviewProtocolRowView: NSView {
-    private let titleLabel = TCPViewerUI.label(
-        "",
-        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
-    )
-    private let valueLabel = TCPViewerUI.label(
-        "",
-        font: .monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
-        color: .secondaryLabelColor
-    )
-    private let barView = CaptureOverviewTrafficBarView()
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        valueLabel.translatesAutoresizingMaskIntoConstraints = false
-        valueLabel.alignment = .right
-        barView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(titleLabel)
-        addSubview(valueLabel)
-        addSubview(barView)
-        NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: 38),
-            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
-            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 2),
-            valueLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            valueLabel.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: valueLabel.leadingAnchor, constant: -8),
-            barView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            barView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            barView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 7),
-            barView.heightAnchor.constraint(equalToConstant: 5),
-        ])
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func render(
-        row: CaptureOverviewProtocolRow,
-        totalBytes: UInt64,
-        byteFormatter: ByteCountFormatter
-    ) {
-        titleLabel.stringValue = row.title
-        let percentage = totalBytes > 0 ? Int((Double(row.totals.bytes) / Double(totalBytes) * 100).rounded()) : 0
-        valueLabel.stringValue = "\(percentage)% · \(byteFormatter.string(fromByteCount: Int64(clamping: row.totals.bytes)))"
-        barView.render(totals: row.totals, maximumBytes: totalBytes)
-    }
-}
-
-private final class CaptureOverviewTrafficChartView: NSView, NSViewToolTipOwner {
-    private var points: [CaptureOverviewTimelinePoint] = []
-    private let byteFormatter: ByteCountFormatter
-    private let timeFormatter: DateFormatter
-    private var toolTipTag: NSView.ToolTipTag = 0
-
-    init(byteFormatter: ByteCountFormatter) {
-        self.byteFormatter = byteFormatter
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .medium
-        timeFormatter = formatter
-        super.init(frame: .zero)
-        toolTipTag = addToolTip(bounds, owner: self, userData: nil)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override var isFlipped: Bool { true }
-
-    func render(points: [CaptureOverviewTimelinePoint]) {
-        self.points = points
-        needsDisplay = true
-    }
-
-    override func setFrameSize(_ newSize: NSSize) {
-        super.setFrameSize(newSize)
-        if toolTipTag != 0 {
-            removeToolTip(toolTipTag)
-        }
-        toolTipTag = addToolTip(bounds, owner: self, userData: nil)
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-        let plot = plotRect
-        NSColor.separatorColor.withAlphaComponent(0.3).setStroke()
-        for index in 0...3 {
-            let y = plot.minY + plot.height * CGFloat(index) / 3
-            let path = NSBezierPath()
-            path.move(to: NSPoint(x: plot.minX, y: y))
-            path.line(to: NSPoint(x: plot.maxX, y: y))
-            path.lineWidth = 0.5
-            path.stroke()
-        }
-        guard !points.isEmpty else {
-            return
-        }
-        let maximum = points.reduce(UInt64(0)) { currentMaximum, point in
-            max(currentMaximum, point.totals.sentBytes, point.totals.receivedBytes)
-        }
-        drawPath(for: \CaptureOverviewTrafficTotals.sentBytes, maximum: maximum, color: .systemBlue, in: plot)
-        drawPath(for: \CaptureOverviewTrafficTotals.receivedBytes, maximum: maximum, color: .systemTeal, in: plot)
-    }
-
-    func view(
-        _ view: NSView,
-        stringForToolTip tag: NSView.ToolTipTag,
-        point: NSPoint,
-        userData data: UnsafeMutableRawPointer?
-    ) -> String {
-        guard let item = nearestPoint(to: point) else {
-            return "No traffic"
-        }
-        return [
-            timeFormatter.string(from: item.date),
-            "Sent \(byteFormatter.string(fromByteCount: Int64(clamping: item.totals.sentBytes)))",
-            "Received \(byteFormatter.string(fromByteCount: Int64(clamping: item.totals.receivedBytes)))",
-            "\(item.totals.packets) packets",
-        ].joined(separator: "\n")
-    }
-
-    private var plotRect: NSRect {
-        bounds.insetBy(dx: 8, dy: 8)
-    }
-
-    private func drawPath(
-        for keyPath: KeyPath<CaptureOverviewTrafficTotals, UInt64>,
-        maximum: UInt64,
-        color: NSColor,
-        in plot: NSRect
-    ) {
-        guard maximum > 0 else {
-            return
-        }
-        let firstDate = points.first?.date.timeIntervalSince1970 ?? 0
-        let lastDate = points.last?.date.timeIntervalSince1970 ?? firstDate
-        let span = max(1, lastDate - firstDate)
-        let path = NSBezierPath()
-        for (index, point) in points.enumerated() {
-            let x = plot.minX + plot.width * CGFloat((point.date.timeIntervalSince1970 - firstDate) / span)
-            let ratio = CGFloat(Double(point.totals[keyPath: keyPath]) / Double(maximum))
-            let y = plot.maxY - plot.height * ratio
-            if index == 0 {
-                path.move(to: NSPoint(x: x, y: y))
-            } else {
-                path.line(to: NSPoint(x: x, y: y))
-            }
-        }
-        color.setStroke()
-        path.lineWidth = 2
-        path.lineJoinStyle = .round
-        path.lineCapStyle = .round
-        path.stroke()
-        if points.count == 1, let point = points.first {
-            let ratio = CGFloat(Double(point.totals[keyPath: keyPath]) / Double(maximum))
-            color.setFill()
-            NSBezierPath(ovalIn: NSRect(x: plot.minX - 2, y: plot.maxY - plot.height * ratio - 2, width: 4, height: 4)).fill()
-        }
-    }
-
-    private func nearestPoint(to point: NSPoint) -> CaptureOverviewTimelinePoint? {
-        guard !points.isEmpty else {
-            return nil
-        }
-        guard let firstDate = points.first?.date.timeIntervalSince1970,
-              let lastDate = points.last?.date.timeIntervalSince1970 else {
-            return nil
-        }
-        let fraction = min(1, max(0, (point.x - plotRect.minX) / max(1, plotRect.width)))
-        let targetDate = firstDate + (lastDate - firstDate) * Double(fraction)
-        return points.min { lhs, rhs in
-            abs(lhs.date.timeIntervalSince1970 - targetDate) < abs(rhs.date.timeIntervalSince1970 - targetDate)
-        }
+    init(snapshot: NetworkInspectorSnapshot) {
+        let ingest = snapshot.base.packetIngestState
+        let interface = snapshot.base.sessionState.selectedInterface
+        workspaceMode = snapshot.workspaceMode
+        backingIdentity = ingest.backingIdentity
+        packetLineageRevision = ingest.packetLineageRevision
+        source = ingest.source
+        sessionPhase = snapshot.base.sessionState.phase
+        interfaceID = interface?.id
+        interfaceName = interface?.displayName
+        interfaceTechnicalName = interface?.technicalName
+        interfaceLinkType = interface?.linkType
+        documentPhase = snapshot.base.documentState.phase
+        documentFileName = snapshot.base.documentState.fileURL?.lastPathComponent
+        importedFileCount = ingest.importedFiles.count
+        firstImportedFileName = ingest.importedFiles.first?.displayName
+        captureFilter = snapshot.base.filterState.normalizedCaptureFilter
+        droppedPacketCount = snapshot.droppedPacketCount
+        truncatedPacketCount = ingest.truncatedPacketCount
+        decodeIssueCount = ingest.decodeIssueCount
     }
 }
 
@@ -387,71 +65,21 @@ final class CaptureOverviewViewController: NSViewController {
 
     private let latestIngestStateProvider: () -> PacketIngestState
     private var service: CaptureOverviewService?
+    private var hostingController: NSHostingController<CaptureOverviewDashboardView>?
     private var latestNetworkSnapshot: NetworkInspectorSnapshot?
     private var overviewSnapshot = CaptureOverviewSnapshot.empty
     private var selectedTopGroup = CaptureOverviewTopGroup.apps
+    private var isCaptureDetailsExpanded = false
     private var renderedBackingIdentity: String?
     private var renderedPacketLineageRevision: UInt64?
+    private var renderedNetworkFingerprint: CaptureOverviewNetworkFingerprint?
+    private var renderedDashboardModel: CaptureOverviewDashboardModel?
+    private var iconCache: [String: NSImage] = [:]
 
-    private let scrollView = NSScrollView()
-    private let documentView = NSView()
-    private let sourceLabel = TCPViewerUI.label("Overview", font: .systemFont(ofSize: 24, weight: .semibold))
-    private let sourceDetailLabel = TCPViewerUI.label(
-        "",
-        font: .systemFont(ofSize: NSFont.systemFontSize),
-        color: .secondaryLabelColor
-    )
-    private let viewPacketsButton = NSButton(title: "View Packets", target: nil, action: nil)
-    private let endpointsButton = NSButton(title: "Endpoints…", target: nil, action: nil)
-    private let durationMetric = CaptureOverviewMetricView()
-    private let packetMetric = CaptureOverviewMetricView()
-    private let trafficMetric = CaptureOverviewMetricView()
-    private let directionMetric = CaptureOverviewMetricView()
-    private let chartView: CaptureOverviewTrafficChartView
-    private let topSegment = NSSegmentedControl(
-        labels: CaptureOverviewTopGroup.allCases.map(\.title),
-        trackingMode: .selectOne,
-        target: nil,
-        action: nil
-    )
-    private let topTableView = NSTableView()
-    private let topScrollView = NSScrollView()
-    private let topEmptyLabel = TCPViewerUI.label(
-        "No app traffic yet.",
-        font: .systemFont(ofSize: NSFont.systemFontSize),
-        color: .secondaryLabelColor
-    )
-    private let protocolStack = NSStackView()
-    private let protocolEmptyLabel = TCPViewerUI.label(
-        "No protocol traffic yet.",
-        font: .systemFont(ofSize: NSFont.systemFontSize),
-        color: .secondaryLabelColor
-    )
-    private let noTrafficCard = CaptureOverviewCardView()
-    private let noTrafficLabel = TCPViewerUI.label(
-        "No traffic captured yet.",
-        font: .systemFont(ofSize: NSFont.systemFontSize),
-        color: .secondaryLabelColor
-    )
-    private let warningCard = CaptureOverviewCardView()
-    private let warningLabel = TCPViewerUI.label(
-        "",
-        font: .systemFont(ofSize: NSFont.systemFontSize, weight: .medium),
-        color: .systemOrange
-    )
-    private let detailsButton = NSButton(title: "Capture details", target: nil, action: nil)
-    private let detailsLabel = TCPViewerUI.label(
-        "",
-        font: .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular),
-        color: .secondaryLabelColor
-    )
     private let byteFormatter: ByteCountFormatter
     private let numberFormatter: NumberFormatter
     private let dateFormatter: DateFormatter
     private let durationFormatter = DateComponentsFormatter()
-    private var iconCache: [String: NSImage] = [:]
-    private weak var chartCard: NSView?
-    private weak var trafficDetailsView: NSView?
 
     init(latestIngestStateProvider: @escaping () -> PacketIngestState) {
         self.latestIngestStateProvider = latestIngestStateProvider
@@ -461,7 +89,6 @@ final class CaptureOverviewViewController: NSViewController {
         byteFormatter.allowedUnits = .useAll
         byteFormatter.includesUnit = true
         self.byteFormatter = byteFormatter
-        chartView = CaptureOverviewTrafficChartView(byteFormatter: byteFormatter)
 
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
@@ -476,7 +103,7 @@ final class CaptureOverviewViewController: NSViewController {
         durationFormatter.allowedUnits = [.day, .hour, .minute, .second]
         durationFormatter.unitsStyle = .abbreviated
         durationFormatter.maximumUnitCount = 2
-        durationFormatter.zeroFormattingBehavior = .pad
+        durationFormatter.zeroFormattingBehavior = .dropLeading
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -490,10 +117,21 @@ final class CaptureOverviewViewController: NSViewController {
     }
 
     override func loadView() {
-        view = TCPViewerDynamicBackgroundView(backgroundColor: .windowBackgroundColor)
-        setupLayout()
+        view = NSView()
+        let controller = NSHostingController(rootView: makeDashboardView(model: .empty))
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        addChild(controller)
+        view.addSubview(controller.view)
+        NSLayoutConstraint.activate([
+            controller.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            controller.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            controller.view.topAnchor.constraint(equalTo: view.topAnchor),
+            controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        hostingController = controller
     }
 
+    // Keep raw capture updates in the existing service and replace the immutable SwiftUI root at most every 500 ms.
     func render(snapshot: NetworkInspectorSnapshot) {
         let ingestState = snapshot.base.packetIngestState
         if renderedBackingIdentity != ingestState.backingIdentity ||
@@ -501,325 +139,280 @@ final class CaptureOverviewViewController: NSViewController {
             overviewSnapshot = .empty
             renderedBackingIdentity = ingestState.backingIdentity
             renderedPacketLineageRevision = ingestState.packetLineageRevision
+            renderedDashboardModel = nil
         }
         latestNetworkSnapshot = snapshot
+
+        guard snapshot.workspaceMode == .overview || service != nil else {
+            return
+        }
+
+        var didCreateService = false
         if snapshot.workspaceMode == .overview, service == nil {
             let service = CaptureOverviewService(latestIngestStateProvider: latestIngestStateProvider)
             service.snapshotHandler = { [weak self] overviewSnapshot in
-                guard let self else {
+                guard let self, self.overviewSnapshot != overviewSnapshot else {
                     return
                 }
                 self.overviewSnapshot = overviewSnapshot
-                self.renderContent()
+                self.renderDashboard()
             }
             self.service = service
+            didCreateService = true
         }
         service?.consume(ingestState)
-        renderContent()
-    }
 
-    // Build a scrollable dashboard that keeps the most useful capture metrics visible first.
-    private func setupLayout() {
-        scrollView.hasVerticalScroller = true
-        scrollView.drawsBackground = false
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        documentView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.documentView = documentView
-        view.addSubview(scrollView)
-
-        sourceLabel.lineBreakMode = .byTruncatingMiddle
-        sourceDetailLabel.lineBreakMode = .byTruncatingMiddle
-        viewPacketsButton.target = self
-        viewPacketsButton.action = #selector(showPackets(_:))
-        viewPacketsButton.bezelStyle = .rounded
-        endpointsButton.target = self
-        endpointsButton.action = #selector(showEndpoints(_:))
-        endpointsButton.bezelStyle = .rounded
-
-        let headerText = NSStackView(views: [sourceLabel, sourceDetailLabel])
-        headerText.orientation = .vertical
-        headerText.alignment = .leading
-        headerText.spacing = 4
-        let headerButtons = NSStackView(views: [viewPacketsButton, endpointsButton])
-        headerButtons.orientation = .horizontal
-        headerButtons.alignment = .centerY
-        headerButtons.spacing = 8
-        let header = NSStackView(views: [headerText, headerButtons])
-        header.orientation = .horizontal
-        header.alignment = .centerY
-        header.distribution = .gravityAreas
-
-        let metrics = NSStackView(views: [durationMetric, packetMetric, trafficMetric, directionMetric])
-        metrics.orientation = .horizontal
-        metrics.alignment = .top
-        metrics.distribution = .fillEqually
-        metrics.spacing = 12
-        for metric in [durationMetric, packetMetric, trafficMetric, directionMetric] {
-            metric.heightAnchor.constraint(equalToConstant: 92).isActive = true
+        let networkFingerprint = CaptureOverviewNetworkFingerprint(snapshot: snapshot)
+        guard didCreateService || renderedNetworkFingerprint != networkFingerprint else {
+            return
         }
-
-        let chartCard = sectionCard(title: "Traffic over time", accessory: trafficLegend(), content: chartView)
-        self.chartCard = chartCard
-        chartView.translatesAutoresizingMaskIntoConstraints = false
-        chartView.heightAnchor.constraint(equalToConstant: 210).isActive = true
-
-        setupTopTable()
-        topSegment.selectedSegment = selectedTopGroup.rawValue
-        topSegment.target = self
-        topSegment.action = #selector(changeTopGroup(_:))
-        topSegment.controlSize = .small
-        let topContainer = NSView()
-        topContainer.translatesAutoresizingMaskIntoConstraints = false
-        topScrollView.translatesAutoresizingMaskIntoConstraints = false
-        topEmptyLabel.translatesAutoresizingMaskIntoConstraints = false
-        topEmptyLabel.alignment = .center
-        topContainer.addSubview(topScrollView)
-        topContainer.addSubview(topEmptyLabel)
-        NSLayoutConstraint.activate([
-            topContainer.heightAnchor.constraint(equalToConstant: 330),
-            topScrollView.leadingAnchor.constraint(equalTo: topContainer.leadingAnchor),
-            topScrollView.trailingAnchor.constraint(equalTo: topContainer.trailingAnchor),
-            topScrollView.topAnchor.constraint(equalTo: topContainer.topAnchor),
-            topScrollView.bottomAnchor.constraint(equalTo: topContainer.bottomAnchor),
-            topEmptyLabel.centerXAnchor.constraint(equalTo: topContainer.centerXAnchor),
-            topEmptyLabel.centerYAnchor.constraint(equalTo: topContainer.centerYAnchor),
-        ])
-        let topCard = sectionCard(title: "Top traffic", accessory: topSegment, content: topContainer)
-
-        protocolStack.orientation = .vertical
-        protocolStack.alignment = .width
-        protocolStack.spacing = 8
-        protocolStack.translatesAutoresizingMaskIntoConstraints = false
-        protocolEmptyLabel.alignment = .center
-        protocolEmptyLabel.translatesAutoresizingMaskIntoConstraints = false
-        let protocolContainer = NSView()
-        protocolContainer.translatesAutoresizingMaskIntoConstraints = false
-        protocolContainer.addSubview(protocolStack)
-        protocolContainer.addSubview(protocolEmptyLabel)
-        NSLayoutConstraint.activate([
-            protocolContainer.heightAnchor.constraint(equalToConstant: 330),
-            protocolStack.leadingAnchor.constraint(equalTo: protocolContainer.leadingAnchor),
-            protocolStack.trailingAnchor.constraint(equalTo: protocolContainer.trailingAnchor),
-            protocolStack.topAnchor.constraint(equalTo: protocolContainer.topAnchor),
-            protocolEmptyLabel.centerXAnchor.constraint(equalTo: protocolContainer.centerXAnchor),
-            protocolEmptyLabel.centerYAnchor.constraint(equalTo: protocolContainer.centerYAnchor),
-        ])
-        let protocolCard = sectionCard(title: "Traffic by protocol", content: protocolContainer)
-
-        let trafficDetails = NSStackView(views: [topCard, protocolCard])
-        trafficDetailsView = trafficDetails
-        trafficDetails.orientation = .horizontal
-        trafficDetails.alignment = .top
-        trafficDetails.distribution = .fillEqually
-        trafficDetails.spacing = 12
-
-        noTrafficLabel.alignment = .center
-        noTrafficLabel.translatesAutoresizingMaskIntoConstraints = false
-        noTrafficCard.addSubview(noTrafficLabel)
-        NSLayoutConstraint.activate([
-            noTrafficLabel.leadingAnchor.constraint(equalTo: noTrafficCard.leadingAnchor, constant: 14),
-            noTrafficLabel.trailingAnchor.constraint(equalTo: noTrafficCard.trailingAnchor, constant: -14),
-            noTrafficLabel.topAnchor.constraint(equalTo: noTrafficCard.topAnchor, constant: 28),
-            noTrafficLabel.bottomAnchor.constraint(equalTo: noTrafficCard.bottomAnchor, constant: -28),
-        ])
-
-        warningLabel.maximumNumberOfLines = 3
-        warningLabel.lineBreakMode = .byWordWrapping
-        warningLabel.translatesAutoresizingMaskIntoConstraints = false
-        warningCard.addSubview(warningLabel)
-        NSLayoutConstraint.activate([
-            warningLabel.leadingAnchor.constraint(equalTo: warningCard.leadingAnchor, constant: 14),
-            warningLabel.trailingAnchor.constraint(equalTo: warningCard.trailingAnchor, constant: -14),
-            warningLabel.topAnchor.constraint(equalTo: warningCard.topAnchor, constant: 12),
-            warningLabel.bottomAnchor.constraint(equalTo: warningCard.bottomAnchor, constant: -12),
-        ])
-
-        detailsButton.target = self
-        detailsButton.action = #selector(toggleDetails(_:))
-        detailsButton.setButtonType(.onOff)
-        detailsButton.bezelStyle = .disclosure
-        detailsButton.state = .off
-        detailsLabel.maximumNumberOfLines = 0
-        detailsLabel.lineBreakMode = .byWordWrapping
-        detailsLabel.isHidden = true
-        let detailsStack = NSStackView(views: [detailsButton, detailsLabel])
-        detailsStack.orientation = .vertical
-        detailsStack.alignment = .leading
-        detailsStack.spacing = 8
-
-        let rootStack = NSStackView(views: [
-            header,
-            metrics,
-            noTrafficCard,
-            chartCard,
-            trafficDetails,
-            warningCard,
-            detailsStack,
-        ])
-        rootStack.orientation = .vertical
-        rootStack.alignment = .width
-        rootStack.spacing = 16
-        rootStack.translatesAutoresizingMaskIntoConstraints = false
-        documentView.addSubview(rootStack)
-
-        NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-            documentView.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
-            documentView.trailingAnchor.constraint(equalTo: scrollView.contentView.trailingAnchor),
-            documentView.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
-            documentView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
-
-            rootStack.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: 22),
-            rootStack.trailingAnchor.constraint(equalTo: documentView.trailingAnchor, constant: -22),
-            rootStack.topAnchor.constraint(equalTo: documentView.topAnchor, constant: 22),
-            rootStack.bottomAnchor.constraint(equalTo: documentView.bottomAnchor, constant: -22),
-        ])
+        renderedNetworkFingerprint = networkFingerprint
+        renderDashboard()
     }
 
-    private func setupTopTable() {
-        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("topTraffic"))
-        column.title = ""
-        column.resizingMask = .autoresizingMask
-        topTableView.addTableColumn(column)
-        topTableView.headerView = nil
-        topTableView.rowHeight = 42
-        topTableView.backgroundColor = .clear
-        topTableView.selectionHighlightStyle = .regular
-        topTableView.intercellSpacing = NSSize(width: 0, height: 2)
-        topTableView.delegate = self
-        topTableView.dataSource = self
-        topTableView.target = self
-        topTableView.action = #selector(openSelectedTopRow(_:))
-        topScrollView.documentView = topTableView
-        topScrollView.hasVerticalScroller = true
-        topScrollView.drawsBackground = false
-    }
-
-    private func sectionCard(title: String, accessory: NSView? = nil, content: NSView) -> CaptureOverviewCardView {
-        let card = CaptureOverviewCardView()
-        let titleLabel = TCPViewerUI.label(
-            title,
-            font: .systemFont(ofSize: 15, weight: .semibold)
+    private func makeDashboardView(model: CaptureOverviewDashboardModel) -> CaptureOverviewDashboardView {
+        CaptureOverviewDashboardView(
+            model: model,
+            onViewPackets: { [weak self] in
+                guard let self else { return }
+                delegate?.captureOverviewViewControllerDidRequestPackets(self)
+            },
+            onShowEndpoints: { [weak self] in
+                guard let self else { return }
+                delegate?.captureOverviewViewControllerDidRequestEndpoints(self)
+            },
+            onSelectTopGroup: { [weak self] group in
+                guard let self, selectedTopGroup != group else { return }
+                selectedTopGroup = group
+                renderDashboard()
+            },
+            onSelectTrafficRow: { [weak self] selection in
+                guard let self else { return }
+                delegate?.captureOverviewViewController(self, didSelect: selection)
+            },
+            onToggleDetails: { [weak self] in
+                guard let self else { return }
+                isCaptureDetailsExpanded.toggle()
+                renderDashboard()
+            }
         )
-        let headerViews = [titleLabel, accessory].compactMap { $0 }
-        let header = NSStackView(views: headerViews)
-        header.orientation = .horizontal
-        header.alignment = .centerY
-        header.distribution = .gravityAreas
-        let stack = NSStackView(views: [header, content])
-        stack.orientation = .vertical
-        stack.alignment = .width
-        stack.spacing = 12
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        card.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 14),
-            stack.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -14),
-            stack.topAnchor.constraint(equalTo: card.topAnchor, constant: 12),
-            stack.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -14),
-        ])
-        return card
     }
 
-    private func trafficLegend() -> NSView {
-        let sent = legendLabel(title: "Sent", color: .systemBlue)
-        let received = legendLabel(title: "Received", color: .systemTeal)
-        let stack = NSStackView(views: [sent, received])
-        stack.orientation = .horizontal
-        stack.alignment = .centerY
-        stack.spacing = 12
-        return stack
-    }
-
-    private func legendLabel(title: String, color: NSColor) -> NSView {
-        let dot = NSView()
-        dot.wantsLayer = true
-        dot.layer?.backgroundColor = color.cgColor
-        dot.layer?.cornerRadius = 3
-        dot.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            dot.widthAnchor.constraint(equalToConstant: 6),
-            dot.heightAnchor.constraint(equalToConstant: 6),
-        ])
-        let label = TCPViewerUI.label(
-            title,
-            font: .systemFont(ofSize: NSFont.smallSystemFontSize),
-            color: .secondaryLabelColor
-        )
-        let stack = NSStackView(views: [dot, label])
-        stack.orientation = .horizontal
-        stack.alignment = .centerY
-        stack.spacing = 5
-        return stack
-    }
-
-    // Render the latest immutable aggregate together with current capture health and source state.
-    private func renderContent() {
+    // Format the bounded aggregate once before handing it to small SwiftUI value views.
+    private func renderDashboard() {
         guard isViewLoaded, let network = latestNetworkSnapshot else {
             return
         }
-        sourceLabel.stringValue = sourceTitle(network)
-        sourceDetailLabel.stringValue = sourceDetails(network)
-        endpointsButton.isEnabled = overviewSnapshot.totals.packets > 0
-        noTrafficCard.isHidden = overviewSnapshot.totals.packets > 0
-        chartCard?.isHidden = overviewSnapshot.totals.packets == 0
-        trafficDetailsView?.isHidden = overviewSnapshot.totals.packets == 0
-
-        durationMetric.render(
-            title: "Duration",
-            value: durationText,
-            detail: overviewSnapshot.firstPacketDate.map { "Started \(dateFormatter.string(from: $0))" } ?? "No packets yet"
-        )
-        packetMetric.render(
-            title: "Packets",
-            value: formattedNumber(overviewSnapshot.totals.packets),
-            detail: "\(overviewSnapshot.appCount) apps · \(overviewSnapshot.domainCount) domains"
-        )
-        trafficMetric.render(
-            title: "Total traffic",
-            value: formattedBytes(overviewSnapshot.totals.bytes),
-            detail: overviewSnapshot.totals.unclassifiedBytes > 0
-                ? "\(formattedBytes(overviewSnapshot.totals.unclassifiedBytes)) unclassified"
-                : "Original packet size"
-        )
-        directionMetric.render(
-            title: "Sent / Received",
-            value: "↑ \(formattedBytes(overviewSnapshot.totals.sentBytes))",
-            detail: "↓ \(formattedBytes(overviewSnapshot.totals.receivedBytes))"
-        )
-        chartView.render(points: overviewSnapshot.timeline)
-        renderTopRows()
-        renderProtocols()
-        renderWarnings(network)
-        renderCaptureDetails(network)
-    }
-
-    private func renderTopRows() {
-        let rows = overviewSnapshot.topRows(for: selectedTopGroup)
-        topEmptyLabel.stringValue = selectedTopGroup == .apps ? "No app traffic yet." : "No resolved domains yet."
-        topEmptyLabel.isHidden = !rows.isEmpty
-        topScrollView.isHidden = rows.isEmpty
-        topTableView.reloadData()
-    }
-
-    private func renderProtocols() {
-        protocolStack.arrangedSubviews.forEach { item in
-            protocolStack.removeArrangedSubview(item)
-            item.removeFromSuperview()
+        let model = makeDashboardModel(network: network)
+        guard renderedDashboardModel != model else {
+            return
         }
-        protocolEmptyLabel.isHidden = !overviewSnapshot.protocols.isEmpty
-        for row in overviewSnapshot.protocols {
-            let rowView = CaptureOverviewProtocolRowView()
-            rowView.render(row: row, totalBytes: overviewSnapshot.totals.bytes, byteFormatter: byteFormatter)
-            protocolStack.addArrangedSubview(rowView)
-        }
+        renderedDashboardModel = model
+        hostingController?.rootView = makeDashboardView(model: model)
     }
 
-    private func renderWarnings(_ snapshot: NetworkInspectorSnapshot) {
+    private func makeDashboardModel(network: NetworkInspectorSnapshot) -> CaptureOverviewDashboardModel {
+        let totals = overviewSnapshot.totals
+        let topRows = overviewSnapshot.topRows(for: selectedTopGroup)
+        let maximumTopBytes = topRows.map(\.totals.bytes).max() ?? 0
+        let hasDirectionalTraffic = totals.sentBytes > 0 || totals.receivedBytes > 0
+        let chartPoints = overviewSnapshot.timeline.flatMap { point -> [CaptureOverviewChartPoint] in
+            let directions: [(CaptureOverviewChartPoint.Direction, UInt64)] = hasDirectionalTraffic
+                ? [(.sent, point.totals.sentBytes), (.received, point.totals.receivedBytes)]
+                : [(.total, point.totals.bytes)]
+            return directions.map { direction, bytes in
+                CaptureOverviewChartPoint(
+                    id: .init(date: point.date, direction: direction),
+                    date: point.date,
+                    direction: direction,
+                    bytes: Double(bytes)
+                )
+            }
+        }
+
+        return CaptureOverviewDashboardModel(
+            title: sourceTitle(network),
+            subtitle: sourceSubtitle(network),
+            status: statusPresentation(network),
+            metrics: metricPresentations(),
+            hasTraffic: totals.packets > 0,
+            hasDirectionalTraffic: hasDirectionalTraffic,
+            trafficPoints: chartPoints,
+            totalText: formattedBytes(totals.bytes),
+            sentText: formattedBytes(totals.sentBytes),
+            receivedText: formattedBytes(totals.receivedBytes),
+            selectedTopGroup: selectedTopGroup,
+            topRows: topRows.map { rowPresentation($0, maximumBytes: maximumTopBytes) },
+            protocolRows: overviewSnapshot.protocols.enumerated().map { index, row in
+                CaptureOverviewProtocolPresentation(
+                    id: row.id,
+                    title: row.title,
+                    totalText: formattedBytes(row.totals.bytes),
+                    percentageText: percentageText(row.totals.bytes, of: totals.bytes),
+                    fraction: fraction(row.totals.bytes, of: totals.bytes),
+                    colorIndex: index
+                )
+            },
+            warningText: warningText(network),
+            details: captureDetails(network),
+            isDetailsExpanded: isCaptureDetailsExpanded
+        )
+    }
+
+    private func metricPresentations() -> [CaptureOverviewMetricPresentation] {
+        let totals = overviewSnapshot.totals
+        let startedText = overviewSnapshot.firstPacketDate.map {
+            "Started \(dateFormatter.string(from: $0))"
+        } ?? "No packets yet"
+        let totalDetail = totals.unclassifiedBytes > 0
+            ? "\(formattedBytes(totals.unclassifiedBytes)) direction unknown"
+            : "Original packet bytes"
+
+        return [
+            CaptureOverviewMetricPresentation(
+                id: "duration",
+                title: "Duration",
+                value: durationText,
+                detail: startedText,
+                symbol: "timer",
+                tone: .indigo
+            ),
+            CaptureOverviewMetricPresentation(
+                id: "packets",
+                title: "Packets",
+                value: formattedNumber(totals.packets),
+                detail: "Across the full capture",
+                symbol: "shippingbox.fill",
+                tone: .orange
+            ),
+            CaptureOverviewMetricPresentation(
+                id: "traffic",
+                title: "Total traffic",
+                value: formattedBytes(totals.bytes),
+                detail: totalDetail,
+                symbol: "arrow.up.arrow.down",
+                tone: .blue
+            ),
+            CaptureOverviewMetricPresentation(
+                id: "sent",
+                title: "Sent",
+                value: formattedBytes(totals.sentBytes),
+                detail: "\(percentageText(totals.sentBytes, of: totals.bytes)) of capture",
+                symbol: "arrow.up.right",
+                tone: .cyan
+            ),
+            CaptureOverviewMetricPresentation(
+                id: "received",
+                title: "Received",
+                value: formattedBytes(totals.receivedBytes),
+                detail: "\(percentageText(totals.receivedBytes, of: totals.bytes)) of capture",
+                symbol: "arrow.down.left",
+                tone: .green
+            ),
+            CaptureOverviewMetricPresentation(
+                id: "identities",
+                title: "Discovered",
+                value: "\(overviewSnapshot.appCount) apps",
+                detail: "\(overviewSnapshot.domainCount) resolved domains",
+                symbol: "point.3.connected.trianglepath.dotted",
+                tone: .purple
+            ),
+        ]
+    }
+
+    private func rowPresentation(
+        _ row: CaptureOverviewTopRow,
+        maximumBytes: UInt64
+    ) -> CaptureOverviewTopTrafficPresentation {
+        CaptureOverviewTopTrafficPresentation(
+            id: row.id,
+            title: row.title,
+            icon: icon(for: row),
+            iconFilePath: row.iconFilePath,
+            selection: row.selection,
+            totalText: formattedBytes(row.totals.bytes),
+            sentText: formattedBytes(row.totals.sentBytes),
+            receivedText: formattedBytes(row.totals.receivedBytes),
+            percentageText: percentageText(row.totals.bytes, of: overviewSnapshot.totals.bytes),
+            sentFraction: fraction(row.totals.sentBytes, of: maximumBytes),
+            receivedFraction: fraction(row.totals.receivedBytes, of: maximumBytes),
+            unknownFraction: fraction(row.totals.unclassifiedBytes, of: maximumBytes)
+        )
+    }
+
+    private func icon(for row: CaptureOverviewTopRow) -> NSImage {
+        if let path = row.iconFilePath {
+            if let cached = iconCache[path] {
+                return cached
+            }
+            if let image = NSImage(contentsOfFile: path) {
+                iconCache[path] = image
+                return image
+            }
+        }
+        let symbol: String
+        switch row.selection {
+        case .app:
+            symbol = "app.fill"
+        case .domain:
+            symbol = "globe"
+        default:
+            symbol = "network"
+        }
+        return NSImage(systemSymbolName: symbol, accessibilityDescription: nil) ?? NSImage()
+    }
+
+    private func sourceTitle(_ snapshot: NetworkInspectorSnapshot) -> String {
+        if let fileName = snapshot.base.documentState.fileURL?.lastPathComponent {
+            return fileName
+        }
+        let ingest = snapshot.base.packetIngestState
+        if ingest.source == .offline {
+            if ingest.importedFiles.count == 1, let importedFile = ingest.importedFiles.first {
+                return importedFile.displayName
+            }
+            return ingest.importedFiles.isEmpty ? "Imported capture" : "\(ingest.importedFiles.count) imported captures"
+        }
+        return snapshot.base.sessionState.selectedInterface?.displayName ?? "Capture overview"
+    }
+
+    private func sourceSubtitle(_ snapshot: NetworkInspectorSnapshot) -> String {
+        let ingest = snapshot.base.packetIngestState
+        if ingest.source == .offline {
+            let count = ingest.importedFiles.count
+            return count > 1 ? "Imported capture · \(count) source files" : "Imported capture"
+        }
+        if let interface = snapshot.base.sessionState.selectedInterface {
+            return "Live capture · \(interface.technicalName)"
+        }
+        return "No capture source selected"
+    }
+
+    private func statusPresentation(_ snapshot: NetworkInspectorSnapshot) -> CaptureOverviewStatusPresentation {
+        if snapshot.base.packetIngestState.source == .offline {
+            let phase = snapshot.base.documentState.phase
+            let title = phase == .idle ? "Loaded" : phase.rawValue.capitalized
+            let tone: CaptureOverviewStatusTone = phase == .failed ? .error : .active
+            return CaptureOverviewStatusPresentation(title: title, tone: tone)
+        }
+        let phase = snapshot.base.sessionState.phase
+        let tone: CaptureOverviewStatusTone
+        switch phase {
+        case .running:
+            tone = .positive
+        case .starting, .stopping:
+            tone = .active
+        case .paused:
+            tone = .attention
+        case .failed:
+            tone = .error
+        case .idle, .ready, .stopped:
+            tone = .neutral
+        }
+        return CaptureOverviewStatusPresentation(title: phase.rawValue.capitalized, tone: tone)
+    }
+
+    private func warningText(_ snapshot: NetworkInspectorSnapshot) -> String? {
         var warnings: [String] = []
         if snapshot.droppedPacketCount > 0 {
             warnings.append("\(formattedNumber(snapshot.droppedPacketCount)) packets dropped")
@@ -827,64 +420,35 @@ final class CaptureOverviewViewController: NSViewController {
         if overviewSnapshot.malformedPacketCount > 0 {
             warnings.append("\(formattedNumber(overviewSnapshot.malformedPacketCount)) malformed packets")
         }
-        if snapshot.base.packetIngestState.truncatedPacketCount > 0 {
-            warnings.append("\(formattedNumber(UInt64(snapshot.base.packetIngestState.truncatedPacketCount))) truncated packets")
+        let ingest = snapshot.base.packetIngestState
+        if ingest.truncatedPacketCount > 0 {
+            warnings.append("\(formattedNumber(UInt64(ingest.truncatedPacketCount))) truncated packets")
         }
-        if snapshot.base.packetIngestState.decodeIssueCount > 0 {
-            warnings.append("\(formattedNumber(UInt64(snapshot.base.packetIngestState.decodeIssueCount))) decode issues")
+        if ingest.decodeIssueCount > 0 {
+            warnings.append("\(formattedNumber(UInt64(ingest.decodeIssueCount))) decode issues")
         }
-        warningLabel.stringValue = warnings.joined(separator: " · ")
-        warningCard.isHidden = warnings.isEmpty
+        return warnings.isEmpty ? nil : warnings.joined(separator: " · ")
     }
 
-    private func renderCaptureDetails(_ snapshot: NetworkInspectorSnapshot) {
+    private func captureDetails(_ snapshot: NetworkInspectorSnapshot) -> [CaptureOverviewDetailPresentation] {
         let session = snapshot.base.sessionState
         let ingest = snapshot.base.packetIngestState
-        var details: [String] = []
+        var details: [CaptureOverviewDetailPresentation] = []
         if ingest.source != .offline, let interface = session.selectedInterface {
-            details.append("Interface: \(interface.displayName) (\(interface.technicalName))")
-            details.append("Link type: \(interface.linkType.rawValue)")
+            details.append(.init(id: "interface", label: "Interface", value: "\(interface.displayName) (\(interface.technicalName))"))
+            details.append(.init(id: "link", label: "Link type", value: interface.linkType.rawValue.capitalized))
         }
         if let fileName = snapshot.base.documentState.fileURL?.lastPathComponent {
-            details.append("File: \(fileName)")
+            details.append(.init(id: "file", label: "File", value: fileName))
         }
         if !ingest.importedFiles.isEmpty {
-            details.append("Imported files: \(ingest.importedFiles.count)")
+            details.append(.init(id: "imports", label: "Imported files", value: formattedNumber(UInt64(ingest.importedFiles.count))))
         }
         if let captureFilter = snapshot.base.filterState.normalizedCaptureFilter, !captureFilter.isEmpty {
-            details.append("Capture filter: \(captureFilter)")
+            details.append(.init(id: "filter", label: "Capture filter", value: captureFilter))
         }
-        details.append("Source: \(ingest.source?.rawValue ?? "none")")
-        detailsLabel.stringValue = details.joined(separator: "\n")
-    }
-
-    private func sourceTitle(_ snapshot: NetworkInspectorSnapshot) -> String {
-        if let fileName = snapshot.base.documentState.fileURL?.lastPathComponent {
-            return fileName
-        }
-        if snapshot.base.packetIngestState.source == .offline {
-            let importedFiles = snapshot.base.packetIngestState.importedFiles
-            if importedFiles.count == 1, let importedFile = importedFiles.first {
-                return importedFile.displayName
-            }
-            return importedFiles.isEmpty ? "Imported capture" : "\(importedFiles.count) imported captures"
-        }
-        if let interface = snapshot.base.sessionState.selectedInterface {
-            return interface.displayName
-        }
-        return "Capture overview"
-    }
-
-    private func sourceDetails(_ snapshot: NetworkInspectorSnapshot) -> String {
-        if snapshot.base.packetIngestState.source == .offline {
-            let phase = snapshot.base.documentState.phase
-            return phase == .idle ? "Imported capture" : "Imported capture · \(phase.rawValue.capitalized)"
-        }
-        let status = snapshot.base.sessionState.phase.rawValue.capitalized
-        if let interface = snapshot.base.sessionState.selectedInterface {
-            return "\(interface.technicalName) · \(status)"
-        }
-        return status
+        details.append(.init(id: "source", label: "Source", value: ingest.source?.rawValue.capitalized ?? "None"))
+        return details
     }
 
     private var durationText: String {
@@ -896,87 +460,40 @@ final class CaptureOverviewViewController: NSViewController {
     }
 
     private func formattedBytes(_ bytes: UInt64) -> String {
-        byteFormatter.string(fromByteCount: Int64(clamping: bytes))
+        guard bytes > 0 else {
+            return "0 bytes"
+        }
+        return byteFormatter.string(fromByteCount: Int64(clamping: bytes))
     }
 
     private func formattedNumber(_ value: UInt64) -> String {
         numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
     }
 
-    private func icon(for row: CaptureOverviewTopRow) -> NSImage? {
-        if let iconFilePath = row.iconFilePath {
-            if let cached = iconCache[iconFilePath] {
-                return cached
-            }
-            if let image = NSImage(contentsOfFile: iconFilePath) {
-                iconCache[iconFilePath] = image
-                return image
-            }
+    private func fraction(_ value: UInt64, of total: UInt64) -> Double {
+        guard total > 0 else {
+            return 0
         }
-        switch row.selection {
-        case .app:
-            return TCPViewerUI.image("app")
-        case .domain:
-            return TCPViewerUI.image("globe")
-        default:
-            return TCPViewerUI.image("network")
+        return min(1, Double(value) / Double(total))
+    }
+
+    private func percentageText(_ value: UInt64, of total: UInt64) -> String {
+        let percentage = fraction(value, of: total) * 100
+        if value > 0, percentage < 1 {
+            return "<1%"
         }
-    }
-
-    @objc private func showPackets(_ sender: Any?) {
-        delegate?.captureOverviewViewControllerDidRequestPackets(self)
-    }
-
-    @objc private func showEndpoints(_ sender: Any?) {
-        delegate?.captureOverviewViewControllerDidRequestEndpoints(self)
-    }
-
-    @objc private func changeTopGroup(_ sender: NSSegmentedControl) {
-        guard let group = CaptureOverviewTopGroup(rawValue: sender.selectedSegment) else {
-            return
-        }
-        selectedTopGroup = group
-        renderTopRows()
-    }
-
-    @objc private func toggleDetails(_ sender: NSButton) {
-        detailsLabel.isHidden = sender.state != .on
-    }
-
-    @objc private func openSelectedTopRow(_ sender: Any?) {
-        let selectedRow = topTableView.clickedRow >= 0 ? topTableView.clickedRow : topTableView.selectedRow
-        let rows = overviewSnapshot.topRows(for: selectedTopGroup)
-        guard rows.indices.contains(selectedRow) else {
-            return
-        }
-        delegate?.captureOverviewViewController(self, didSelect: rows[selectedRow].selection)
+        return "\(Int(percentage.rounded()))%"
     }
 }
 
-extension CaptureOverviewViewController: NSTableViewDataSource, NSTableViewDelegate {
-    func numberOfRows(in tableView: NSTableView) -> Int {
-        overviewSnapshot.topRows(for: selectedTopGroup).count
+#if DEBUG
+extension CaptureOverviewViewController {
+    var isSwiftUIHostedForTesting: Bool {
+        hostingController != nil
     }
 
-    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
-        let rows = overviewSnapshot.topRows(for: selectedTopGroup)
-        guard rows.indices.contains(row) else {
-            return nil
-        }
-        let cell = tableView.makeView(
-            withIdentifier: CaptureOverviewTopCellView.identifier,
-            owner: self
-        ) as? CaptureOverviewTopCellView ?? CaptureOverviewTopCellView(frame: .zero)
-        cell.identifier = CaptureOverviewTopCellView.identifier
-        let maximumBytes = rows.map(\.totals.bytes).max() ?? 0
-        cell.render(
-            row: rows[row],
-            icon: icon(for: rows[row]),
-            maximumBytes: maximumBytes,
-            captureBytes: overviewSnapshot.totals.bytes,
-            byteFormatter: byteFormatter
-        )
-        return cell
+    var showsNoTrafficStateForTesting: Bool {
+        renderedDashboardModel?.hasTraffic == false
     }
-
 }
+#endif

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -195,6 +195,11 @@ enum EndpointStatisticsDisplayedSourcePolicy {
             latestSource.packetTableGeneration == source.packetTableGeneration &&
             latestSource.visiblePacketCount == source.visiblePacketCount
     }
+
+    // Finish the UI refresh when a display-filter job settles without changing the visible packet set.
+    static func shouldPresentAfterFiltering(wasWaitingForFilter: Bool, didForward: Bool) -> Bool {
+        wasWaitingForFilter && !didForward
+    }
 }
 
 enum EndpointStatisticsPacketIDSelection {
@@ -657,14 +662,15 @@ struct EndpointStatisticsDisplayedScopeForwarder {
         }
 
         let sourceChanged = sourceIdentity != source.identity
-        let skippedTableGeneration: Bool
-        if let packetTableGeneration {
-            skippedTableGeneration = source.packetTableGeneration != packetTableGeneration &+ 1 &&
-                source.packetTableGeneration != packetTableGeneration
-        } else {
-            skippedTableGeneration = true
+        guard !forceReplacement,
+              !sourceChanged,
+              let currentPacketTableGeneration = packetTableGeneration else {
+            return .replacementRequired
         }
-        if forceReplacement || sourceChanged || skippedTableGeneration {
+        if source.packetTableGeneration == currentPacketTableGeneration {
+            return source.visiblePacketCount == packetCount ? .none : .replacementRequired
+        }
+        guard source.packetTableGeneration == currentPacketTableGeneration &+ 1 else {
             return .replacementRequired
         }
 
@@ -1466,6 +1472,7 @@ private final class EndpointStatisticsViewController: NSViewController {
                 abandonActivePresentation()
                 setCalculating(true, text: "Updating displayed packets…")
             } else {
+                let wasWaitingForFilter = isWaitingForDisplayFilter
                 isWaitingForDisplayFilter = false
                 if displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused {
                     displayedPacketsPipeline.recordDroppedMutation(
@@ -1482,6 +1489,11 @@ private final class EndpointStatisticsViewController: NSViewController {
                 let didForward = consumeDisplayedSource(source, forceReplacement: forcedReplacement)
                 if forcedReplacement && didForward {
                     recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
+                } else if EndpointStatisticsDisplayedSourcePolicy.shouldPresentAfterFiltering(
+                    wasWaitingForFilter: wasWaitingForFilter,
+                    didForward: didForward
+                ) {
+                    requestPresentation(intent: .explicit)
                 }
             }
         }

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -10,13 +10,12 @@ import PcapPlusPlusCore
 
 private enum EndpointStatisticsToolbarItem {
     static let endpointTypes = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.endpointTypes")
-    static let displayedPackets = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.displayedPackets")
-    static let showPackets = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.showPackets")
-    static let copy = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.copy")
     static let search = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.search")
 }
 
 final class EndpointStatisticsWindowController: NSWindowController, NSWindowDelegate {
+    static let defaultContentSize = NSSize(width: 1_440, height: 820)
+
     var closeHandler: (() -> Void)?
 
     private let statisticsViewController: EndpointStatisticsViewController
@@ -34,7 +33,7 @@ final class EndpointStatisticsWindowController: NSWindowController, NSWindowDele
             latestIngestStateProvider: latestIngestStateProvider
         )
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 1_340, height: 720),
+            contentRect: NSRect(origin: .zero, size: Self.defaultContentSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
@@ -1214,11 +1213,7 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
     private let segmentControl = NSSegmentedControl()
     private let displayedPacketsCheckbox = NSButton(checkboxWithTitle: "Displayed packets only", target: nil, action: nil)
     private let endpointTypesToolbarItem = NSToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.endpointTypes)
-    private let displayedPacketsToolbarItem = NSToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.displayedPackets)
-    private let showPacketsToolbarItem = NSToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.showPackets)
-    private let copyToolbarItem = NSMenuToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.copy)
     private let searchToolbarItem = NSSearchToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.search)
-    private let copyMenu = NSMenu(title: "Copy Endpoints")
     private let scrollView = NSScrollView()
     private let tableView = EndpointStatisticsTableView()
     private let footerLabel = NSTextField(labelWithString: "No endpoints")
@@ -1374,11 +1369,12 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         )
     }
 
-    // Keep navigation and common table actions in the native window toolbar.
+    // Keep endpoint navigation and search in the native window toolbar.
     func installToolbar(in window: NSWindow) {
         loadViewIfNeeded()
         let toolbar = NSToolbar(identifier: "TCPViewer.EndpointStatisticsToolbar.v1")
         toolbar.delegate = self
+        toolbar.centeredItemIdentifiers = [EndpointStatisticsToolbarItem.endpointTypes]
         toolbar.displayMode = .iconOnly
         toolbar.allowsUserCustomization = false
         toolbar.autosavesConfiguration = false
@@ -1646,31 +1642,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         endpointTypesToolbarItem.view = segmentControl
         endpointTypesToolbarItem.visibilityPriority = .user
 
-        displayedPacketsCheckbox.controlSize = .small
-        displayedPacketsToolbarItem.label = "Displayed Packets"
-        displayedPacketsToolbarItem.paletteLabel = "Displayed Packets Only"
-        displayedPacketsToolbarItem.view = displayedPacketsCheckbox
-        displayedPacketsToolbarItem.visibilityPriority = .high
-
-        showPacketsToolbarItem.label = "Show Packets"
-        showPacketsToolbarItem.paletteLabel = "Show Related Packets"
-        showPacketsToolbarItem.toolTip = "Show packets for the selected endpoint"
-        showPacketsToolbarItem.image = TCPViewerUI.image("list.bullet.rectangle")
-        showPacketsToolbarItem.target = self
-        showPacketsToolbarItem.action = #selector(showRelatedPacketsFromToolbar(_:))
-        showPacketsToolbarItem.visibilityPriority = .high
-        showPacketsToolbarItem.isEnabled = false
-
-        copyToolbarItem.label = "Copy"
-        copyToolbarItem.paletteLabel = "Copy Endpoints"
-        copyToolbarItem.toolTip = "Copy endpoint rows as CSV or JSON"
-        copyToolbarItem.image = TCPViewerUI.image("doc.on.doc")
-        copyToolbarItem.menu = copyMenu
-        copyToolbarItem.visibilityPriority = .high
-        copyToolbarItem.isEnabled = false
-        copyMenu.autoenablesItems = false
-        copyMenu.delegate = self
-
         searchToolbarItem.label = "Search"
         searchToolbarItem.paletteLabel = "Search Endpoints"
         searchToolbarItem.visibilityPriority = .high
@@ -1741,9 +1712,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         [
             EndpointStatisticsToolbarItem.endpointTypes,
             .flexibleSpace,
-            EndpointStatisticsToolbarItem.displayedPackets,
-            EndpointStatisticsToolbarItem.showPackets,
-            EndpointStatisticsToolbarItem.copy,
             EndpointStatisticsToolbarItem.search,
         ]
     }
@@ -1760,12 +1728,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         switch itemIdentifier {
         case EndpointStatisticsToolbarItem.endpointTypes:
             endpointTypesToolbarItem
-        case EndpointStatisticsToolbarItem.displayedPackets:
-            displayedPacketsToolbarItem
-        case EndpointStatisticsToolbarItem.showPackets:
-            showPacketsToolbarItem
-        case EndpointStatisticsToolbarItem.copy:
-            copyToolbarItem
         case EndpointStatisticsToolbarItem.search:
             searchToolbarItem
         default:
@@ -2713,7 +2675,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
                 context: request.context,
                 classificationRevision: request.classificationRevision
             )
-            updateToolbarActions()
             automaticRefreshPolicy.didCommit(
                 unfilteredEndpointCount: result.table.unfilteredRowCount
             )
@@ -2830,11 +2791,11 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
     ) -> String {
         switch column {
         case .packets: formatNumber(row.packets)
-        case .bytes: formatNumber(row.bytes)
+        case .bytes: byteCountText(row.bytes)
         case .txPackets: formatNumber(row.txPackets)
-        case .txBytes: formatNumber(row.txBytes)
+        case .txBytes: byteCountText(row.txBytes)
         case .rxPackets: formatNumber(row.rxPackets)
-        case .rxBytes: formatNumber(row.rxBytes)
+        case .rxBytes: byteCountText(row.rxBytes)
         default: column.stringValue(in: row)
         }
     }
@@ -2847,12 +2808,10 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         selectedGroup = EndpointStatisticsGroup.allCases[sender.selectedSegment]
         applyColumnLayout(for: selectedGroup)
         applySortDescriptor(currentSort)
-        updateToolbarActions()
         requestPresentation(intent: .explicit)
     }
 
     @objc private func displayedPacketsScopeChanged(_ sender: NSButton) {
-        updateToolbarActions()
         var waitsForAggregation = false
         if usesDisplayedPackets {
             needsDisplayedReplacement = true
@@ -2898,11 +2857,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
             return
         }
         showRelatedPackets(rows[rowIndex].id)
-    }
-
-    @objc private func showRelatedPacketsFromToolbar(_ sender: Any?) {
-        contextTarget = .none
-        showRelatedPacketsFromMenu(sender)
     }
 
     @objc private func showRelatedPacketsFromMenu(_ sender: Any?) {
@@ -3150,26 +3104,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         menu.addItem(menuItem("Copy All Rows as JSON", action: #selector(copyAllJSONFromMenu(_:)), isEnabled: rowsAreActionable && !rows.isEmpty))
     }
 
-    private func updateCopyMenu(_ menu: NSMenu) {
-        contextTarget = .none
-        menu.removeAllItems()
-        let selection = targetSelection()
-        let hasSelection = rowsAreActionable && !selection.isEmpty(rowCount: rows.count)
-        let hasRows = rowsAreActionable && !rows.isEmpty
-
-        menu.addItem(menuItem("Copy Selected Rows as CSV", action: #selector(copySelectedCSVFromMenu(_:)), isEnabled: hasSelection))
-        menu.addItem(menuItem("Copy Selected Rows as JSON", action: #selector(copySelectedJSONFromMenu(_:)), isEnabled: hasSelection))
-        menu.addItem(.separator())
-        menu.addItem(menuItem("Copy All Rows as CSV", action: #selector(copyAllCSVFromMenu(_:)), isEnabled: hasRows))
-        menu.addItem(menuItem("Copy All Rows as JSON", action: #selector(copyAllJSONFromMenu(_:)), isEnabled: hasRows))
-    }
-
-    private func updateToolbarActions() {
-        let hasSelection = rowsAreActionable && !tableView.selectedRowIndexes.isEmpty
-        showPacketsToolbarItem.isEnabled = hasSelection
-        copyToolbarItem.isEnabled = rowsAreActionable && !rows.isEmpty
-    }
-
     private func menuItem(_ title: String, action: Selector, isEnabled: Bool) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
@@ -3350,7 +3284,6 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
 
 extension EndpointStatisticsViewController: NSSearchFieldDelegate {
     func controlTextDidChange(_ obj: Notification) {
-        updateToolbarActions()
         requestPresentation(intent: .explicit)
     }
 }
@@ -3419,7 +3352,6 @@ extension EndpointStatisticsViewController: NSTableViewDataSource, NSTableViewDe
               let key = descriptor.key,
               let column = EndpointStatisticsTableColumn(rawValue: key) else {
             sortByGroup[selectedGroup] = .busiestFirst
-            updateToolbarActions()
             requestPresentation(intent: .explicit)
             return
         }
@@ -3427,12 +3359,7 @@ extension EndpointStatisticsViewController: NSTableViewDataSource, NSTableViewDe
             column: column,
             isAscending: descriptor.ascending
         )
-        updateToolbarActions()
         requestPresentation(intent: .explicit)
-    }
-
-    func tableViewSelectionDidChange(_ notification: Notification) {
-        updateToolbarActions()
     }
 
     func tableViewColumnDidMove(_ notification: Notification) {
@@ -3448,8 +3375,6 @@ extension EndpointStatisticsViewController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === tableView.menu {
             updateContextMenu(menu)
-        } else if menu === copyMenu {
-            updateCopyMenu(menu)
         }
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -1,0 +1,3358 @@
+//
+//  EndpointStatisticsWindowController.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import AppKit
+import PcapPlusPlusCore
+
+final class EndpointStatisticsWindowController: NSWindowController, NSWindowDelegate {
+    var closeHandler: (() -> Void)?
+
+    private let statisticsViewController: EndpointStatisticsViewController
+
+    init(
+        configuration: AppConfiguration,
+        packetProvider: @escaping ([PacketSummary.ID]) -> [PacketSummary],
+        showRelatedPackets: @escaping (EndpointStatisticsRow.ID) -> Void,
+        latestIngestStateProvider: @escaping () -> PacketIngestState? = { nil }
+    ) {
+        statisticsViewController = EndpointStatisticsViewController(
+            configuration: configuration,
+            packetProvider: packetProvider,
+            showRelatedPackets: showRelatedPackets,
+            latestIngestStateProvider: latestIngestStateProvider
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_240, height: 720),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.minSize = NSSize(width: 940, height: 460)
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.setFrameAutosaveName("TCPViewer.EndpointStatisticsWindow")
+        super.init(window: window)
+        window.delegate = self
+        window.contentViewController = statisticsViewController
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Forward every raw ingest mutation so the service remains incremental between UI refreshes.
+    func consume(ingestState: PacketIngestState) {
+        statisticsViewController.consume(ingestState: ingestState)
+    }
+
+    func render(snapshot: NetworkInspectorSnapshot) {
+        statisticsViewController.render(snapshot: snapshot)
+    }
+
+    func updateTitle(_ title: String) {
+        window?.title = title
+    }
+
+    func present(title: String) {
+        updateTitle(title)
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    @IBAction func focusStructuredFilter(_ sender: Any?) {
+        statisticsViewController.focusSearch()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        statisticsViewController.cancel()
+        closeHandler?()
+    }
+
+    deinit {
+        statisticsViewController.cancel()
+    }
+}
+
+private protocol EndpointStatisticsTableKeyboardActionHandling: AnyObject {
+    func endpointStatisticsTableDidRequestCopy(_ tableView: NSTableView)
+}
+
+private final class EndpointStatisticsTableView: NSTableView {
+    weak var keyboardActionHandler: EndpointStatisticsTableKeyboardActionHandling?
+
+    @objc func copy(_ sender: Any?) {
+        keyboardActionHandler?.endpointStatisticsTableDidRequestCopy(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags.contains(.command), event.charactersIgnoringModifiers?.lowercased() == "c" {
+            copy(nil)
+            return
+        }
+        super.keyDown(with: event)
+    }
+}
+
+struct EndpointStatisticsSourceIdentity: Equatable, Sendable {
+    let backingIdentity: String?
+    let packetLineageRevision: UInt64
+}
+
+struct EndpointStatisticsRenderedSource {
+    let identity: EndpointStatisticsSourceIdentity
+    let packetTableGeneration: UInt64
+    let visiblePacketCount: Int
+    let updatePlan: PacketTableUpdatePlan
+    let isFiltering: Bool
+
+    private let packetIDLoader: (EndpointStatisticsPacketIDSelection) -> [PacketSummary.ID]
+
+    init(snapshot: NetworkInspectorSnapshot) {
+        let rowStore = snapshot.packetTableRowStore
+        let visiblePacketCount = snapshot.visiblePacketCount
+        self.init(
+            identity: EndpointStatisticsSourceIdentity(
+                backingIdentity: snapshot.base.packetIngestState.backingIdentity,
+                packetLineageRevision: snapshot.base.packetIngestState.packetLineageRevision
+            ),
+            packetTableGeneration: snapshot.packetTableGeneration,
+            visiblePacketCount: visiblePacketCount,
+            updatePlan: snapshot.packetTableUpdatePlan,
+            isFiltering: snapshot.isPacketTableFiltering,
+            packetIDLoader: { selection in
+                switch selection {
+                case .range(let range):
+                    guard range.upperBound <= rowStore.rowIDs.count else {
+                        return []
+                    }
+                    return Array(rowStore.rowIDs[range])
+                case .indexes(let indexes):
+                    guard indexes.last.map({ $0 < rowStore.rowIDs.count }) != false else {
+                        return []
+                    }
+                    return indexes.map { rowStore.rowIDs[$0] }
+                }
+            }
+        )
+    }
+
+    init(
+        identity: EndpointStatisticsSourceIdentity,
+        packetTableGeneration: UInt64,
+        visiblePacketCount: Int,
+        updatePlan: PacketTableUpdatePlan,
+        isFiltering: Bool,
+        packetIDLoader: @escaping (EndpointStatisticsPacketIDSelection) -> [PacketSummary.ID]
+    ) {
+        self.identity = identity
+        self.packetTableGeneration = packetTableGeneration
+        self.visiblePacketCount = visiblePacketCount
+        self.updatePlan = updatePlan
+        self.isFiltering = isFiltering
+        self.packetIDLoader = packetIDLoader
+    }
+
+    // Load only the IDs needed by the displayed-scope delta instead of aliasing the table's buffer.
+    func packetIDs(in range: Range<Int>) -> [PacketSummary.ID]? {
+        guard range.lowerBound >= 0,
+              range.upperBound <= visiblePacketCount else {
+            return nil
+        }
+        let packetIDs = packetIDLoader(.range(range))
+        return packetIDs.count == range.count ? packetIDs : nil
+    }
+
+    func packetIDs(at indexes: IndexSet) -> [PacketSummary.ID]? {
+        guard indexes.last.map({ $0 < visiblePacketCount }) != false else {
+            return nil
+        }
+        let packetIDs = packetIDLoader(.indexes(indexes))
+        return packetIDs.count == indexes.count ? packetIDs : nil
+    }
+}
+
+enum EndpointStatisticsDisplayedSourcePolicy {
+    static func canLoadReplacement(
+        source: EndpointStatisticsRenderedSource,
+        latestSource: EndpointStatisticsRenderedSource?,
+        expectedIdentity: EndpointStatisticsSourceIdentity,
+        usesDisplayedPackets: Bool
+    ) -> Bool {
+        guard usesDisplayedPackets,
+              !source.isFiltering,
+              source.identity == expectedIdentity,
+              let latestSource,
+              !latestSource.isFiltering else {
+            return false
+        }
+        return latestSource.identity == source.identity &&
+            latestSource.packetTableGeneration == source.packetTableGeneration &&
+            latestSource.visiblePacketCount == source.visiblePacketCount
+    }
+}
+
+enum EndpointStatisticsPacketIDSelection {
+    case range(Range<Int>)
+    case indexes(IndexSet)
+
+    var count: Int {
+        switch self {
+        case .range(let range): range.count
+        case .indexes(let indexes): indexes.count
+        }
+    }
+}
+
+enum EndpointStatisticsDisplayedScopeForwardingResult {
+    case none
+    case update(EndpointStatisticsIngestUpdate)
+    case replacementRequired
+}
+
+struct EndpointStatisticsDisplayedDeferredUpdate {
+    let packetTableGeneration: UInt64
+    let totalPacketCount: Int
+    let kind: EndpointStatisticsIngestUpdate.Kind
+}
+
+struct EndpointStatisticsDisplayedReplacementAccumulator {
+    struct PacketChunk: Sendable {
+        let startIndex: Int
+        var packets: [PacketSummary]
+    }
+
+    static let defaultChunkSize = 2_048
+
+    private(set) var packetCount: Int
+    let chunkSize: Int
+    private(set) var packetChunks: [PacketChunk] = []
+    private(set) var nextPacketIndex = 0
+
+    init(packetCount: Int, chunkSize: Int = defaultChunkSize) {
+        precondition(packetCount >= 0)
+        precondition(chunkSize > 0)
+        self.packetCount = packetCount
+        self.chunkSize = chunkSize
+    }
+
+    var nextRange: Range<Int>? {
+        guard nextPacketIndex < packetCount else {
+            return nil
+        }
+        return nextPacketIndex..<min(packetCount, nextPacketIndex + chunkSize)
+    }
+
+    var isComplete: Bool {
+        nextPacketIndex == packetCount
+    }
+
+    mutating func append(packetIDs: [PacketSummary.ID], packets: [PacketSummary]) -> Bool {
+        guard let range = nextRange,
+              packetIDs.count == range.count,
+              packets.map(\.id) == packetIDs else {
+            return false
+        }
+        packetChunks.append(PacketChunk(startIndex: range.lowerBound, packets: packets))
+        nextPacketIndex = range.upperBound
+        return true
+    }
+
+    mutating func extend(to packetCount: Int) -> Bool {
+        guard packetCount >= self.packetCount else {
+            return false
+        }
+        self.packetCount = packetCount
+        return true
+    }
+
+    mutating func replaceLoadedPacket(at packetIndex: Int, with packet: PacketSummary) {
+        guard packetIndex >= 0, packetIndex < nextPacketIndex else {
+            return
+        }
+        guard let chunkIndex = loadedChunkIndex(containing: packetIndex) else {
+            return
+        }
+        let indexInChunk = packetIndex - packetChunks[chunkIndex].startIndex
+        guard packetChunks[chunkIndex].packets.indices.contains(indexInChunk) else {
+            return
+        }
+        packetChunks[chunkIndex].packets[indexInChunk] = packet
+    }
+
+    private func loadedChunkIndex(containing packetIndex: Int) -> Int? {
+        var lowerBound = 0
+        var upperBound = packetChunks.count
+        while lowerBound < upperBound {
+            let midpoint = lowerBound + (upperBound - lowerBound) / 2
+            if packetChunks[midpoint].startIndex <= packetIndex {
+                lowerBound = midpoint + 1
+            } else {
+                upperBound = midpoint
+            }
+        }
+        return lowerBound > 0 ? lowerBound - 1 : nil
+    }
+}
+
+private struct EndpointStatisticsPresentationRequest: Sendable {
+    let generation: UInt64
+    let intent: EndpointStatisticsPresentationIntent
+    let usesDisplayedPackets: Bool
+    let sourceIdentity: EndpointStatisticsSourceIdentity
+    let ingestCursor: EndpointStatisticsIngestCursor?
+    let displayedCursor: EndpointStatisticsIngestCursor?
+    let classificationRevision: UInt64
+    let group: EndpointStatisticsGroup
+    let searchText: String
+    let sort: EndpointStatisticsTableSort
+
+    var context: EndpointStatisticsPresentationContext {
+        EndpointStatisticsPresentationContext(
+            usesDisplayedPackets: usesDisplayedPackets,
+            sourceIdentity: sourceIdentity,
+            group: group,
+            searchText: searchText,
+            sort: sort
+        )
+    }
+}
+
+private struct EndpointStatisticsPresentationResult: Sendable {
+    let request: EndpointStatisticsPresentationRequest
+    let cancellationToken: EndpointStatisticsCancellationToken
+    let endpointCounts: [EndpointStatisticsGroup: Int]
+    let scopeTotals: EndpointStatisticsTotals
+    let table: EndpointStatisticsTablePresentation
+    let processingDuration: TimeInterval
+}
+
+enum EndpointStatisticsPresentationCadence {
+    static let maximumRefreshRateInterval: TimeInterval = 0.25
+    static let maximumCooldown: TimeInterval = 2
+
+    static func cooldown(after processingDuration: TimeInterval) -> TimeInterval {
+        guard processingDuration > maximumRefreshRateInterval else {
+            return 0
+        }
+        return min(maximumCooldown, max(maximumRefreshRateInterval, processingDuration))
+    }
+}
+
+enum EndpointStatisticsPresentationIntent: Equatable, Sendable {
+    case automatic
+    case explicit
+
+    func merging(_ other: EndpointStatisticsPresentationIntent?) -> EndpointStatisticsPresentationIntent {
+        self == .explicit || other == .explicit ? .explicit : .automatic
+    }
+}
+
+struct EndpointStatisticsAutomaticRefreshPolicy {
+    static let maximumLiveEndpointCount = 10_000
+
+    private(set) var isPaused = false
+
+    func accepts(_ intent: EndpointStatisticsPresentationIntent) -> Bool {
+        intent == .explicit || !isPaused
+    }
+
+    mutating func didCommit(unfilteredEndpointCount: Int) {
+        isPaused = unfilteredEndpointCount > Self.maximumLiveEndpointCount
+    }
+}
+
+struct EndpointStatisticsDisplayedReplacementRecoveryState {
+    var isPaused = false
+    var pendingSourceReplacement = false
+
+    var shouldResumeAutomatically: Bool {
+        pendingSourceReplacement
+    }
+
+    // An overloaded replacement must wait for Refresh instead of retrying on every render.
+    mutating func pauseForOverflow() {
+        isPaused = true
+        pendingSourceReplacement = false
+    }
+
+    mutating func replacementWasAccepted() {
+        isPaused = false
+        pendingSourceReplacement = false
+    }
+}
+
+enum EndpointStatisticsFooterFormatter {
+    static func trafficParts(
+        totals: EndpointStatisticsTotals,
+        formatBytes: (UInt64) -> String
+    ) -> [String] {
+        var parts = [
+            formatBytes(totals.bytes),
+            "Tx \(formatBytes(totals.txBytes))",
+            "Rx \(formatBytes(totals.rxBytes))",
+        ]
+        if totals.unclassifiedBytes > 0 {
+            parts.append("Unclassified \(formatBytes(totals.unclassifiedBytes))")
+        }
+        return parts
+    }
+}
+
+struct EndpointStatisticsPresentationContext: Equatable, Sendable {
+    let usesDisplayedPackets: Bool
+    let sourceIdentity: EndpointStatisticsSourceIdentity
+    let group: EndpointStatisticsGroup
+    let searchText: String
+    let sort: EndpointStatisticsTableSort
+}
+
+enum EndpointStatisticsPresentationCommitDecision: Equatable {
+    case discard
+    case commit
+    case commitAndRefresh
+}
+
+enum EndpointStatisticsPresentationCommitPolicy {
+    // Older append snapshots are coherent enough to show; lineage or query changes are not.
+    static func decision(
+        requestContext: EndpointStatisticsPresentationContext,
+        currentContext: EndpointStatisticsPresentationContext,
+        requestIngestCursor: EndpointStatisticsIngestCursor?,
+        currentIngestCursor: EndpointStatisticsIngestCursor?,
+        requestDisplayedCursor: EndpointStatisticsIngestCursor?,
+        currentDisplayedCursor: EndpointStatisticsIngestCursor?,
+        requestClassificationRevision: UInt64,
+        currentClassificationRevision: UInt64,
+        isWaitingForDisplayFilter: Bool
+    ) -> EndpointStatisticsPresentationCommitDecision {
+        guard !isWaitingForDisplayFilter,
+              requestContext == currentContext,
+              requestClassificationRevision == currentClassificationRevision else {
+            return .discard
+        }
+
+        let requestCursor = requestContext.usesDisplayedPackets
+            ? requestDisplayedCursor
+            : requestIngestCursor
+        let currentCursor = currentContext.usesDisplayedPackets
+            ? currentDisplayedCursor
+            : currentIngestCursor
+        switch (requestCursor, currentCursor) {
+        case (nil, nil):
+            return .commit
+        case (.some(let requestCursor), .some(let currentCursor)):
+            guard requestCursor.packetLineageRevision == currentCursor.packetLineageRevision else {
+                return .discard
+            }
+            return requestCursor == currentCursor ? .commit : .commitAndRefresh
+        case (.none, .some), (.some, .none):
+            return .discard
+        }
+    }
+}
+
+struct EndpointStatisticsActionState: Equatable {
+    let context: EndpointStatisticsPresentationContext
+    let classificationRevision: UInt64
+}
+
+enum EndpointStatisticsRowActionPolicy {
+    static func isEnabled(
+        committedState: EndpointStatisticsActionState?,
+        currentState: EndpointStatisticsActionState,
+        isWaitingForDisplayFilter: Bool
+    ) -> Bool {
+        !isWaitingForDisplayFilter && committedState == currentState
+    }
+}
+
+struct EndpointStatisticsExportCommitToken: Equatable, Sendable {
+    let generation: UInt64
+    let pasteboardChangeCount: Int
+}
+
+enum EndpointStatisticsExportCommitPolicy {
+    static func shouldCommit(
+        _ token: EndpointStatisticsExportCommitToken,
+        currentGeneration: UInt64,
+        currentPasteboardChangeCount: Int
+    ) -> Bool {
+        token.generation == currentGeneration &&
+            token.pasteboardChangeCount == currentPasteboardChangeCount
+    }
+}
+
+struct EndpointStatisticsScopeUpdatePipeline {
+    private var coordinator: EndpointStatisticsUpdateDrainCoordinator
+    private var inFlightClassificationRevision: UInt64 = 0
+    private var pendingClassificationRevision: UInt64 = 0
+
+    private(set) var latestClassificationRevision: UInt64 = 0
+    private(set) var consumedClassificationRevision: UInt64 = 0
+
+    var isPaused: Bool {
+        coordinator.isPaused
+    }
+
+    var canResume: Bool {
+        coordinator.isPaused && !coordinator.isDrainInFlight
+    }
+
+    var isDrainInFlight: Bool {
+        coordinator.isDrainInFlight
+    }
+
+    init(maximumPendingPacketCount: Int = 10_000) {
+        coordinator = EndpointStatisticsUpdateDrainCoordinator(
+            maximumPendingPacketCount: maximumPendingPacketCount
+        )
+    }
+
+    mutating func enqueue(
+        _ update: EndpointStatisticsIngestUpdate
+    ) -> EndpointStatisticsUpdateDrainCoordinator.Action {
+        if update.changesEndpointClassification {
+            latestClassificationRevision &+= 1
+        }
+        let action = coordinator.enqueue(update)
+        recordEnqueueAction(action)
+        return action
+    }
+
+    // Paused pipelines track semantic changes without retaining the dropped packet payload.
+    mutating func recordDroppedMutation(changesEndpointClassification: Bool) {
+        if changesEndpointClassification {
+            latestClassificationRevision &+= 1
+        }
+    }
+
+    mutating func drainCompleted(
+        result: EndpointStatisticsConsumeResult
+    ) -> EndpointStatisticsUpdateDrainCoordinator.Action {
+        if result == .consumed {
+            consumedClassificationRevision = inFlightClassificationRevision
+        }
+        let action = coordinator.drainCompleted(didConsume: result == .consumed)
+        recordCompletionAction(action)
+        return action
+    }
+
+    mutating func resume(
+        withReplacement update: EndpointStatisticsIngestUpdate
+    ) -> EndpointStatisticsUpdateDrainCoordinator.Action {
+        guard canResume else {
+            return isPaused ? .paused : .none
+        }
+        latestClassificationRevision &+= 1
+        let action = coordinator.resume(withReplacement: update)
+        if case .drain = action {
+            inFlightClassificationRevision = latestClassificationRevision
+            pendingClassificationRevision = 0
+        }
+        return action
+    }
+
+    mutating func cancel() {
+        coordinator.cancel()
+        inFlightClassificationRevision = 0
+        pendingClassificationRevision = 0
+    }
+
+    private mutating func recordEnqueueAction(
+        _ action: EndpointStatisticsUpdateDrainCoordinator.Action
+    ) {
+        switch action {
+        case .drain:
+            inFlightClassificationRevision = latestClassificationRevision
+        case .none:
+            if !coordinator.isPaused {
+                pendingClassificationRevision = latestClassificationRevision
+            }
+        case .paused:
+            pendingClassificationRevision = 0
+        }
+    }
+
+
+    private mutating func recordCompletionAction(
+        _ action: EndpointStatisticsUpdateDrainCoordinator.Action
+    ) {
+        if case .drain = action {
+            inFlightClassificationRevision = pendingClassificationRevision
+        }
+        pendingClassificationRevision = 0
+    }
+}
+
+private extension EndpointStatisticsIngestUpdate {
+    var changesEndpointClassification: Bool {
+        switch kind {
+        case .replace, .metadata, .appendWithMetadata:
+            true
+        case .append:
+            false
+        }
+    }
+}
+
+private extension EndpointStatisticsIngestUpdate.Kind {
+    var retainedPacketCountUpperBound: Int {
+        switch self {
+        case .replace(let packets), .append(let packets), .metadata(let packets):
+            packets.count
+        case .appendWithMetadata(let newPackets, let updatedPackets):
+            newPackets.count + updatedPackets.count
+        }
+    }
+}
+
+private extension PacketIngestMutation {
+    var changesEndpointClassification: Bool {
+        switch self {
+        case .reset, .replace, .metadataUpdate, .appendWithMetadataUpdates:
+            true
+        case .none, .append:
+            false
+        }
+    }
+}
+
+private extension PacketTableUpdatePlan {
+    var changesEndpointClassification: Bool {
+        switch self {
+        case .reload, .reloadRows, .appendAndReloadRows:
+            true
+        case .none, .append:
+            false
+        }
+    }
+}
+
+struct EndpointStatisticsDisplayedScopeForwarder {
+    static let maximumDeltaPacketCount = 10_000
+
+    private(set) var cursor: EndpointStatisticsIngestCursor?
+    private(set) var sourceIdentity: EndpointStatisticsSourceIdentity?
+    private(set) var packetTableGeneration: UInt64?
+    private(set) var packetCount = 0
+
+    private var nextPacketRevision: UInt64 = 1
+    private var nextLineageRevision: UInt64 = 1
+
+    // Turn exact packet-table update plans into small statistics updates on the main thread.
+    mutating func forwardingResult(
+        from source: EndpointStatisticsRenderedSource,
+        expectedSourceIdentity: EndpointStatisticsSourceIdentity,
+        forceReplacement: Bool,
+        packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    ) -> EndpointStatisticsDisplayedScopeForwardingResult {
+        guard !source.isFiltering, source.identity == expectedSourceIdentity else {
+            return .none
+        }
+
+        let sourceChanged = sourceIdentity != source.identity
+        let skippedTableGeneration: Bool
+        if let packetTableGeneration {
+            skippedTableGeneration = source.packetTableGeneration != packetTableGeneration &+ 1 &&
+                source.packetTableGeneration != packetTableGeneration
+        } else {
+            skippedTableGeneration = true
+        }
+        if forceReplacement || sourceChanged || skippedTableGeneration {
+            return .replacementRequired
+        }
+
+        switch source.updatePlan {
+        case .none:
+            guard source.visiblePacketCount == packetCount else {
+                return .replacementRequired
+            }
+            packetTableGeneration = source.packetTableGeneration
+            return .none
+        case .append(let range):
+            return appendResult(
+                from: source,
+                appendRange: range,
+                reloadIndexes: [],
+                packetProvider: packetProvider
+            )
+        case .reload:
+            return .replacementRequired
+        case .reloadRows(let indexes):
+            return metadataResult(from: source, indexes: indexes, packetProvider: packetProvider)
+        case .appendAndReloadRows(let range, let indexes):
+            return appendResult(
+                from: source,
+                appendRange: range,
+                reloadIndexes: indexes,
+                packetProvider: packetProvider
+            )
+        }
+    }
+
+    mutating func replacementUpdate(
+        from source: EndpointStatisticsRenderedSource,
+        packets: [PacketSummary]
+    ) -> EndpointStatisticsIngestUpdate? {
+        guard packets.count == source.visiblePacketCount else {
+            return nil
+        }
+        nextPacketRevision &+= 1
+        nextLineageRevision &+= 1
+        sourceIdentity = source.identity
+        packetTableGeneration = source.packetTableGeneration
+        packetCount = source.visiblePacketCount
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: nextPacketRevision,
+            packetLineageRevision: nextLineageRevision,
+            totalPacketCount: packetCount,
+            kind: .replace(packets)
+        )
+        cursor = update.cursor
+        return update
+    }
+
+    mutating func deferredUpdate(
+        _ deferredUpdate: EndpointStatisticsDisplayedDeferredUpdate
+    ) -> EndpointStatisticsIngestUpdate? {
+        guard sourceIdentity != nil,
+              packetTableGeneration.map({ deferredUpdate.packetTableGeneration == $0 &+ 1 }) == true else {
+            return nil
+        }
+        let expectedPacketCount: Int
+        switch deferredUpdate.kind {
+        case .append(let packets):
+            expectedPacketCount = packetCount + packets.count
+        case .appendWithMetadata(let newPackets, _):
+            expectedPacketCount = packetCount + newPackets.count
+        case .metadata:
+            expectedPacketCount = packetCount
+        case .replace:
+            return nil
+        }
+        guard deferredUpdate.totalPacketCount == expectedPacketCount else {
+            return nil
+        }
+        nextPacketRevision &+= 1
+        packetTableGeneration = deferredUpdate.packetTableGeneration
+        packetCount = deferredUpdate.totalPacketCount
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: nextPacketRevision,
+            packetLineageRevision: nextLineageRevision,
+            totalPacketCount: packetCount,
+            kind: deferredUpdate.kind
+        )
+        cursor = update.cursor
+        return update
+    }
+
+    private mutating func appendResult(
+        from source: EndpointStatisticsRenderedSource,
+        appendRange: Range<Int>,
+        reloadIndexes: IndexSet,
+        packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    ) -> EndpointStatisticsDisplayedScopeForwardingResult {
+        guard appendRange.count <= Self.maximumDeltaPacketCount,
+              reloadIndexes.count <= Self.maximumDeltaPacketCount - appendRange.count else {
+            return .replacementRequired
+        }
+        guard appendRange.lowerBound == packetCount,
+              appendRange.upperBound == source.visiblePacketCount,
+              appendRange.lowerBound >= 0,
+              appendRange.lowerBound < appendRange.upperBound else {
+            return .replacementRequired
+        }
+
+        guard let appendedIDs = source.packetIDs(in: appendRange) else {
+            return .replacementRequired
+        }
+        let appendedPackets = packetProvider(appendedIDs)
+        guard appendedPackets.map(\.id) == appendedIDs else {
+            return .replacementRequired
+        }
+        let validReloadIndexes = IndexSet(reloadIndexes.filter { $0 >= 0 && $0 < source.visiblePacketCount })
+        let updatedIDs: [PacketSummary.ID]
+        if validReloadIndexes.isEmpty {
+            updatedIDs = []
+        } else {
+            guard let loadedIDs = source.packetIDs(at: validReloadIndexes) else {
+                return .replacementRequired
+            }
+            updatedIDs = loadedIDs
+        }
+        let updatedPackets = packetProvider(updatedIDs)
+        guard updatedPackets.map(\.id) == updatedIDs else {
+            return .replacementRequired
+        }
+        nextPacketRevision &+= 1
+        packetTableGeneration = source.packetTableGeneration
+        packetCount = source.visiblePacketCount
+        let kind: EndpointStatisticsIngestUpdate.Kind = updatedPackets.isEmpty
+            ? .append(appendedPackets)
+            : .appendWithMetadata(newPackets: appendedPackets, updatedPackets: updatedPackets)
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: nextPacketRevision,
+            packetLineageRevision: nextLineageRevision,
+            totalPacketCount: packetCount,
+            kind: kind
+        )
+        cursor = update.cursor
+        return .update(update)
+    }
+
+    private mutating func metadataResult(
+        from source: EndpointStatisticsRenderedSource,
+        indexes: IndexSet,
+        packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    ) -> EndpointStatisticsDisplayedScopeForwardingResult {
+        guard indexes.count <= Self.maximumDeltaPacketCount else {
+            return .replacementRequired
+        }
+        let validIndexes = IndexSet(indexes.filter { $0 >= 0 && $0 < source.visiblePacketCount })
+        guard !validIndexes.isEmpty else {
+            packetTableGeneration = source.packetTableGeneration
+            return .none
+        }
+        guard let updatedIDs = source.packetIDs(at: validIndexes) else {
+            return .replacementRequired
+        }
+        let updatedPackets = packetProvider(updatedIDs)
+        guard updatedPackets.map(\.id) == updatedIDs else {
+            return .replacementRequired
+        }
+        nextPacketRevision &+= 1
+        packetTableGeneration = source.packetTableGeneration
+        packetCount = source.visiblePacketCount
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: nextPacketRevision,
+            packetLineageRevision: nextLineageRevision,
+            totalPacketCount: packetCount,
+            kind: .metadata(updatedPackets)
+        )
+        cursor = update.cursor
+        return .update(update)
+    }
+}
+
+enum EndpointStatisticsRawDeltaPolicy {
+    static let maximumPacketCount = 10_000
+
+    static func exceedsAutomaticLimit(_ mutation: PacketIngestMutation) -> Bool {
+        switch mutation {
+        case .append(let range):
+            return range.count > maximumPacketCount
+        case .appendWithMetadataUpdates(let range, let packetIDs):
+            return range.count > maximumPacketCount ||
+                packetIDs.count > maximumPacketCount - range.count
+        case .metadataUpdate(let packetIDs):
+            return packetIDs.count > maximumPacketCount
+        case .none, .reset, .replace:
+            return false
+        }
+    }
+}
+
+enum EndpointStatisticsReplacementMode: Equatable {
+    case enqueue
+    case resume
+}
+
+enum EndpointStatisticsDisplayedReplacementUpdateResult: Equatable {
+    case updated
+    case incompatible
+    case overflow
+}
+
+final class EndpointStatisticsDisplayedReplacementWork {
+    static let maximumMetadataPatchCount = 10_000
+
+    private(set) var source: EndpointStatisticsRenderedSource
+    let mode: EndpointStatisticsReplacementMode
+    private(set) var cancellationToken = EndpointStatisticsCancellationToken()
+    var accumulator: EndpointStatisticsDisplayedReplacementAccumulator
+    var isContinuationScheduled = false
+    var isFlattening = false
+    private(set) var deferredUpdates: [EndpointStatisticsDisplayedDeferredUpdate] = []
+    private(set) var retainedDeferredPacketCount = 0
+    private var logicalPacketCount: Int
+
+    init(source: EndpointStatisticsRenderedSource, mode: EndpointStatisticsReplacementMode) {
+        self.source = source
+        self.mode = mode
+        accumulator = EndpointStatisticsDisplayedReplacementAccumulator(
+            packetCount: source.visiblePacketCount
+        )
+        logicalPacketCount = source.visiblePacketCount
+    }
+
+    // Preserve loaded chunks across exact append/reload deltas so a busy table cannot starve replacement.
+    func update(
+        to nextSource: EndpointStatisticsRenderedSource,
+        packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    ) -> EndpointStatisticsDisplayedReplacementUpdateResult {
+        guard !nextSource.isFiltering,
+              nextSource.identity == source.identity else {
+            return .incompatible
+        }
+        if nextSource.packetTableGeneration == source.packetTableGeneration {
+            guard nextSource.visiblePacketCount == source.visiblePacketCount else {
+                return .incompatible
+            }
+            source = nextSource
+            return .updated
+        }
+        guard nextSource.packetTableGeneration == source.packetTableGeneration &+ 1 else {
+            return .incompatible
+        }
+
+        let appendRange: Range<Int>?
+        let reloadIndexes: IndexSet
+        switch nextSource.updatePlan {
+        case .none:
+            appendRange = nil
+            reloadIndexes = []
+        case .append(let range):
+            appendRange = range
+            reloadIndexes = []
+        case .reloadRows(let indexes):
+            appendRange = nil
+            reloadIndexes = indexes
+        case .appendAndReloadRows(let range, let indexes):
+            appendRange = range
+            reloadIndexes = indexes
+        case .reload:
+            return .incompatible
+        }
+        guard reloadIndexes.count <= Self.maximumMetadataPatchCount else {
+            return .overflow
+        }
+        if isFlattening {
+            return deferUpdate(
+                from: nextSource,
+                appendRange: appendRange,
+                reloadIndexes: reloadIndexes,
+                packetProvider: packetProvider
+            )
+        }
+        if let appendRange {
+            guard appendRange.lowerBound == accumulator.packetCount,
+                  appendRange.upperBound == nextSource.visiblePacketCount,
+                  accumulator.extend(to: nextSource.visiblePacketCount) else {
+                return .incompatible
+            }
+        } else if nextSource.visiblePacketCount != accumulator.packetCount {
+            return .incompatible
+        }
+
+        let loadedIndexes = IndexSet(reloadIndexes.filter { $0 >= 0 && $0 < accumulator.nextPacketIndex })
+        if !loadedIndexes.isEmpty {
+            guard let packetIDs = nextSource.packetIDs(at: loadedIndexes) else {
+                return .incompatible
+            }
+            let packets = packetProvider(packetIDs)
+            guard packets.map(\.id) == packetIDs else {
+                return .incompatible
+            }
+            for (packetIndex, packet) in zip(loadedIndexes, packets) {
+                accumulator.replaceLoadedPacket(at: packetIndex, with: packet)
+            }
+        }
+
+        cancellationToken.cancel()
+        cancellationToken = EndpointStatisticsCancellationToken()
+        isFlattening = false
+        source = nextSource
+        logicalPacketCount = nextSource.visiblePacketCount
+        return .updated
+    }
+
+    func acceptsFlattenedPackets(
+        token: EndpointStatisticsCancellationToken,
+        packetCount: Int,
+        flattenedPacketCount: Int
+    ) -> Bool {
+        cancellationToken === token &&
+            accumulator.packetCount == packetCount &&
+            flattenedPacketCount == packetCount &&
+            !token.isCancelled()
+    }
+
+    private func deferUpdate(
+        from nextSource: EndpointStatisticsRenderedSource,
+        appendRange: Range<Int>?,
+        reloadIndexes: IndexSet,
+        packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    ) -> EndpointStatisticsDisplayedReplacementUpdateResult {
+        let appendCount = appendRange?.count ?? 0
+        if let appendRange {
+            guard appendRange.lowerBound == logicalPacketCount,
+                  appendRange.upperBound == nextSource.visiblePacketCount else {
+                return .incompatible
+            }
+        } else if nextSource.visiblePacketCount != logicalPacketCount {
+            return .incompatible
+        }
+        guard appendCount <= Self.maximumMetadataPatchCount,
+              reloadIndexes.count <= Self.maximumMetadataPatchCount - appendCount,
+              appendCount + reloadIndexes.count <= Self.maximumMetadataPatchCount - retainedDeferredPacketCount else {
+            return .overflow
+        }
+        if let appendRange {
+            guard let packetIDs = nextSource.packetIDs(in: appendRange) else {
+                return .incompatible
+            }
+            let newPackets = packetProvider(packetIDs)
+            guard newPackets.map(\.id) == packetIDs else {
+                return .incompatible
+            }
+            guard let updatedPackets = resolvedPackets(
+                at: reloadIndexes,
+                from: nextSource,
+                packetProvider: packetProvider
+            ) else {
+                return .incompatible
+            }
+            let kind: EndpointStatisticsIngestUpdate.Kind = updatedPackets.isEmpty
+                ? .append(newPackets)
+                : .appendWithMetadata(newPackets: newPackets, updatedPackets: updatedPackets)
+            appendDeferredUpdate(kind, source: nextSource, retainedPacketCount: appendCount + reloadIndexes.count)
+            return .updated
+        }
+        guard let updatedPackets = resolvedPackets(
+                at: reloadIndexes,
+                from: nextSource,
+                packetProvider: packetProvider
+              ) else {
+            return .incompatible
+        }
+        appendDeferredUpdate(
+            .metadata(updatedPackets),
+            source: nextSource,
+            retainedPacketCount: reloadIndexes.count
+        )
+        return .updated
+    }
+
+    private func resolvedPackets(
+        at indexes: IndexSet,
+        from source: EndpointStatisticsRenderedSource,
+        packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    ) -> [PacketSummary]? {
+        guard !indexes.isEmpty else {
+            return []
+        }
+        let validIndexes = IndexSet(indexes.filter { $0 >= 0 && $0 < source.visiblePacketCount })
+        guard validIndexes.count == indexes.count,
+              let packetIDs = source.packetIDs(at: validIndexes) else {
+            return nil
+        }
+        let packets = packetProvider(packetIDs)
+        return packets.map(\.id) == packetIDs ? packets : nil
+    }
+
+    private func appendDeferredUpdate(
+        _ kind: EndpointStatisticsIngestUpdate.Kind,
+        source: EndpointStatisticsRenderedSource,
+        retainedPacketCount: Int
+    ) {
+        deferredUpdates.append(EndpointStatisticsDisplayedDeferredUpdate(
+            packetTableGeneration: source.packetTableGeneration,
+            totalPacketCount: source.visiblePacketCount,
+            kind: kind
+        ))
+        self.retainedDeferredPacketCount += retainedPacketCount
+        logicalPacketCount = source.visiblePacketCount
+        self.source = source
+    }
+}
+
+final class EndpointStatisticsRawReplacementWork {
+    let sourceIdentity: EndpointStatisticsSourceIdentity
+    let mode: EndpointStatisticsReplacementMode
+    var packetRevision: UInt64
+    var cancellationToken = EndpointStatisticsCancellationToken()
+    var accumulator: EndpointStatisticsDisplayedReplacementAccumulator
+    var isContinuationScheduled = false
+    var isFlattening = false
+    private(set) var deferredUpdates: [EndpointStatisticsIngestUpdate] = []
+    private(set) var retainedDeferredPacketCount = 0
+    private(set) var logicalPacketCount: Int
+
+    init(
+        sourceIdentity: EndpointStatisticsSourceIdentity,
+        packetRevision: UInt64,
+        packetCount: Int,
+        mode: EndpointStatisticsReplacementMode
+    ) {
+        self.sourceIdentity = sourceIdentity
+        self.packetRevision = packetRevision
+        self.mode = mode
+        accumulator = EndpointStatisticsDisplayedReplacementAccumulator(packetCount: packetCount)
+        logicalPacketCount = packetCount
+    }
+
+    func prepareForMorePackets(packetRevision: UInt64, packetCount: Int) -> Bool {
+        guard accumulator.extend(to: packetCount) else {
+            return false
+        }
+        cancellationToken.cancel()
+        cancellationToken = EndpointStatisticsCancellationToken()
+        isFlattening = false
+        self.packetRevision = packetRevision
+        logicalPacketCount = packetCount
+        return true
+    }
+
+    func prepareForMetadata(packetRevision: UInt64) {
+        cancellationToken.cancel()
+        cancellationToken = EndpointStatisticsCancellationToken()
+        isFlattening = false
+        self.packetRevision = packetRevision
+    }
+
+    func deferUpdate(_ update: EndpointStatisticsIngestUpdate, maximumPacketCount: Int) -> Bool {
+        guard update.previousPacketRevision == packetRevision,
+              update.packetLineageRevision == sourceIdentity.packetLineageRevision else {
+            return false
+        }
+        let expectedPacketCount: Int
+        switch update.kind {
+        case .append(let packets):
+            expectedPacketCount = logicalPacketCount + packets.count
+        case .appendWithMetadata(let newPackets, _):
+            expectedPacketCount = logicalPacketCount + newPackets.count
+        case .metadata:
+            expectedPacketCount = logicalPacketCount
+        case .replace:
+            return false
+        }
+        let retainedPacketCount = update.kind.retainedPacketCountUpperBound
+        guard update.totalPacketCount == expectedPacketCount,
+              retainedPacketCount <= maximumPacketCount - retainedDeferredPacketCount else {
+            return false
+        }
+        deferredUpdates.append(update)
+        retainedDeferredPacketCount += retainedPacketCount
+        packetRevision = update.packetRevision
+        logicalPacketCount = update.totalPacketCount
+        return true
+    }
+
+    func acceptsFlattenedPackets(
+        token: EndpointStatisticsCancellationToken,
+        packetRevision: UInt64,
+        packetCount: Int,
+        flattenedPacketCount: Int
+    ) -> Bool {
+        cancellationToken === token &&
+            packetRevision <= self.packetRevision &&
+            accumulator.packetCount == packetCount &&
+            flattenedPacketCount == packetCount &&
+            !token.isCancelled()
+    }
+}
+
+private final class EndpointStatisticsViewController: NSViewController {
+    private let configuration: AppConfiguration
+    private let packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
+    private let showRelatedPackets: (EndpointStatisticsRow.ID) -> Void
+    private let latestIngestStateProvider: () -> PacketIngestState?
+    private let allPacketsQueue = DispatchQueue(
+        label: "com.proxyman.tcpviewer.endpoint-statistics.all",
+        qos: .userInitiated
+    )
+    private let displayedPacketsQueue = DispatchQueue(
+        label: "com.proxyman.tcpviewer.endpoint-statistics.displayed",
+        qos: .userInitiated
+    )
+    private let exportQueue = DispatchQueue(
+        label: "com.proxyman.tcpviewer.endpoint-statistics.export",
+        qos: .userInitiated
+    )
+    private let allPacketsService = EndpointStatisticsService()
+    private let displayedPacketsService = EndpointStatisticsService()
+    private let allPacketsCancellationToken = EndpointStatisticsCancellationToken()
+    private let displayedPacketsCancellationToken = EndpointStatisticsCancellationToken()
+
+    private let segmentControl = NSSegmentedControl()
+    private let displayedPacketsCheckbox = NSButton(checkboxWithTitle: "Displayed packets only", target: nil, action: nil)
+    private let searchField = NSSearchField()
+    private let scrollView = NSScrollView()
+    private let tableView = EndpointStatisticsTableView()
+    private let footerLabel = NSTextField(labelWithString: "No endpoints")
+    private let progressIndicator = NSProgressIndicator()
+    private let calculatingLabel = NSTextField(labelWithString: "Calculating…")
+    private let refreshNoticeLabel = NSTextField(labelWithString: "")
+    private let refreshButton = NSButton(title: "Refresh", target: nil, action: nil)
+    private let numberFormatter: NumberFormatter
+    private let byteCountFormatter: ByteCountFormatter
+
+    private let columnServices: [EndpointStatisticsGroup: PacketTableColumnService]
+    private let columnStores: [EndpointStatisticsGroup: PacketTableColumnLayoutStore]
+    private var columnVisibilityMenuController: PacketTableColumnVisibilityMenuController?
+    private var isApplyingColumnLayout = false
+    private var sortByGroup = Dictionary(
+        uniqueKeysWithValues: EndpointStatisticsGroup.allCases.map { ($0, EndpointStatisticsTableSort.busiestFirst) }
+    )
+
+    private var selectedGroup: EndpointStatisticsGroup = .apps
+    private var rows: [EndpointStatisticsRow] = []
+    private var rowIndexByID: [EndpointStatisticsRow.ID: Int] = [:]
+    private var latestRenderedSource: EndpointStatisticsRenderedSource?
+    private var latestSourceIdentity = EndpointStatisticsSourceIdentity(backingIdentity: nil, packetLineageRevision: 0)
+    private var ingestCursor: EndpointStatisticsIngestCursor?
+    private var consumedIngestCursor: EndpointStatisticsIngestCursor?
+    private var rawReplacementWork: EndpointStatisticsRawReplacementWork?
+    private var isRawReplacementPaused = false
+    private var displayedForwarder = EndpointStatisticsDisplayedScopeForwarder()
+    private var displayedReplacementWork: EndpointStatisticsDisplayedReplacementWork?
+    private var displayedReplacementRecoveryState = EndpointStatisticsDisplayedReplacementRecoveryState()
+    private var isDisplayedReplacementPaused: Bool {
+        get { displayedReplacementRecoveryState.isPaused }
+        set { displayedReplacementRecoveryState.isPaused = newValue }
+    }
+    private var consumedDisplayedCursor: EndpointStatisticsIngestCursor?
+    private var allPacketsPipeline = EndpointStatisticsScopeUpdatePipeline()
+    private var displayedPacketsPipeline = EndpointStatisticsScopeUpdatePipeline()
+    private var needsDisplayedReplacement = true
+    private var pendingAllPacketsSourceReplacement = false
+    private var pendingDisplayedPacketsSourceReplacement: Bool {
+        get { displayedReplacementRecoveryState.pendingSourceReplacement }
+        set { displayedReplacementRecoveryState.pendingSourceReplacement = newValue }
+    }
+    private var waitsForAllPacketsManualRefresh = false
+    private var waitsForDisplayedPacketsManualRefresh = false
+    private var allPacketsPresentationIntentAfterDrain: EndpointStatisticsPresentationIntent?
+    private var displayedPacketsPresentationIntentAfterDrain: EndpointStatisticsPresentationIntent?
+
+    private var presentationGeneration: UInt64 = 0
+    private var scheduledPresentationWorkItem: DispatchWorkItem?
+    private var isPresentationInFlight = false
+    private var activePresentationCancellationToken: EndpointStatisticsCancellationToken?
+    private var pendingPresentationIntent: EndpointStatisticsPresentationIntent?
+    private var lastPresentationStartTime: TimeInterval = 0
+    private var nextPresentationAllowedTime: TimeInterval = 0
+    private var automaticRefreshPolicy = EndpointStatisticsAutomaticRefreshPolicy()
+    private var contextTarget = EndpointStatisticsContextTarget.none
+    private var exportGeneration: UInt64 = 0
+    private var activeExportCancellationToken: EndpointStatisticsCancellationToken?
+    private var isWaitingForDisplayFilter = false
+    private var committedActionState: EndpointStatisticsActionState?
+    private var isCancelled = false
+
+    init(
+        configuration: AppConfiguration,
+        packetProvider: @escaping ([PacketSummary.ID]) -> [PacketSummary],
+        showRelatedPackets: @escaping (EndpointStatisticsRow.ID) -> Void,
+        latestIngestStateProvider: @escaping () -> PacketIngestState?
+    ) {
+        self.configuration = configuration
+        self.packetProvider = packetProvider
+        self.showRelatedPackets = showRelatedPackets
+        self.latestIngestStateProvider = latestIngestStateProvider
+
+        var services: [EndpointStatisticsGroup: PacketTableColumnService] = [:]
+        var stores: [EndpointStatisticsGroup: PacketTableColumnLayoutStore] = [:]
+        for group in EndpointStatisticsGroup.allCases {
+            let service = PacketTableColumnService(definitions: Self.columnDefinitions(for: group))
+            let store = PacketTableColumnLayoutStore(
+                defaults: configuration.userDefaults,
+                key: "TCPViewer.endpointStatistics.columns.v1.\(group.rawValue)"
+            )
+            if let layout = store.load() {
+                service.applyVisibility(from: layout)
+            }
+            services[group] = service
+            stores[group] = store
+        }
+        columnServices = services
+        columnStores = stores
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.maximumFractionDigits = 0
+        self.numberFormatter = numberFormatter
+
+        let byteCountFormatter = ByteCountFormatter()
+        byteCountFormatter.countStyle = .file
+        byteCountFormatter.allowedUnits = [.useAll]
+        byteCountFormatter.includesUnit = true
+        self.byteCountFormatter = byteCountFormatter
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    func cancel() {
+        guard !isCancelled else {
+            return
+        }
+        isCancelled = true
+        activeExportCancellationToken?.cancel()
+        activeExportCancellationToken = nil
+        exportGeneration &+= 1
+        scheduledPresentationWorkItem?.cancel()
+        scheduledPresentationWorkItem = nil
+        rawReplacementWork?.cancellationToken.cancel()
+        rawReplacementWork = nil
+        displayedReplacementWork?.cancellationToken.cancel()
+        displayedReplacementWork = nil
+        allPacketsCancellationToken.cancel()
+        displayedPacketsCancellationToken.cancel()
+        activePresentationCancellationToken?.cancel()
+        activePresentationCancellationToken = nil
+        allPacketsPipeline.cancel()
+        displayedPacketsPipeline.cancel()
+    }
+
+    override func loadView() {
+        view = NSView()
+        setupControls()
+        setupTable()
+        setupLayout()
+        applyColumnLayout(for: selectedGroup)
+        applySortDescriptor(currentSort)
+        updateSegmentLabels(counts: [:])
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appConfigurationDidChange(_:)),
+            name: AppConfiguration.didChangeNotification,
+            object: configuration
+        )
+    }
+
+    // Convert a main-thread ingest state into a small owned update before crossing queues.
+    func consume(ingestState: PacketIngestState) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard !isCancelled else {
+            return
+        }
+        let sourceIdentity = EndpointStatisticsSourceIdentity(
+            backingIdentity: ingestState.backingIdentity,
+            packetLineageRevision: ingestState.packetLineageRevision
+        )
+        if ingestCursor?.packetRevision == ingestState.packetRevision,
+           latestSourceIdentity == sourceIdentity {
+            return
+        }
+        let sourceChanged = latestSourceIdentity != sourceIdentity
+        if sourceChanged {
+            needsDisplayedReplacement = true
+            displayedReplacementWork?.cancellationToken.cancel()
+            displayedReplacementWork = nil
+            if usesDisplayedPackets {
+                scheduledPresentationWorkItem?.cancel()
+                scheduledPresentationWorkItem = nil
+                presentationGeneration &+= 1
+                pendingPresentationIntent = .explicit
+                abandonActivePresentation()
+                setCalculating(true, text: "Updating displayed packets…")
+            }
+        }
+        if sourceChanged, displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused {
+            pendingDisplayedPacketsSourceReplacement = true
+        }
+        let previousIngestCursor = ingestCursor
+        ingestCursor = EndpointStatisticsIngestCursor(
+            packetRevision: ingestState.packetRevision,
+            packetLineageRevision: ingestState.packetLineageRevision,
+            totalPacketCount: ingestState.packets.count
+        )
+        latestSourceIdentity = sourceIdentity
+
+        if let rawReplacementWork {
+            updateRawReplacement(
+                rawReplacementWork,
+                from: ingestState,
+                sourceIdentity: sourceIdentity
+            )
+            if sourceChanged {
+                recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: false)
+            }
+            return
+        }
+        if isRawReplacementPaused {
+            allPacketsPipeline.recordDroppedMutation(
+                changesEndpointClassification: ingestState.lastMutation.changesEndpointClassification
+            )
+            if sourceChanged {
+                pendingAllPacketsSourceReplacement = true
+                startRawReplacement(
+                    from: ingestState,
+                    mode: allPacketsPipeline.canResume ? .resume : .enqueue
+                )
+                recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: false)
+            } else {
+                updateRefreshNotice()
+            }
+            return
+        }
+        if allPacketsPipeline.isPaused {
+            if sourceChanged {
+                pendingAllPacketsSourceReplacement = true
+                allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+                if allPacketsPipeline.canResume {
+                    startRawReplacement(from: ingestState, mode: .resume)
+                }
+            } else {
+                allPacketsPipeline.recordDroppedMutation(
+                    changesEndpointClassification: ingestState.lastMutation.changesEndpointClassification
+                )
+            }
+            updateRefreshNotice()
+            return
+        }
+
+        if !sourceChanged,
+           EndpointStatisticsRawDeltaPolicy.exceedsAutomaticLimit(ingestState.lastMutation) {
+            allPacketsPipeline.recordDroppedMutation(
+                changesEndpointClassification: ingestState.lastMutation.changesEndpointClassification
+            )
+            isRawReplacementPaused = true
+            waitsForAllPacketsManualRefresh = false
+            updateRefreshNotice()
+            return
+        }
+
+        let update = EndpointStatisticsIngestUpdate(
+            ingestState: ingestState,
+            previousCursor: previousIngestCursor
+        )
+        if case .replace = update.kind {
+            allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            startRawReplacement(from: ingestState, mode: .enqueue)
+            if sourceChanged {
+                recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: false)
+            }
+            return
+        }
+        let action = allPacketsPipeline.enqueue(update)
+        if sourceChanged, case .paused = action {
+            pendingAllPacketsSourceReplacement = true
+        }
+        handleAllPacketsDrainAction(action)
+        if sourceChanged {
+            recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: false)
+        }
+    }
+
+    func render(snapshot: NetworkInspectorSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard !isCancelled else {
+            return
+        }
+        // This descriptor retains the row store, not its Array value, so all-packet renders stay CoW-free.
+        let source = EndpointStatisticsRenderedSource(snapshot: snapshot)
+        latestRenderedSource = source
+        if usesDisplayedPackets {
+            if source.isFiltering {
+                isWaitingForDisplayFilter = true
+                presentationGeneration &+= 1
+                pendingPresentationIntent = nil
+                abandonActivePresentation()
+                setCalculating(true, text: "Updating displayed packets…")
+            } else {
+                isWaitingForDisplayFilter = false
+                if displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused {
+                    displayedPacketsPipeline.recordDroppedMutation(
+                        changesEndpointClassification: source.updatePlan.changesEndpointClassification
+                    )
+                    if waitsForDisplayedPacketsManualRefresh ||
+                        displayedReplacementRecoveryState.shouldResumeAutomatically {
+                        resumeDisplayedPacketsForSourceReplacement(source)
+                    }
+                    updateRefreshNotice()
+                    return
+                }
+                let forcedReplacement = needsDisplayedReplacement
+                let didForward = consumeDisplayedSource(source, forceReplacement: forcedReplacement)
+                if forcedReplacement && didForward {
+                    recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
+                }
+            }
+        }
+    }
+
+    func focusSearch() {
+        view.window?.makeFirstResponder(searchField)
+    }
+
+    private var usesDisplayedPackets: Bool {
+        displayedPacketsCheckbox.state == .on
+    }
+
+    private var currentPipelineIsPaused: Bool {
+        usesDisplayedPackets
+            ? displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused
+            : allPacketsPipeline.isPaused || isRawReplacementPaused
+    }
+
+    private var currentPipelineIsDraining: Bool {
+        usesDisplayedPackets
+            ? displayedPacketsPipeline.isDrainInFlight || displayedReplacementWork != nil
+            : allPacketsPipeline.isDrainInFlight || rawReplacementWork != nil
+    }
+
+    private var currentSort: EndpointStatisticsTableSort {
+        sortByGroup[selectedGroup] ?? .busiestFirst
+    }
+
+    private var currentPresentationContext: EndpointStatisticsPresentationContext {
+        EndpointStatisticsPresentationContext(
+            usesDisplayedPackets: usesDisplayedPackets,
+            sourceIdentity: latestSourceIdentity,
+            group: selectedGroup,
+            searchText: searchField.stringValue,
+            sort: currentSort
+        )
+    }
+
+    private var currentActionState: EndpointStatisticsActionState {
+        return EndpointStatisticsActionState(
+            context: currentPresentationContext,
+            classificationRevision: usesDisplayedPackets
+                ? displayedPacketsPipeline.latestClassificationRevision
+                : allPacketsPipeline.latestClassificationRevision
+        )
+    }
+
+    private var rowsAreActionable: Bool {
+        EndpointStatisticsRowActionPolicy.isEnabled(
+            committedState: committedActionState,
+            currentState: currentActionState,
+            isWaitingForDisplayFilter: isWaitingForDisplayFilter
+        )
+    }
+
+    private var currentColumnService: PacketTableColumnService? {
+        columnServices[selectedGroup]
+    }
+
+    private func setupControls() {
+        segmentControl.segmentCount = EndpointStatisticsGroup.allCases.count
+        segmentControl.trackingMode = .selectOne
+        segmentControl.segmentStyle = .rounded
+        segmentControl.selectedSegment = 0
+        segmentControl.target = self
+        segmentControl.action = #selector(groupChanged(_:))
+        segmentControl.setAccessibilityLabel("Endpoint type")
+
+        displayedPacketsCheckbox.target = self
+        displayedPacketsCheckbox.action = #selector(displayedPacketsScopeChanged(_:))
+        displayedPacketsCheckbox.toolTip = "Use the packets currently shown in the main table."
+
+        searchField.placeholderString = "Search endpoints"
+        searchField.sendsSearchStringImmediately = true
+        searchField.delegate = self
+        searchField.setAccessibilityLabel("Search endpoints")
+
+        progressIndicator.style = .spinning
+        progressIndicator.controlSize = .small
+        progressIndicator.isDisplayedWhenStopped = false
+        calculatingLabel.textColor = .secondaryLabelColor
+        calculatingLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        calculatingLabel.isHidden = true
+
+        footerLabel.textColor = .secondaryLabelColor
+        footerLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        footerLabel.lineBreakMode = .byTruncatingTail
+
+        refreshNoticeLabel.textColor = .secondaryLabelColor
+        refreshNoticeLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        refreshNoticeLabel.lineBreakMode = .byTruncatingTail
+        refreshNoticeLabel.isHidden = true
+        refreshButton.controlSize = .small
+        refreshButton.bezelStyle = .rounded
+        refreshButton.target = self
+        refreshButton.action = #selector(refreshStatistics(_:))
+        refreshButton.isHidden = true
+    }
+
+    private func setupTable() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.keyboardActionHandler = self
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.allowsEmptySelection = true
+        tableView.allowsMultipleSelection = true
+        tableView.allowsColumnReordering = true
+        tableView.allowsColumnResizing = true
+        tableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
+        tableView.selectionHighlightStyle = .regular
+        tableView.style = .fullWidth
+        tableView.rowHeight = configuration.packetRowHeight
+        tableView.intercellSpacing = .zero
+        tableView.target = self
+        tableView.doubleAction = #selector(showRelatedPacketsFromDoubleClick(_:))
+        tableView.menu = makeContextMenu()
+
+        Self.columnDefinitions(for: .tcp).forEach(addColumn)
+
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = false
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .controlBackgroundColor
+    }
+
+    // Keep the common controls visible while the table consumes the flexible window area.
+    private func setupLayout() {
+        let topStack = NSStackView(views: [segmentControl, displayedPacketsCheckbox, searchField])
+        topStack.orientation = .horizontal
+        topStack.alignment = .centerY
+        topStack.spacing = 12
+        segmentControl.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        searchField.setContentHuggingPriority(.required, for: .horizontal)
+
+        let calculationStack = NSStackView(views: [progressIndicator, calculatingLabel])
+        calculationStack.orientation = .horizontal
+        calculationStack.alignment = .centerY
+        calculationStack.spacing = 5
+
+        let refreshStack = NSStackView(views: [refreshNoticeLabel, refreshButton])
+        refreshStack.orientation = .horizontal
+        refreshStack.alignment = .centerY
+        refreshStack.spacing = 6
+
+        let footerStack = NSStackView(views: [footerLabel, refreshStack, calculationStack])
+        footerStack.orientation = .horizontal
+        footerStack.alignment = .centerY
+        footerStack.spacing = 8
+        footerLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        refreshNoticeLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        refreshStack.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        calculationStack.setContentHuggingPriority(.required, for: .horizontal)
+
+        [topStack, scrollView, footerStack].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+
+        NSLayoutConstraint.activate([
+            topStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            topStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            topStack.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
+            searchField.widthAnchor.constraint(equalToConstant: 220),
+
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topStack.bottomAnchor, constant: 10),
+            scrollView.bottomAnchor.constraint(equalTo: footerStack.topAnchor, constant: -6),
+
+            footerStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            footerStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
+            footerStack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -7),
+            footerStack.heightAnchor.constraint(greaterThanOrEqualToConstant: 20),
+        ])
+    }
+
+    private func addColumn(_ definition: PacketTableColumnDefinition) {
+        guard let column = EndpointStatisticsTableColumn(rawValue: definition.identifier) else {
+            return
+        }
+        let tableColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(definition.identifier))
+        tableColumn.title = definition.title
+        tableColumn.width = CGFloat(definition.defaultWidth)
+        tableColumn.minWidth = CGFloat(definition.minimumWidth)
+        tableColumn.resizingMask = column == .summary
+            ? [.userResizingMask, .autoresizingMask]
+            : .userResizingMask
+        tableColumn.dataCell = cell(for: definition)
+        tableColumn.sortDescriptorPrototype = NSSortDescriptor(
+            key: column.rawValue,
+            ascending: !column.isNumeric
+        )
+        tableView.addTableColumn(tableColumn)
+    }
+
+    private func cell(for definition: PacketTableColumnDefinition) -> NSCell {
+        let cell: NSCell
+        switch definition.cellKind {
+        case .text:
+            cell = PacketTextCell()
+        case .client:
+            cell = PacketClientCell()
+        case .protocol:
+            cell = PacketProtocolCell()
+        }
+        if let column = EndpointStatisticsTableColumn(rawValue: definition.identifier) {
+            cell.alignment = Self.alignment(for: column)
+        }
+        return cell
+    }
+
+    private func consumeDisplayedSource(
+        _ source: EndpointStatisticsRenderedSource,
+        forceReplacement: Bool
+    ) -> Bool {
+        let result = displayedForwarder.forwardingResult(
+            from: source,
+            expectedSourceIdentity: latestSourceIdentity,
+            forceReplacement: forceReplacement,
+            packetProvider: packetProvider
+        )
+        switch result {
+        case .none:
+            return false
+        case .replacementRequired:
+            if source.updatePlan.changesEndpointClassification,
+               displayedReplacementWork?.source.packetTableGeneration != source.packetTableGeneration {
+                displayedPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            }
+            return startDisplayedReplacement(from: source, mode: .enqueue)
+        case .update(let update):
+            let action = displayedPacketsPipeline.enqueue(update)
+            handleDisplayedPacketsDrainAction(action)
+            return true
+        }
+    }
+
+    // Resolve a large displayed replacement in run-loop chunks, then flatten its chunks off-main.
+    private func startDisplayedReplacement(
+        from source: EndpointStatisticsRenderedSource,
+        mode: EndpointStatisticsReplacementMode
+    ) -> Bool {
+        guard isCurrentDisplayedSource(source) else {
+            needsDisplayedReplacement = true
+            return false
+        }
+        if let work = displayedReplacementWork, work.mode == mode {
+            switch work.update(to: source, packetProvider: packetProvider) {
+            case .updated:
+                scheduleDisplayedReplacementContinuation(work)
+                return true
+            case .overflow:
+                pauseDisplayedReplacement(work)
+                return false
+            case .incompatible:
+                break
+            }
+        }
+
+        displayedReplacementWork?.cancellationToken.cancel()
+        let work = EndpointStatisticsDisplayedReplacementWork(source: source, mode: mode)
+        displayedReplacementWork = work
+        isDisplayedReplacementPaused = false
+        needsDisplayedReplacement = true
+        setCalculating(true, text: "Loading displayed endpoints…")
+        scheduleDisplayedReplacementContinuation(work)
+        return true
+    }
+
+    private func continueDisplayedReplacement(_ work: EndpointStatisticsDisplayedReplacementWork) {
+        guard displayedReplacementWork === work,
+              !work.cancellationToken.isCancelled(),
+              isCurrentDisplayedSource(work.source) else {
+            cancelDisplayedReplacement(work)
+            return
+        }
+        guard let range = work.accumulator.nextRange else {
+            flattenDisplayedReplacement(work)
+            return
+        }
+        guard let packetIDs = work.source.packetIDs(in: range) else {
+            cancelDisplayedReplacement(work)
+            return
+        }
+        let packets = packetProvider(packetIDs)
+        guard work.accumulator.append(packetIDs: packetIDs, packets: packets) else {
+            cancelDisplayedReplacement(work)
+            return
+        }
+        scheduleDisplayedReplacementContinuation(work)
+    }
+
+    private func flattenDisplayedReplacement(_ work: EndpointStatisticsDisplayedReplacementWork) {
+        guard !work.isFlattening else {
+            return
+        }
+        work.isFlattening = true
+        let chunks = work.accumulator.packetChunks
+        let packetCount = work.accumulator.packetCount
+        let source = work.source
+        let cancellationToken = work.cancellationToken
+        displayedPacketsQueue.async { [weak self, weak work] in
+            var packets: [PacketSummary] = []
+            packets.reserveCapacity(packetCount)
+            for chunk in chunks {
+                guard !cancellationToken.isCancelled() else {
+                    return
+                }
+                packets.append(contentsOf: chunk.packets)
+            }
+            DispatchQueue.main.async {
+                guard let self, let work else {
+                    return
+                }
+                self.finishDisplayedReplacement(
+                    work,
+                    source: source,
+                    cancellationToken: cancellationToken,
+                    packetCount: packetCount,
+                    packets: packets
+                )
+            }
+        }
+    }
+
+    private func finishDisplayedReplacement(
+        _ work: EndpointStatisticsDisplayedReplacementWork,
+        source: EndpointStatisticsRenderedSource,
+        cancellationToken: EndpointStatisticsCancellationToken,
+        packetCount: Int,
+        packets: [PacketSummary]
+    ) {
+        guard displayedReplacementWork === work,
+              work.acceptsFlattenedPackets(
+                token: cancellationToken,
+                packetCount: packetCount,
+                flattenedPacketCount: packets.count
+              ) else {
+            return
+        }
+        guard source.identity == work.source.identity,
+              isCurrentDisplayedSource(work.source),
+              let update = displayedForwarder.replacementUpdate(from: source, packets: packets) else {
+            cancelDisplayedReplacement(work)
+            return
+        }
+        var deferredUpdates: [EndpointStatisticsIngestUpdate] = []
+        deferredUpdates.reserveCapacity(work.deferredUpdates.count)
+        for deferredUpdate in work.deferredUpdates {
+            guard let update = displayedForwarder.deferredUpdate(deferredUpdate) else {
+                cancelDisplayedReplacement(work)
+                return
+            }
+            deferredUpdates.append(update)
+        }
+        displayedReplacementWork = nil
+
+        let action: EndpointStatisticsUpdateDrainCoordinator.Action
+        switch work.mode {
+        case .enqueue:
+            if displayedPacketsPipeline.canResume {
+                action = displayedPacketsPipeline.resume(withReplacement: update)
+                pendingDisplayedPacketsSourceReplacement = false
+                waitsForDisplayedPacketsManualRefresh = true
+            } else {
+                guard !displayedPacketsPipeline.isPaused else {
+                    needsDisplayedReplacement = true
+                    pendingDisplayedPacketsSourceReplacement = true
+                    updateRefreshNotice()
+                    return
+                }
+                action = displayedPacketsPipeline.enqueue(update)
+            }
+            if case .paused = action {
+                needsDisplayedReplacement = true
+                pendingDisplayedPacketsSourceReplacement = true
+            }
+        case .resume:
+            guard displayedPacketsPipeline.canResume else {
+                needsDisplayedReplacement = true
+                pendingDisplayedPacketsSourceReplacement = true
+                updateRefreshNotice()
+                return
+            }
+            action = displayedPacketsPipeline.resume(withReplacement: update)
+            if case .drain = action {
+                pendingDisplayedPacketsSourceReplacement = false
+                waitsForDisplayedPacketsManualRefresh = true
+            }
+        }
+        if case .drain = action {
+            displayedReplacementRecoveryState.replacementWasAccepted()
+            needsDisplayedReplacement = false
+        }
+        handleDisplayedPacketsDrainAction(action)
+        guard case .drain = action else {
+            return
+        }
+        for deferredUpdate in deferredUpdates {
+            let deferredAction = displayedPacketsPipeline.enqueue(deferredUpdate)
+            if case .paused = deferredAction {
+                needsDisplayedReplacement = true
+                waitsForDisplayedPacketsManualRefresh = false
+            }
+            handleDisplayedPacketsDrainAction(deferredAction)
+            if case .paused = deferredAction {
+                break
+            }
+        }
+    }
+
+    private func cancelDisplayedReplacement(_ work: EndpointStatisticsDisplayedReplacementWork) {
+        work.cancellationToken.cancel()
+        if displayedReplacementWork === work {
+            displayedReplacementWork = nil
+        }
+        needsDisplayedReplacement = true
+    }
+
+    private func pauseDisplayedReplacement(_ work: EndpointStatisticsDisplayedReplacementWork) {
+        cancelDisplayedReplacement(work)
+        displayedReplacementRecoveryState.pauseForOverflow()
+        waitsForDisplayedPacketsManualRefresh = false
+        updateRefreshNotice()
+    }
+
+    private func scheduleDisplayedReplacementContinuation(
+        _ work: EndpointStatisticsDisplayedReplacementWork
+    ) {
+        guard !work.isContinuationScheduled else {
+            return
+        }
+        work.isContinuationScheduled = true
+        DispatchQueue.main.async { [weak self, weak work] in
+            guard let work else {
+                return
+            }
+            work.isContinuationScheduled = false
+            self?.continueDisplayedReplacement(work)
+        }
+    }
+
+    private func isCurrentDisplayedSource(_ source: EndpointStatisticsRenderedSource) -> Bool {
+        !isCancelled && EndpointStatisticsDisplayedSourcePolicy.canLoadReplacement(
+            source: source,
+            latestSource: latestRenderedSource,
+            expectedIdentity: latestSourceIdentity,
+            usesDisplayedPackets: usesDisplayedPackets
+        )
+    }
+
+    private func startRawReplacement(
+        from ingestState: PacketIngestState,
+        mode: EndpointStatisticsReplacementMode
+    ) {
+        rawReplacementWork?.cancellationToken.cancel()
+        let work = EndpointStatisticsRawReplacementWork(
+            sourceIdentity: EndpointStatisticsSourceIdentity(
+                backingIdentity: ingestState.backingIdentity,
+                packetLineageRevision: ingestState.packetLineageRevision
+            ),
+            packetRevision: ingestState.packetRevision,
+            packetCount: ingestState.packets.count,
+            mode: mode
+        )
+        rawReplacementWork = work
+        isRawReplacementPaused = false
+        if !usesDisplayedPackets {
+            setCalculating(true, text: "Loading endpoints…")
+        }
+        scheduleRawReplacementContinuation(work)
+    }
+
+    // Copy only one producer range per main turn so live appends retain their unique Array buffer.
+    private func continueRawReplacement(_ work: EndpointStatisticsRawReplacementWork) {
+        guard rawReplacementWork === work,
+              !work.cancellationToken.isCancelled(),
+              !isRawReplacementPaused,
+              let ingestState = latestIngestStateProvider() else {
+            return
+        }
+        let currentIdentity = EndpointStatisticsSourceIdentity(
+            backingIdentity: ingestState.backingIdentity,
+            packetLineageRevision: ingestState.packetLineageRevision
+        )
+        guard currentIdentity == work.sourceIdentity,
+              ingestState.packetRevision == work.packetRevision,
+              ingestState.packets.count == work.accumulator.packetCount else {
+            startRawReplacement(from: ingestState, mode: work.mode)
+            return
+        }
+        guard let range = work.accumulator.nextRange else {
+            flattenRawReplacement(work)
+            return
+        }
+        let packets = Array(ingestState.packets[range])
+        guard work.accumulator.append(packetIDs: packets.map(\.id), packets: packets) else {
+            pauseRawReplacement(work)
+            return
+        }
+        scheduleRawReplacementContinuation(work)
+    }
+
+    private func flattenRawReplacement(_ work: EndpointStatisticsRawReplacementWork) {
+        guard !work.isFlattening else {
+            return
+        }
+        work.isFlattening = true
+        let chunks = work.accumulator.packetChunks
+        let packetCount = work.accumulator.packetCount
+        let packetRevision = work.packetRevision
+        let cancellationToken = work.cancellationToken
+        allPacketsQueue.async { [weak self, weak work] in
+            var packets: [PacketSummary] = []
+            packets.reserveCapacity(packetCount)
+            for chunk in chunks {
+                guard !cancellationToken.isCancelled() else {
+                    return
+                }
+                packets.append(contentsOf: chunk.packets)
+            }
+            DispatchQueue.main.async {
+                guard let self, let work else {
+                    return
+                }
+                self.finishRawReplacement(
+                    work,
+                    cancellationToken: cancellationToken,
+                    packetRevision: packetRevision,
+                    packetCount: packetCount,
+                    packets: packets
+                )
+            }
+        }
+    }
+
+    private func finishRawReplacement(
+        _ work: EndpointStatisticsRawReplacementWork,
+        cancellationToken: EndpointStatisticsCancellationToken,
+        packetRevision: UInt64,
+        packetCount: Int,
+        packets: [PacketSummary]
+    ) {
+        guard rawReplacementWork === work,
+              work.acceptsFlattenedPackets(
+                token: cancellationToken,
+                packetRevision: packetRevision,
+                packetCount: packetCount,
+                flattenedPacketCount: packets.count
+              ),
+              !isRawReplacementPaused,
+              latestSourceIdentity == work.sourceIdentity,
+              ingestCursor?.packetRevision == work.packetRevision,
+              ingestCursor?.packetLineageRevision == work.sourceIdentity.packetLineageRevision,
+              ingestCursor?.totalPacketCount == work.logicalPacketCount else {
+            return
+        }
+        rawReplacementWork = nil
+        let deferredUpdates = work.deferredUpdates
+        let replacement = EndpointStatisticsIngestUpdate(
+            packetRevision: packetRevision,
+            packetLineageRevision: work.sourceIdentity.packetLineageRevision,
+            totalPacketCount: packetCount,
+            kind: .replace(packets)
+        )
+        let action: EndpointStatisticsUpdateDrainCoordinator.Action
+        switch work.mode {
+        case .enqueue:
+            if allPacketsPipeline.canResume {
+                action = allPacketsPipeline.resume(withReplacement: replacement)
+                pendingAllPacketsSourceReplacement = false
+                waitsForAllPacketsManualRefresh = true
+            } else {
+                guard !allPacketsPipeline.isPaused else {
+                    pendingAllPacketsSourceReplacement = true
+                    updateRefreshNotice()
+                    return
+                }
+                action = allPacketsPipeline.enqueue(replacement)
+            }
+            if case .paused = action {
+                pendingAllPacketsSourceReplacement = true
+            }
+        case .resume:
+            guard allPacketsPipeline.canResume else {
+                pendingAllPacketsSourceReplacement = true
+                updateRefreshNotice()
+                return
+            }
+            action = allPacketsPipeline.resume(withReplacement: replacement)
+            if case .drain = action {
+                pendingAllPacketsSourceReplacement = false
+                waitsForAllPacketsManualRefresh = true
+            }
+        }
+        if case .drain = action {
+            isRawReplacementPaused = false
+            pendingAllPacketsSourceReplacement = false
+        }
+        handleAllPacketsDrainAction(action)
+        guard case .drain = action else {
+            return
+        }
+        for deferredUpdate in deferredUpdates {
+            let deferredAction = allPacketsPipeline.enqueue(deferredUpdate)
+            if case .paused = deferredAction {
+                isRawReplacementPaused = true
+                waitsForAllPacketsManualRefresh = false
+            }
+            handleAllPacketsDrainAction(deferredAction)
+            if case .paused = deferredAction {
+                break
+            }
+        }
+    }
+
+    private func updateRawReplacement(
+        _ work: EndpointStatisticsRawReplacementWork,
+        from ingestState: PacketIngestState,
+        sourceIdentity: EndpointStatisticsSourceIdentity
+    ) {
+        let nextRevision = work.packetRevision &+ 1
+        guard sourceIdentity == work.sourceIdentity,
+              ingestState.packetRevision == nextRevision else {
+            allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            startRawReplacement(from: ingestState, mode: work.mode)
+            return
+        }
+        if work.isFlattening {
+            deferRawMutationDuringFlatten(work, from: ingestState)
+            return
+        }
+
+        switch ingestState.lastMutation {
+        case .append(let range):
+            guard range.lowerBound == work.accumulator.packetCount,
+                  range.upperBound == ingestState.packets.count,
+                  work.prepareForMorePackets(
+                    packetRevision: ingestState.packetRevision,
+                    packetCount: ingestState.packets.count
+                  ) else {
+                startRawReplacement(from: ingestState, mode: work.mode)
+                return
+            }
+        case .appendWithMetadataUpdates(let range, let packetIDs):
+            guard range.count <= EndpointStatisticsRawDeltaPolicy.maximumPacketCount,
+                  packetIDs.count <= EndpointStatisticsRawDeltaPolicy.maximumPacketCount - range.count,
+                  range.lowerBound == work.accumulator.packetCount,
+                  range.upperBound == ingestState.packets.count,
+                  work.prepareForMorePackets(
+                    packetRevision: ingestState.packetRevision,
+                    packetCount: ingestState.packets.count
+                  ) else {
+                allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+                pauseRawReplacement(work)
+                return
+            }
+            allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            applyRawMetadata(packetIDs, from: ingestState, to: work)
+        case .metadataUpdate(let packetIDs):
+            guard packetIDs.count <= EndpointStatisticsRawDeltaPolicy.maximumPacketCount,
+                  ingestState.packets.count == work.accumulator.packetCount else {
+                allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+                pauseRawReplacement(work)
+                return
+            }
+            work.prepareForMetadata(packetRevision: ingestState.packetRevision)
+            allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            applyRawMetadata(packetIDs, from: ingestState, to: work)
+        case .none, .reset, .replace:
+            allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            startRawReplacement(from: ingestState, mode: work.mode)
+            return
+        }
+        scheduleRawReplacementContinuation(work)
+    }
+
+    private func deferRawMutationDuringFlatten(
+        _ work: EndpointStatisticsRawReplacementWork,
+        from ingestState: PacketIngestState
+    ) {
+        guard !EndpointStatisticsRawDeltaPolicy.exceedsAutomaticLimit(ingestState.lastMutation) else {
+            if ingestState.lastMutation.changesEndpointClassification {
+                allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            }
+            pauseRawReplacement(work)
+            return
+        }
+        let previousCursor = EndpointStatisticsIngestCursor(
+            packetRevision: work.packetRevision,
+            packetLineageRevision: work.sourceIdentity.packetLineageRevision,
+            totalPacketCount: work.logicalPacketCount
+        )
+        let update = EndpointStatisticsIngestUpdate(
+            ingestState: ingestState,
+            previousCursor: previousCursor
+        )
+        guard update.previousPacketRevision != nil,
+              work.deferUpdate(
+                update,
+                maximumPacketCount: EndpointStatisticsRawDeltaPolicy.maximumPacketCount
+              ) else {
+            if ingestState.lastMutation.changesEndpointClassification {
+                allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+            }
+            pauseRawReplacement(work)
+            return
+        }
+        if ingestState.lastMutation.changesEndpointClassification {
+            allPacketsPipeline.recordDroppedMutation(changesEndpointClassification: true)
+        }
+    }
+
+    private func applyRawMetadata(
+        _ packetIDs: [PacketSummary.ID],
+        from ingestState: PacketIngestState,
+        to work: EndpointStatisticsRawReplacementWork
+    ) {
+        for packetID in packetIDs {
+            guard let packetIndex = ingestState.packetIndexByID[packetID],
+                  ingestState.packets.indices.contains(packetIndex) else {
+                continue
+            }
+            work.accumulator.replaceLoadedPacket(
+                at: packetIndex,
+                with: ingestState.packets[packetIndex]
+            )
+        }
+    }
+
+    private func pauseRawReplacement(_ work: EndpointStatisticsRawReplacementWork) {
+        work.cancellationToken.cancel()
+        if rawReplacementWork === work {
+            rawReplacementWork = nil
+        }
+        isRawReplacementPaused = true
+        waitsForAllPacketsManualRefresh = false
+        updateRefreshNotice()
+    }
+
+    private func scheduleRawReplacementContinuation(_ work: EndpointStatisticsRawReplacementWork) {
+        guard !work.isContinuationScheduled else {
+            return
+        }
+        work.isContinuationScheduled = true
+        DispatchQueue.main.async { [weak self, weak work] in
+            guard let work else {
+                return
+            }
+            work.isContinuationScheduled = false
+            self?.continueRawReplacement(work)
+        }
+    }
+
+    // Keep one raw-ingest drain in flight and pause without retaining more deltas after overload.
+    private func handleAllPacketsDrainAction(_ action: EndpointStatisticsUpdateDrainCoordinator.Action) {
+        switch action {
+        case .none:
+            break
+        case .drain(let update):
+            let service = allPacketsService
+            let cancellationToken = allPacketsCancellationToken
+            allPacketsQueue.async {
+                let result = service.consume(update, cancellationToken: cancellationToken)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, !self.isCancelled else {
+                        return
+                    }
+                    if result == .consumed {
+                        self.consumedIngestCursor = update.cursor
+                    }
+                    let nextAction = self.allPacketsPipeline.drainCompleted(result: result)
+                    let pipelineIsIdle: Bool
+                    if case .none = nextAction {
+                        pipelineIsIdle = true
+                    } else {
+                        pipelineIsIdle = false
+                    }
+                    self.handleAllPacketsDrainAction(nextAction)
+                    guard pipelineIsIdle else {
+                        return
+                    }
+                    if result == .consumed, self.waitsForAllPacketsManualRefresh {
+                        self.waitsForAllPacketsManualRefresh = false
+                        if !self.usesDisplayedPackets {
+                            self.allPacketsPresentationIntentAfterDrain = nil
+                            self.requestPresentation(intent: .explicit)
+                        }
+                    } else if result == .consumed, !self.usesDisplayedPackets {
+                        let intent = self.allPacketsPresentationIntentAfterDrain ?? .automatic
+                        self.allPacketsPresentationIntentAfterDrain = nil
+                        self.requestPresentation(intent: intent)
+                    }
+                }
+            }
+        case .paused:
+            if waitsForAllPacketsManualRefresh, allPacketsPipeline.canResume {
+                attemptAllPacketsManualRefresh()
+            } else if pendingAllPacketsSourceReplacement, allPacketsPipeline.canResume {
+                attemptPendingAllPacketsSourceReplacement()
+            }
+            updateRefreshNotice()
+        }
+    }
+
+    // The displayed scope uses the same bounded drain while resolving replacement IDs on main.
+    private func handleDisplayedPacketsDrainAction(_ action: EndpointStatisticsUpdateDrainCoordinator.Action) {
+        switch action {
+        case .none:
+            break
+        case .drain(let update):
+            let service = displayedPacketsService
+            let cancellationToken = displayedPacketsCancellationToken
+            displayedPacketsQueue.async {
+                let result = service.consume(update, cancellationToken: cancellationToken)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, !self.isCancelled else {
+                        return
+                    }
+                    if result == .consumed {
+                        self.consumedDisplayedCursor = update.cursor
+                    }
+                    let nextAction = self.displayedPacketsPipeline.drainCompleted(result: result)
+                    let pipelineIsIdle: Bool
+                    if case .none = nextAction {
+                        pipelineIsIdle = true
+                    } else {
+                        pipelineIsIdle = false
+                    }
+                    self.handleDisplayedPacketsDrainAction(nextAction)
+                    guard pipelineIsIdle else {
+                        return
+                    }
+                    if result == .consumed, self.waitsForDisplayedPacketsManualRefresh {
+                        self.waitsForDisplayedPacketsManualRefresh = false
+                        if self.usesDisplayedPackets, !self.isWaitingForDisplayFilter {
+                            self.displayedPacketsPresentationIntentAfterDrain = nil
+                            self.requestPresentation(intent: .explicit)
+                        }
+                    } else if result == .consumed,
+                              self.usesDisplayedPackets,
+                              !self.isWaitingForDisplayFilter {
+                        let intent = self.displayedPacketsPresentationIntentAfterDrain ?? .automatic
+                        self.displayedPacketsPresentationIntentAfterDrain = nil
+                        self.requestPresentation(intent: intent)
+                    }
+                }
+            }
+        case .paused:
+            if waitsForDisplayedPacketsManualRefresh,
+               displayedPacketsPipeline.canResume,
+               let latestRenderedSource {
+                resumeDisplayedPacketsForSourceReplacement(latestRenderedSource)
+            } else if displayedReplacementRecoveryState.shouldResumeAutomatically,
+                      displayedPacketsPipeline.canResume,
+                      let latestRenderedSource {
+                resumeDisplayedPacketsForSourceReplacement(latestRenderedSource)
+            }
+            updateRefreshNotice()
+        }
+    }
+
+    private func recoverDisplayedScope() {
+        needsDisplayedReplacement = true
+        guard usesDisplayedPackets,
+              let latestRenderedSource,
+              !latestRenderedSource.isFiltering else {
+            if usesDisplayedPackets {
+                setCalculating(true, text: "Refreshing displayed packets…")
+            }
+            return
+        }
+        setCalculating(true, text: "Refreshing displayed packets…")
+        if consumeDisplayedSource(latestRenderedSource, forceReplacement: true) {
+            recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
+        } else {
+            requestPresentation(intent: .explicit)
+        }
+    }
+
+    private func recordPresentationIntentAfterDrain(
+        _ intent: EndpointStatisticsPresentationIntent,
+        usesDisplayedPackets: Bool
+    ) {
+        if intent == .explicit {
+            presentationGeneration &+= 1
+            abandonActivePresentation()
+        }
+        if usesDisplayedPackets {
+            if displayedPacketsPresentationIntentAfterDrain != .explicit {
+                displayedPacketsPresentationIntentAfterDrain = intent
+            }
+        } else if allPacketsPresentationIntentAfterDrain != .explicit {
+            allPacketsPresentationIntentAfterDrain = intent
+        }
+        setCalculating(true, text: "Calculating…")
+    }
+
+    private func attemptPendingAllPacketsSourceReplacement() {
+        guard pendingAllPacketsSourceReplacement,
+              allPacketsPipeline.canResume,
+              let ingestState = latestIngestStateProvider() else {
+            return
+        }
+        startRawReplacement(from: ingestState, mode: .resume)
+    }
+
+    private func attemptAllPacketsManualRefresh() {
+        guard waitsForAllPacketsManualRefresh,
+              allPacketsPipeline.canResume || isRawReplacementPaused else {
+            return
+        }
+        guard let ingestState = latestIngestStateProvider() else {
+            waitsForAllPacketsManualRefresh = false
+            updateRefreshNotice()
+            return
+        }
+        if let ingestCursor,
+           ingestState.packetLineageRevision == ingestCursor.packetLineageRevision,
+           ingestState.packetRevision < ingestCursor.packetRevision {
+            waitsForAllPacketsManualRefresh = false
+            updateRefreshNotice()
+            return
+        }
+        ingestCursor = EndpointStatisticsIngestCursor(
+            packetRevision: ingestState.packetRevision,
+            packetLineageRevision: ingestState.packetLineageRevision,
+            totalPacketCount: ingestState.packets.count
+        )
+        latestSourceIdentity = EndpointStatisticsSourceIdentity(
+            backingIdentity: ingestState.backingIdentity,
+            packetLineageRevision: ingestState.packetLineageRevision
+        )
+        startRawReplacement(
+            from: ingestState,
+            mode: allPacketsPipeline.canResume ? .resume : .enqueue
+        )
+    }
+
+    private func resumeDisplayedPacketsForSourceReplacement(_ source: EndpointStatisticsRenderedSource) {
+        guard displayedPacketsPipeline.canResume || isDisplayedReplacementPaused else {
+            return
+        }
+        let mode: EndpointStatisticsReplacementMode = displayedPacketsPipeline.canResume
+            ? .resume
+            : .enqueue
+        _ = startDisplayedReplacement(from: source, mode: mode)
+    }
+
+    // Coalesce live changes, while explicit controls may request one refresh of a large table.
+    private func requestPresentation(intent: EndpointStatisticsPresentationIntent = .automatic) {
+        guard !isCancelled else {
+            return
+        }
+        guard !currentPipelineIsPaused else {
+            updateRefreshNotice()
+            return
+        }
+        // A control change queued during a drain must outrank the automatic idle callback.
+        let effectiveIntent = intent.merging(pendingPresentationIntent)
+        guard automaticRefreshPolicy.accepts(effectiveIntent) else {
+            updateRefreshNotice()
+            return
+        }
+        if !currentPipelineIsDraining {
+            if usesDisplayedPackets {
+                displayedPacketsPresentationIntentAfterDrain = nil
+            } else {
+                allPacketsPresentationIntentAfterDrain = nil
+            }
+        }
+        if effectiveIntent == .explicit {
+            abandonActivePresentation()
+        }
+        presentationGeneration &+= 1
+        pendingPresentationIntent = effectiveIntent
+        setCalculating(true, text: "Calculating…")
+        guard !usesDisplayedPackets || (
+            !needsDisplayedReplacement && latestRenderedSource?.identity == latestSourceIdentity
+        ) else {
+            return
+        }
+        guard !usesDisplayedPackets || !isWaitingForDisplayFilter else {
+            return
+        }
+        guard !currentPipelineIsDraining else {
+            return
+        }
+        guard !isPresentationInFlight, scheduledPresentationWorkItem == nil else {
+            return
+        }
+
+        let now = Date.timeIntervalSinceReferenceDate
+        let elapsed = now - lastPresentationStartTime
+        let rateLimitDelay = EndpointStatisticsPresentationCadence.maximumRefreshRateInterval - elapsed
+        let backpressureDelay = nextPresentationAllowedTime - now
+        let delay = max(0, rateLimitDelay, backpressureDelay)
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.beginPresentation()
+        }
+        scheduledPresentationWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func abandonActivePresentation() {
+        activePresentationCancellationToken?.cancel()
+        activePresentationCancellationToken = nil
+        isPresentationInFlight = false
+    }
+
+    private func beginPresentation() {
+        scheduledPresentationWorkItem = nil
+        guard let intent = pendingPresentationIntent,
+              !isPresentationInFlight,
+              !currentPipelineIsPaused,
+              !currentPipelineIsDraining else {
+            return
+        }
+        guard !usesDisplayedPackets || (
+            !needsDisplayedReplacement &&
+                !isWaitingForDisplayFilter &&
+                latestRenderedSource?.identity == latestSourceIdentity
+        ) else {
+            return
+        }
+        pendingPresentationIntent = nil
+        isPresentationInFlight = true
+        let presentationCancellationToken = EndpointStatisticsCancellationToken()
+        activePresentationCancellationToken = presentationCancellationToken
+        lastPresentationStartTime = Date.timeIntervalSinceReferenceDate
+
+        let request = EndpointStatisticsPresentationRequest(
+            generation: presentationGeneration,
+            intent: intent,
+            usesDisplayedPackets: usesDisplayedPackets,
+            sourceIdentity: latestSourceIdentity,
+            ingestCursor: consumedIngestCursor,
+            displayedCursor: consumedDisplayedCursor,
+            classificationRevision: usesDisplayedPackets
+                ? displayedPacketsPipeline.consumedClassificationRevision
+                : allPacketsPipeline.consumedClassificationRevision,
+            group: selectedGroup,
+            searchText: searchField.stringValue,
+            sort: currentSort
+        )
+        let service = request.usesDisplayedPackets ? displayedPacketsService : allPacketsService
+        let processingQueue = request.usesDisplayedPackets ? displayedPacketsQueue : allPacketsQueue
+        processingQueue.async {
+            let processingStartTime = ProcessInfo.processInfo.systemUptime
+            guard let snapshot = service.currentSnapshot(
+                for: request.group,
+                cancellationToken: presentationCancellationToken
+            ),
+            let table = EndpointStatisticsTablePresenter.presentation(
+                rows: snapshot.rows,
+                searchText: request.searchText,
+                sort: request.sort,
+                cancellationToken: presentationCancellationToken
+            ) else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentationDidCancel(presentationCancellationToken)
+                }
+                return
+            }
+            let result = EndpointStatisticsPresentationResult(
+                request: request,
+                cancellationToken: presentationCancellationToken,
+                endpointCounts: snapshot.endpointCounts,
+                scopeTotals: snapshot.footerTotals,
+                table: table,
+                processingDuration: ProcessInfo.processInfo.systemUptime - processingStartTime
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.finishPresentation(result)
+            }
+        }
+    }
+
+    private func finishPresentation(_ result: EndpointStatisticsPresentationResult) {
+        guard activePresentationCancellationToken === result.cancellationToken else {
+            return
+        }
+        activePresentationCancellationToken = nil
+        isPresentationInFlight = false
+        nextPresentationAllowedTime = Date.timeIntervalSinceReferenceDate +
+            EndpointStatisticsPresentationCadence.cooldown(after: result.processingDuration)
+        let request = result.request
+        let decision = EndpointStatisticsPresentationCommitPolicy.decision(
+            requestContext: request.context,
+            currentContext: currentPresentationContext,
+            requestIngestCursor: request.ingestCursor,
+            currentIngestCursor: ingestCursor,
+            requestDisplayedCursor: request.displayedCursor,
+            currentDisplayedCursor: displayedForwarder.cursor,
+            requestClassificationRevision: request.classificationRevision,
+            currentClassificationRevision: usesDisplayedPackets
+                ? displayedPacketsPipeline.latestClassificationRevision
+                : allPacketsPipeline.latestClassificationRevision,
+            isWaitingForDisplayFilter: isWaitingForDisplayFilter
+        )
+        if decision != .discard {
+            let selectedRowIDs = EndpointStatisticsSelectionRestoration.selectedRowIDs(
+                rows: rows,
+                selectedIndexes: tableView.selectedRowIndexes
+            )
+            rows = result.table.rows
+            rowIndexByID = result.table.rowIndexByID
+            tableView.reloadData()
+            let selectedIndexes = EndpointStatisticsSelectionRestoration.rowIndexes(
+                for: selectedRowIDs,
+                rowIndexByID: result.table.rowIndexByID
+            )
+            if selectedIndexes.isEmpty {
+                tableView.deselectAll(nil)
+            } else {
+                tableView.selectRowIndexes(selectedIndexes, byExtendingSelection: false)
+            }
+            updateSegmentLabels(counts: result.endpointCounts)
+            updateFooter(table: result.table, scopeTotals: result.scopeTotals)
+            committedActionState = EndpointStatisticsActionState(
+                context: request.context,
+                classificationRevision: request.classificationRevision
+            )
+            automaticRefreshPolicy.didCommit(
+                unfilteredEndpointCount: result.table.unfilteredRowCount
+            )
+            setCalculating(false, text: "")
+            updateRefreshNotice()
+        }
+
+        if !isWaitingForDisplayFilter &&
+            (pendingPresentationIntent != nil || decision == .discard || decision == .commitAndRefresh) {
+            let nextIntent = pendingPresentationIntent ?? .automatic
+            requestPresentation(intent: nextIntent)
+        }
+    }
+
+    private func presentationDidCancel(_ cancellationToken: EndpointStatisticsCancellationToken) {
+        guard activePresentationCancellationToken === cancellationToken else {
+            return
+        }
+        activePresentationCancellationToken = nil
+        isPresentationInFlight = false
+        if pendingPresentationIntent != nil {
+            requestPresentation(intent: pendingPresentationIntent ?? .automatic)
+        }
+    }
+
+    private func updateSegmentLabels(counts: [EndpointStatisticsGroup: Int]) {
+        for (index, group) in EndpointStatisticsGroup.allCases.enumerated() {
+            segmentControl.setLabel("\(group.title) (\(counts[group] ?? 0))", forSegment: index)
+        }
+    }
+
+    private func updateFooter(
+        table: EndpointStatisticsTablePresentation,
+        scopeTotals: EndpointStatisticsTotals
+    ) {
+        let endpointText: String
+        if table.rows.count == table.unfilteredRowCount {
+            endpointText = countText(table.rows.count, singular: "endpoint")
+        } else {
+            endpointText = "\(formatNumber(UInt64(table.rows.count))) of \(formatNumber(UInt64(table.unfilteredRowCount))) endpoints"
+        }
+        footerLabel.stringValue = ([
+            endpointText,
+            countText(scopeTotals.packets, singular: "packet"),
+        ] + EndpointStatisticsFooterFormatter.trafficParts(
+            totals: scopeTotals,
+            formatBytes: byteCountText
+        )).joined(separator: " · ")
+    }
+
+    private func setCalculating(_ isCalculating: Bool, text: String) {
+        calculatingLabel.stringValue = text
+        calculatingLabel.isHidden = !isCalculating
+        if isCalculating {
+            progressIndicator.startAnimation(nil)
+        } else {
+            progressIndicator.stopAnimation(nil)
+        }
+    }
+
+    private func updateRefreshNotice() {
+        let message: String?
+        if currentPipelineIsPaused {
+            message = "Statistics updates paused to keep capture responsive."
+        } else if automaticRefreshPolicy.isPaused {
+            message = "Live updates paused for tables over 10,000 endpoints."
+        } else {
+            message = nil
+        }
+        refreshNoticeLabel.stringValue = message ?? ""
+        refreshNoticeLabel.isHidden = message == nil
+        refreshButton.isHidden = message == nil
+        let waitsForCurrentScope = usesDisplayedPackets
+            ? waitsForDisplayedPacketsManualRefresh
+            : waitsForAllPacketsManualRefresh
+        refreshButton.isEnabled = !isPresentationInFlight &&
+            !currentPipelineIsDraining &&
+            !waitsForCurrentScope
+    }
+
+    @objc private func refreshStatistics(_ sender: Any?) {
+        guard !isCancelled, !currentPipelineIsDraining else {
+            return
+        }
+        if currentPipelineIsPaused {
+            setCalculating(true, text: "Refreshing…")
+            if usesDisplayedPackets {
+                waitsForDisplayedPacketsManualRefresh = true
+                pendingDisplayedPacketsSourceReplacement = false
+                guard let latestRenderedSource, !latestRenderedSource.isFiltering else {
+                    setCalculating(true, text: "Updating displayed packets…")
+                    return
+                }
+                resumeDisplayedPacketsForSourceReplacement(latestRenderedSource)
+            } else {
+                waitsForAllPacketsManualRefresh = true
+                pendingAllPacketsSourceReplacement = false
+                attemptAllPacketsManualRefresh()
+            }
+            updateRefreshNotice()
+            return
+        }
+        requestPresentation(intent: .explicit)
+    }
+
+    private func countText(_ count: Int, singular: String) -> String {
+        countText(UInt64(max(count, 0)), singular: singular)
+    }
+
+    private func countText(_ count: UInt64, singular: String) -> String {
+        "\(formatNumber(count)) \(singular)\(count == 1 ? "" : "s")"
+    }
+
+    private func formatNumber(_ value: UInt64) -> String {
+        numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+
+    private func byteCountText(_ value: UInt64) -> String {
+        let clampedValue = value > UInt64(Int64.max) ? Int64.max : Int64(value)
+        return byteCountFormatter.string(fromByteCount: clampedValue)
+    }
+
+    private func displayText(
+        for column: EndpointStatisticsTableColumn,
+        row: EndpointStatisticsRow
+    ) -> String {
+        switch column {
+        case .packets: formatNumber(row.packets)
+        case .bytes: formatNumber(row.bytes)
+        case .txPackets: formatNumber(row.txPackets)
+        case .txBytes: formatNumber(row.txBytes)
+        case .rxPackets: formatNumber(row.rxPackets)
+        case .rxBytes: formatNumber(row.rxBytes)
+        default: column.stringValue(in: row)
+        }
+    }
+
+    @objc private func groupChanged(_ sender: NSSegmentedControl) {
+        guard EndpointStatisticsGroup.allCases.indices.contains(sender.selectedSegment) else {
+            return
+        }
+        saveCurrentColumnLayout()
+        selectedGroup = EndpointStatisticsGroup.allCases[sender.selectedSegment]
+        applyColumnLayout(for: selectedGroup)
+        applySortDescriptor(currentSort)
+        requestPresentation(intent: .explicit)
+    }
+
+    @objc private func displayedPacketsScopeChanged(_ sender: NSButton) {
+        var waitsForAggregation = false
+        if usesDisplayedPackets {
+            needsDisplayedReplacement = true
+            if let latestRenderedSource, latestRenderedSource.isFiltering {
+                isWaitingForDisplayFilter = true
+                waitsForAggregation = true
+                recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
+                setCalculating(true, text: "Updating displayed packets…")
+            } else if displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused {
+                isWaitingForDisplayFilter = false
+                waitsForAggregation = true
+                recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
+                updateRefreshNotice()
+            } else if let latestRenderedSource {
+                isWaitingForDisplayFilter = false
+                if consumeDisplayedSource(latestRenderedSource, forceReplacement: true) {
+                    waitsForAggregation = true
+                    recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
+                }
+            }
+        } else {
+            displayedReplacementWork?.cancellationToken.cancel()
+            displayedReplacementWork = nil
+            waitsForDisplayedPacketsManualRefresh = false
+            needsDisplayedReplacement = true
+            isWaitingForDisplayFilter = false
+            if allPacketsPipeline.isDrainInFlight || allPacketsPipeline.isPaused {
+                waitsForAggregation = true
+                recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: false)
+            }
+        }
+        updateRefreshNotice()
+        if !waitsForAggregation {
+            requestPresentation(intent: .explicit)
+        }
+    }
+
+    @objc private func showRelatedPacketsFromDoubleClick(_ sender: Any?) {
+        guard rowsAreActionable else {
+            return
+        }
+        let rowIndex = tableView.clickedRow >= 0 ? tableView.clickedRow : tableView.selectedRow
+        guard rows.indices.contains(rowIndex) else {
+            return
+        }
+        showRelatedPackets(rows[rowIndex].id)
+    }
+
+    @objc private func showRelatedPacketsFromMenu(_ sender: Any?) {
+        guard rowsAreActionable else {
+            return
+        }
+        let rowIndex: Int?
+        if contextTarget.rowID != nil {
+            rowIndex = contextTarget.resolvedRowIndex(
+                rowIndexByID: rowIndexByID,
+                rowCount: rows.count
+            )
+        } else {
+            rowIndex = targetSelection().firstIndex(rowCount: rows.count)
+        }
+        guard let rowIndex, rows.indices.contains(rowIndex) else {
+            return
+        }
+        showRelatedPackets(rows[rowIndex].id)
+    }
+
+    @objc private func copyCellFromMenu(_ sender: Any?) {
+        guard rowsAreActionable,
+              let rowIndex = contextTarget.resolvedRowIndex(
+                rowIndexByID: rowIndexByID,
+                rowCount: rows.count
+              ),
+              let column = contextTarget.column else {
+            return
+        }
+        guard let value = EndpointStatisticsSemanticCopyPolicy.copyableValue(
+            column.stringValue(in: rows[rowIndex]),
+            isAggregatePlaceholder: column.isAggregatePlaceholder(in: rows[rowIndex])
+        ) else {
+            return
+        }
+        writeToPasteboard(value)
+    }
+
+    @objc private func copyAddressFromMenu(_ sender: Any?) {
+        copyValues(field: .address, selection: targetSelection())
+    }
+
+    @objc private func copyDomainFromMenu(_ sender: Any?) {
+        copyValues(field: .domain, selection: targetSelection())
+    }
+
+    @objc private func copyClientFromMenu(_ sender: Any?) {
+        copyValues(field: .client, selection: targetSelection())
+    }
+
+    @objc private func copySelectedCSVFromMenu(_ sender: Any?) {
+        copy(selection: targetSelection(), asJSON: false)
+    }
+
+    @objc private func copySelectedJSONFromMenu(_ sender: Any?) {
+        copy(selection: targetSelection(), asJSON: true)
+    }
+
+    @objc private func copyAllCSVFromMenu(_ sender: Any?) {
+        copy(selection: .all, asJSON: false)
+    }
+
+    @objc private func copyAllJSONFromMenu(_ sender: Any?) {
+        copy(selection: .all, asJSON: true)
+    }
+
+    // Capture only the immutable row buffer and selection descriptor before formatting off-main.
+    private func copy(selection: EndpointStatisticsRowSelection, asJSON: Bool) {
+        guard rowsAreActionable, !selection.isEmpty(rowCount: rows.count) else {
+            return
+        }
+        let rowSnapshot = rows
+        let columns = visibleColumns()
+        let (cancellationToken, commitToken) = beginExport()
+        exportQueue.async {
+            guard let selectedRows = selection.resolvedRows(
+                from: rowSnapshot,
+                cancellationToken: cancellationToken
+            ) else {
+                return
+            }
+            let value = asJSON
+                ? EndpointStatisticsTableExportFormatter.json(
+                    rows: selectedRows,
+                    columns: columns,
+                    cancellationToken: cancellationToken
+                )
+                : EndpointStatisticsTableExportFormatter.csv(
+                    rows: selectedRows,
+                    columns: columns,
+                    cancellationToken: cancellationToken
+                )
+            guard let value, !value.isEmpty else {
+                return
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.commitExport(value, cancellationToken: cancellationToken, commitToken: commitToken)
+            }
+        }
+    }
+
+    private func copyValues(
+        field: EndpointStatisticsSemanticCopyField,
+        selection: EndpointStatisticsRowSelection
+    ) {
+        guard rowsAreActionable, !selection.isEmpty(rowCount: rows.count) else {
+            return
+        }
+        let rowSnapshot = rows
+        let (cancellationToken, commitToken) = beginExport()
+        exportQueue.async {
+            guard let selectedRows = selection.resolvedRows(
+                from: rowSnapshot,
+                cancellationToken: cancellationToken
+            ),
+            let value = EndpointStatisticsSemanticValueFormatter.joinedValues(
+                rows: selectedRows,
+                field: field,
+                cancellationToken: cancellationToken
+            ),
+            !value.isEmpty else {
+                return
+            }
+            DispatchQueue.main.async { [weak self] in
+                self?.commitExport(value, cancellationToken: cancellationToken, commitToken: commitToken)
+            }
+        }
+    }
+
+    private func beginExport() -> (
+        cancellationToken: EndpointStatisticsCancellationToken,
+        commitToken: EndpointStatisticsExportCommitToken
+    ) {
+        activeExportCancellationToken?.cancel()
+        exportGeneration &+= 1
+        let cancellationToken = EndpointStatisticsCancellationToken()
+        activeExportCancellationToken = cancellationToken
+        return (
+            cancellationToken,
+            EndpointStatisticsExportCommitToken(
+                generation: exportGeneration,
+                pasteboardChangeCount: NSPasteboard.general.changeCount
+            )
+        )
+    }
+
+    private func commitExport(
+        _ value: String,
+        cancellationToken: EndpointStatisticsCancellationToken,
+        commitToken: EndpointStatisticsExportCommitToken
+    ) {
+        guard activeExportCancellationToken === cancellationToken,
+              !cancellationToken.isCancelled(),
+              EndpointStatisticsExportCommitPolicy.shouldCommit(
+                commitToken,
+                currentGeneration: exportGeneration,
+                currentPasteboardChangeCount: NSPasteboard.general.changeCount
+              ) else {
+            return
+        }
+        activeExportCancellationToken = nil
+        writeToPasteboard(value, invalidatesPendingExports: false)
+    }
+
+    private func writeToPasteboard(_ value: String, invalidatesPendingExports: Bool = true) {
+        guard !value.isEmpty else {
+            return
+        }
+        if invalidatesPendingExports {
+            activeExportCancellationToken?.cancel()
+            activeExportCancellationToken = nil
+            exportGeneration &+= 1
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+
+    private func targetSelection() -> EndpointStatisticsRowSelection {
+        guard rowsAreActionable else {
+            return .indexes([])
+        }
+        let indexes: IndexSet
+        if contextTarget.rowID != nil {
+            guard let contextRow = contextTarget.resolvedRowIndex(
+                rowIndexByID: rowIndexByID,
+                rowCount: rows.count
+            ) else {
+                return .indexes([])
+            }
+            indexes = tableView.selectedRowIndexes.contains(contextRow)
+                ? tableView.selectedRowIndexes
+                : IndexSet(integer: contextRow)
+        } else {
+            indexes = tableView.selectedRowIndexes
+        }
+        return .indexes(indexes)
+    }
+
+    private func visibleColumns() -> [EndpointStatisticsTableColumn] {
+        tableView.tableColumns.compactMap { column in
+            guard !column.isHidden else {
+                return nil
+            }
+            return EndpointStatisticsTableColumn(rawValue: column.identifier.rawValue)
+        }
+    }
+
+    private func makeContextMenu() -> NSMenu {
+        let menu = NSMenu(title: "Endpoints")
+        menu.delegate = self
+        menu.autoenablesItems = false
+        return menu
+    }
+
+    // Build row-sensitive actions only when the native context menu opens.
+    private func updateContextMenu(_ menu: NSMenu) {
+        updateContextPosition()
+        menu.removeAllItems()
+        let selection = targetSelection()
+        let hasRows = rowsAreActionable && !selection.isEmpty(rowCount: rows.count)
+
+        menu.addItem(menuItem("Show Related Packets", action: #selector(showRelatedPacketsFromMenu(_:)), isEnabled: hasRows))
+        menu.addItem(.separator())
+        menu.addItem(menuItem("Copy Cell", action: #selector(copyCellFromMenu(_:)), isEnabled: contextCellValue() != nil))
+        menu.addItem(menuItem(
+            "Copy Address",
+            action: #selector(copyAddressFromMenu(_:)),
+            isEnabled: hasRows && selection.containsCopyableValue(in: rows, field: .address)
+        ))
+        menu.addItem(menuItem(
+            "Copy Domain",
+            action: #selector(copyDomainFromMenu(_:)),
+            isEnabled: hasRows && selection.containsCopyableValue(in: rows, field: .domain)
+        ))
+        menu.addItem(menuItem(
+            "Copy App",
+            action: #selector(copyClientFromMenu(_:)),
+            isEnabled: hasRows && selection.containsCopyableValue(in: rows, field: .client)
+        ))
+        menu.addItem(.separator())
+        menu.addItem(menuItem("Copy Selected Rows as CSV", action: #selector(copySelectedCSVFromMenu(_:)), isEnabled: hasRows))
+        menu.addItem(menuItem("Copy Selected Rows as JSON", action: #selector(copySelectedJSONFromMenu(_:)), isEnabled: hasRows))
+        menu.addItem(menuItem("Copy All Rows as CSV", action: #selector(copyAllCSVFromMenu(_:)), isEnabled: rowsAreActionable && !rows.isEmpty))
+        menu.addItem(menuItem("Copy All Rows as JSON", action: #selector(copyAllJSONFromMenu(_:)), isEnabled: rowsAreActionable && !rows.isEmpty))
+    }
+
+    private func menuItem(_ title: String, action: Selector, isEnabled: Bool) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.isEnabled = isEnabled
+        return item
+    }
+
+    private func updateContextPosition() {
+        guard let event = NSApp.currentEvent, let window = tableView.window, event.window === window else {
+            contextTarget = .none
+            return
+        }
+        let point = tableView.convert(event.locationInWindow, from: nil)
+        let rowIndex = tableView.row(at: point)
+        let columnIndex = tableView.column(at: point)
+        let rowID = rows.indices.contains(rowIndex) ? rows[rowIndex].id : nil
+        let column = tableView.tableColumns.indices.contains(columnIndex)
+            ? EndpointStatisticsTableColumn(
+                rawValue: tableView.tableColumns[columnIndex].identifier.rawValue
+            )
+            : nil
+        contextTarget = EndpointStatisticsContextTarget(rowID: rowID, column: column)
+    }
+
+    private func contextCellValue() -> String? {
+        guard rowsAreActionable,
+              let rowIndex = contextTarget.resolvedRowIndex(
+                rowIndexByID: rowIndexByID,
+                rowCount: rows.count
+              ),
+              let column = contextTarget.column else {
+            return nil
+        }
+        let value = column.stringValue(in: rows[rowIndex])
+        return EndpointStatisticsSemanticCopyPolicy.copyableValue(
+            value,
+            isAggregatePlaceholder: column.isAggregatePlaceholder(in: rows[rowIndex])
+        )
+    }
+
+    // Restore each protocol tab's own visible columns, order, and widths.
+    private func applyColumnLayout(for group: EndpointStatisticsGroup) {
+        guard let service = columnServices[group] else {
+            return
+        }
+        isApplyingColumnLayout = true
+        defer { isApplyingColumnLayout = false }
+
+        let savedLayout = columnStores[group]?.load()
+        var seenIdentifiers = Set<String>()
+        let savedOrder = savedLayout?.columns.compactMap { column in
+            service.definition(identifier: column.identifier) != nil && seenIdentifiers.insert(column.identifier).inserted
+                ? column.identifier
+                : nil
+        } ?? []
+        let missingIdentifiers = service.definitions.compactMap { definition in
+            seenIdentifiers.insert(definition.identifier).inserted ? definition.identifier : nil
+        }
+        for (targetIndex, identifier) in (savedOrder + missingIdentifiers).enumerated() {
+            guard let currentIndex = tableView.tableColumns.firstIndex(where: {
+                $0.identifier.rawValue == identifier
+            }), currentIndex != targetIndex else {
+                continue
+            }
+            tableView.moveColumn(currentIndex, toColumn: targetIndex)
+        }
+        var savedWidths: [String: Double] = [:]
+        for column in savedLayout?.columns ?? [] where savedWidths[column.identifier] == nil {
+            savedWidths[column.identifier] = column.width
+        }
+        for column in tableView.tableColumns {
+            let identifier = column.identifier.rawValue
+            column.isHidden = !service.isColumnVisible(identifier: identifier)
+            if let width = savedWidths[identifier], width.isFinite {
+                column.width = max(column.minWidth, CGFloat(width))
+            } else if let definition = service.definition(identifier: identifier) {
+                column.width = max(column.minWidth, CGFloat(definition.defaultWidth))
+            }
+        }
+
+        let menuController = PacketTableColumnVisibilityMenuController(columnService: service)
+        menuController.actionHandler = self
+        columnVisibilityMenuController = menuController
+        tableView.headerView?.menu = menuController.makeMenu()
+        tableView.reloadData()
+    }
+
+    private func saveCurrentColumnLayout() {
+        guard !isApplyingColumnLayout,
+              let service = currentColumnService,
+              let store = columnStores[selectedGroup] else {
+            return
+        }
+        for column in tableView.tableColumns {
+            service.syncColumnVisibility(
+                identifier: column.identifier.rawValue,
+                isVisible: !column.isHidden
+            )
+        }
+        store.save(PacketTableColumnLayout(columns: tableView.tableColumns.map { column in
+            PacketTableColumnLayout.Column(
+                identifier: column.identifier.rawValue,
+                isVisible: !column.isHidden,
+                width: Double(column.width)
+            )
+        }))
+    }
+
+    private func applySortDescriptor(_ sort: EndpointStatisticsTableSort) {
+        tableView.sortDescriptors = [NSSortDescriptor(
+            key: sort.column.rawValue,
+            ascending: sort.isAscending
+        )]
+    }
+
+    @objc private func appConfigurationDidChange(_ notification: Notification) {
+        tableView.rowHeight = configuration.packetRowHeight
+        tableView.reloadData()
+    }
+
+    private static func columnDefinitions(
+        for group: EndpointStatisticsGroup
+    ) -> [PacketTableColumnDefinition] {
+        EndpointStatisticsTableColumn.allCases.map { column in
+            PacketTableColumnDefinition.custom(
+                identifier: column.rawValue,
+                title: column.title,
+                defaultWidth: defaultWidth(for: column),
+                minimumWidth: minimumWidth(for: column),
+                cellKind: column == .client ? .client : (column == .protocolName ? .protocol : .text),
+                isDefaultVisible: isDefaultVisible(column, group: group),
+                canUserHide: true
+            )
+        }
+    }
+
+    private static func alignment(for column: EndpointStatisticsTableColumn) -> NSTextAlignment {
+        column.isNumeric ? .right : (column == .protocolName ? .center : .left)
+    }
+
+    private static func isDefaultVisible(
+        _ column: EndpointStatisticsTableColumn,
+        group: EndpointStatisticsGroup
+    ) -> Bool {
+        switch column {
+        case .address:
+            group != .apps && group != .domains
+        case .port:
+            group == .tcp || group == .udp
+        default:
+            true
+        }
+    }
+
+    private static func defaultWidth(for column: EndpointStatisticsTableColumn) -> Double {
+        switch column {
+        case .address: 190
+        case .port: 72
+        case .protocolName: 100
+        case .client: 150
+        case .domain: 190
+        case .packets, .bytes: 98
+        case .txPackets, .rxPackets: 105
+        case .txBytes, .rxBytes: 100
+        case .summary: 190
+        }
+    }
+
+    private static func minimumWidth(for column: EndpointStatisticsTableColumn) -> Double {
+        switch column {
+        case .address, .domain: 110
+        case .client: 90
+        case .summary: 130
+        default: 68
+        }
+    }
+}
+
+extension EndpointStatisticsViewController: NSSearchFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        requestPresentation(intent: .explicit)
+    }
+}
+
+extension EndpointStatisticsViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        rows.count
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        objectValueFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> Any? {
+        guard rows.indices.contains(row),
+              let identifier = tableColumn?.identifier.rawValue,
+              let column = EndpointStatisticsTableColumn(rawValue: identifier) else {
+            return nil
+        }
+        return displayText(for: column, row: rows[row])
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        willDisplayCell cell: Any,
+        for tableColumn: NSTableColumn?,
+        row: Int
+    ) {
+        guard rows.indices.contains(row),
+              let identifier = tableColumn?.identifier.rawValue,
+              let column = EndpointStatisticsTableColumn(rawValue: identifier) else {
+            return
+        }
+        let endpoint = rows[row]
+        if let cell = cell as? PacketProtocolCell {
+            cell.configure(
+                protocolText: endpoint.protocolName ?? "",
+                severity: .normal,
+                textStyle: .plain,
+                configuration: configuration
+            )
+        } else if let cell = cell as? PacketClientCell {
+            cell.configure(
+                displayName: endpoint.client ?? "",
+                iconFilePath: nil,
+                textStyle: .plain,
+                configuration: configuration
+            )
+        } else if let cell = cell as? PacketTextCell {
+            let value = column.stringValue(in: endpoint)
+            let style: PacketTextCell.Style = value.isEmpty || column.isAggregatePlaceholder(in: endpoint)
+                ? .secondary
+                : .primary
+            cell.configure(style: style, textStyle: .plain, configuration: configuration)
+        }
+        if let cell = cell as? NSCell {
+            cell.alignment = Self.alignment(for: column)
+        }
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        sortDescriptorsDidChange oldDescriptors: [NSSortDescriptor]
+    ) {
+        guard let descriptor = tableView.sortDescriptors.first,
+              let key = descriptor.key,
+              let column = EndpointStatisticsTableColumn(rawValue: key) else {
+            sortByGroup[selectedGroup] = .busiestFirst
+            requestPresentation(intent: .explicit)
+            return
+        }
+        sortByGroup[selectedGroup] = EndpointStatisticsTableSort(
+            column: column,
+            isAscending: descriptor.ascending
+        )
+        requestPresentation(intent: .explicit)
+    }
+
+    func tableViewColumnDidMove(_ notification: Notification) {
+        saveCurrentColumnLayout()
+    }
+
+    func tableViewColumnDidResize(_ notification: Notification) {
+        saveCurrentColumnLayout()
+    }
+}
+
+extension EndpointStatisticsViewController: NSMenuDelegate {
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        if menu === tableView.menu {
+            updateContextMenu(menu)
+        }
+    }
+}
+
+extension EndpointStatisticsViewController: EndpointStatisticsTableKeyboardActionHandling {
+    func endpointStatisticsTableDidRequestCopy(_ tableView: NSTableView) {
+        contextTarget = .none
+        copy(selection: targetSelection(), asJSON: false)
+    }
+}
+
+extension EndpointStatisticsViewController: PacketTableColumnVisibilityMenuActionHandling {
+    func togglePacketTableColumnVisibilityFromMenu(_ sender: Any?) {
+        guard let item = sender as? NSMenuItem,
+              let identifier = item.representedObject as? String,
+              let service = currentColumnService,
+              service.toggleColumnVisibility(identifier: identifier),
+              let column = tableView.tableColumn(withIdentifier: NSUserInterfaceItemIdentifier(identifier)) else {
+            return
+        }
+        column.isHidden = !service.isColumnVisible(identifier: identifier)
+        saveCurrentColumnLayout()
+        tableView.headerView?.menu?.cancelTracking()
+    }
+
+    func resetPacketTableColumnsFromMenu(_ sender: Any?) {
+        guard let service = currentColumnService, let store = columnStores[selectedGroup] else {
+            return
+        }
+        service.resetToDefaults()
+        store.clear()
+        applyColumnLayout(for: selectedGroup)
+        tableView.headerView?.menu?.cancelTracking()
+    }
+}

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -349,7 +349,7 @@ private struct EndpointStatisticsPresentationResult: Sendable {
 }
 
 enum EndpointStatisticsPresentationCadence {
-    static let maximumRefreshRateInterval: TimeInterval = 0.25
+    static let maximumRefreshRateInterval: TimeInterval = 0.5
     static let maximumCooldown: TimeInterval = 2
 
     // Automatic refreshes wait after the last table commit, while user actions skip that cadence delay.
@@ -1616,7 +1616,7 @@ private final class EndpointStatisticsViewController: NSViewController, NSToolba
         displayedPacketsCheckbox.action = #selector(displayedPacketsScopeChanged(_:))
         displayedPacketsCheckbox.toolTip = "Use the packets currently shown in the main table."
 
-        searchField.placeholderString = "Search endpoints"
+        searchField.placeholderString = "Search endpoints (⌘F)"
         searchField.sendsSearchStringImmediately = true
         searchField.delegate = self
         searchField.setAccessibilityLabel("Search endpoints")

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -341,6 +341,19 @@ enum EndpointStatisticsPresentationCadence {
     static let maximumRefreshRateInterval: TimeInterval = 0.25
     static let maximumCooldown: TimeInterval = 2
 
+    // Automatic refreshes wait after the last table commit, while user actions skip that cadence delay.
+    static func delay(
+        for intent: EndpointStatisticsPresentationIntent,
+        lastCommitTime: TimeInterval,
+        nextAllowedTime: TimeInterval,
+        now: TimeInterval
+    ) -> TimeInterval {
+        let refreshDelay = intent == .automatic
+            ? maximumRefreshRateInterval - (now - lastCommitTime)
+            : 0
+        return max(0, refreshDelay, nextAllowedTime - now)
+    }
+
     static func cooldown(after processingDuration: TimeInterval) -> TimeInterval {
         guard processingDuration > maximumRefreshRateInterval else {
             return 0
@@ -1192,8 +1205,6 @@ private final class EndpointStatisticsViewController: NSViewController {
     private let scrollView = NSScrollView()
     private let tableView = EndpointStatisticsTableView()
     private let footerLabel = NSTextField(labelWithString: "No endpoints")
-    private let progressIndicator = NSProgressIndicator()
-    private let calculatingLabel = NSTextField(labelWithString: "Calculating…")
     private let refreshNoticeLabel = NSTextField(labelWithString: "")
     private let refreshButton = NSButton(title: "Refresh", target: nil, action: nil)
     private let numberFormatter: NumberFormatter
@@ -1242,7 +1253,7 @@ private final class EndpointStatisticsViewController: NSViewController {
     private var isPresentationInFlight = false
     private var activePresentationCancellationToken: EndpointStatisticsCancellationToken?
     private var pendingPresentationIntent: EndpointStatisticsPresentationIntent?
-    private var lastPresentationStartTime: TimeInterval = 0
+    private var lastPresentationCommitTime: TimeInterval = 0
     private var nextPresentationAllowedTime: TimeInterval = 0
     private var automaticRefreshPolicy = EndpointStatisticsAutomaticRefreshPolicy()
     private var contextTarget = EndpointStatisticsContextTarget.none
@@ -1366,7 +1377,6 @@ private final class EndpointStatisticsViewController: NSViewController {
                 presentationGeneration &+= 1
                 pendingPresentationIntent = .explicit
                 abandonActivePresentation()
-                setCalculating(true, text: "Updating displayed packets…")
             }
         }
         if sourceChanged, displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused {
@@ -1470,7 +1480,6 @@ private final class EndpointStatisticsViewController: NSViewController {
                 presentationGeneration &+= 1
                 pendingPresentationIntent = nil
                 abandonActivePresentation()
-                setCalculating(true, text: "Updating displayed packets…")
             } else {
                 let wasWaitingForFilter = isWaitingForDisplayFilter
                 isWaitingForDisplayFilter = false
@@ -1572,13 +1581,6 @@ private final class EndpointStatisticsViewController: NSViewController {
         searchField.delegate = self
         searchField.setAccessibilityLabel("Search endpoints")
 
-        progressIndicator.style = .spinning
-        progressIndicator.controlSize = .small
-        progressIndicator.isDisplayedWhenStopped = false
-        calculatingLabel.textColor = .secondaryLabelColor
-        calculatingLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        calculatingLabel.isHidden = true
-
         footerLabel.textColor = .secondaryLabelColor
         footerLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
         footerLabel.lineBreakMode = .byTruncatingTail
@@ -1631,24 +1633,18 @@ private final class EndpointStatisticsViewController: NSViewController {
         segmentControl.setContentHuggingPriority(.defaultLow, for: .horizontal)
         searchField.setContentHuggingPriority(.required, for: .horizontal)
 
-        let calculationStack = NSStackView(views: [progressIndicator, calculatingLabel])
-        calculationStack.orientation = .horizontal
-        calculationStack.alignment = .centerY
-        calculationStack.spacing = 5
-
         let refreshStack = NSStackView(views: [refreshNoticeLabel, refreshButton])
         refreshStack.orientation = .horizontal
         refreshStack.alignment = .centerY
         refreshStack.spacing = 6
 
-        let footerStack = NSStackView(views: [footerLabel, refreshStack, calculationStack])
+        let footerStack = NSStackView(views: [footerLabel, refreshStack])
         footerStack.orientation = .horizontal
         footerStack.alignment = .centerY
         footerStack.spacing = 8
         footerLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         refreshNoticeLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         refreshStack.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        calculationStack.setContentHuggingPriority(.required, for: .horizontal)
 
         [topStack, scrollView, footerStack].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -1761,7 +1757,6 @@ private final class EndpointStatisticsViewController: NSViewController {
         displayedReplacementWork = work
         isDisplayedReplacementPaused = false
         needsDisplayedReplacement = true
-        setCalculating(true, text: "Loading displayed endpoints…")
         scheduleDisplayedReplacementContinuation(work)
         return true
     }
@@ -1964,9 +1959,6 @@ private final class EndpointStatisticsViewController: NSViewController {
         )
         rawReplacementWork = work
         isRawReplacementPaused = false
-        if !usesDisplayedPackets {
-            setCalculating(true, text: "Loading endpoints…")
-        }
         scheduleRawReplacementContinuation(work)
     }
 
@@ -2364,12 +2356,8 @@ private final class EndpointStatisticsViewController: NSViewController {
         guard usesDisplayedPackets,
               let latestRenderedSource,
               !latestRenderedSource.isFiltering else {
-            if usesDisplayedPackets {
-                setCalculating(true, text: "Refreshing displayed packets…")
-            }
             return
         }
-        setCalculating(true, text: "Refreshing displayed packets…")
         if consumeDisplayedSource(latestRenderedSource, forceReplacement: true) {
             recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
         } else {
@@ -2392,7 +2380,6 @@ private final class EndpointStatisticsViewController: NSViewController {
         } else if allPacketsPresentationIntentAfterDrain != .explicit {
             allPacketsPresentationIntentAfterDrain = intent
         }
-        setCalculating(true, text: "Calculating…")
     }
 
     private func attemptPendingAllPacketsSourceReplacement() {
@@ -2470,10 +2457,11 @@ private final class EndpointStatisticsViewController: NSViewController {
         }
         if effectiveIntent == .explicit {
             abandonActivePresentation()
+            scheduledPresentationWorkItem?.cancel()
+            scheduledPresentationWorkItem = nil
         }
         presentationGeneration &+= 1
         pendingPresentationIntent = effectiveIntent
-        setCalculating(true, text: "Calculating…")
         guard !usesDisplayedPackets || (
             !needsDisplayedReplacement && latestRenderedSource?.identity == latestSourceIdentity
         ) else {
@@ -2490,10 +2478,12 @@ private final class EndpointStatisticsViewController: NSViewController {
         }
 
         let now = Date.timeIntervalSinceReferenceDate
-        let elapsed = now - lastPresentationStartTime
-        let rateLimitDelay = EndpointStatisticsPresentationCadence.maximumRefreshRateInterval - elapsed
-        let backpressureDelay = nextPresentationAllowedTime - now
-        let delay = max(0, rateLimitDelay, backpressureDelay)
+        let delay = EndpointStatisticsPresentationCadence.delay(
+            for: effectiveIntent,
+            lastCommitTime: lastPresentationCommitTime,
+            nextAllowedTime: nextPresentationAllowedTime,
+            now: now
+        )
         let workItem = DispatchWorkItem { [weak self] in
             self?.beginPresentation()
         }
@@ -2526,7 +2516,6 @@ private final class EndpointStatisticsViewController: NSViewController {
         isPresentationInFlight = true
         let presentationCancellationToken = EndpointStatisticsCancellationToken()
         activePresentationCancellationToken = presentationCancellationToken
-        lastPresentationStartTime = Date.timeIntervalSinceReferenceDate
 
         let request = EndpointStatisticsPresentationRequest(
             generation: presentationGeneration,
@@ -2623,7 +2612,7 @@ private final class EndpointStatisticsViewController: NSViewController {
             automaticRefreshPolicy.didCommit(
                 unfilteredEndpointCount: result.table.unfilteredRowCount
             )
-            setCalculating(false, text: "")
+            lastPresentationCommitTime = Date.timeIntervalSinceReferenceDate
             updateRefreshNotice()
         }
 
@@ -2670,16 +2659,6 @@ private final class EndpointStatisticsViewController: NSViewController {
         )).joined(separator: " · ")
     }
 
-    private func setCalculating(_ isCalculating: Bool, text: String) {
-        calculatingLabel.stringValue = text
-        calculatingLabel.isHidden = !isCalculating
-        if isCalculating {
-            progressIndicator.startAnimation(nil)
-        } else {
-            progressIndicator.stopAnimation(nil)
-        }
-    }
-
     private func updateRefreshNotice() {
         let message: String?
         if currentPipelineIsPaused {
@@ -2705,12 +2684,10 @@ private final class EndpointStatisticsViewController: NSViewController {
             return
         }
         if currentPipelineIsPaused {
-            setCalculating(true, text: "Refreshing…")
             if usesDisplayedPackets {
                 waitsForDisplayedPacketsManualRefresh = true
                 pendingDisplayedPacketsSourceReplacement = false
                 guard let latestRenderedSource, !latestRenderedSource.isFiltering else {
-                    setCalculating(true, text: "Updating displayed packets…")
                     return
                 }
                 resumeDisplayedPacketsForSourceReplacement(latestRenderedSource)
@@ -2776,7 +2753,6 @@ private final class EndpointStatisticsViewController: NSViewController {
                 isWaitingForDisplayFilter = true
                 waitsForAggregation = true
                 recordPresentationIntentAfterDrain(.explicit, usesDisplayedPackets: true)
-                setCalculating(true, text: "Updating displayed packets…")
             } else if displayedPacketsPipeline.isPaused || isDisplayedReplacementPaused {
                 isWaitingForDisplayFilter = false
                 waitsForAggregation = true

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -58,7 +58,10 @@ final class EndpointStatisticsWindowController: NSWindowController, NSWindowDele
         window?.title = title
     }
 
-    func present(title: String) {
+    func present(title: String, forceAllPackets: Bool = false) {
+        if forceAllPackets {
+            statisticsViewController.useAllPacketsScope()
+        }
         updateTitle(title)
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
@@ -1506,6 +1509,16 @@ private final class EndpointStatisticsViewController: NSViewController {
                 }
             }
         }
+    }
+
+    // Overview always opens the complete capture while keeping the selected tab and column layout.
+    func useAllPacketsScope() {
+        loadViewIfNeeded()
+        guard usesDisplayedPackets else {
+            return
+        }
+        displayedPacketsCheckbox.state = .off
+        displayedPacketsScopeChanged(displayedPacketsCheckbox)
     }
 
     func focusSearch() {

--- a/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/EndpointStatisticsWindowController.swift
@@ -8,6 +8,14 @@
 import AppKit
 import PcapPlusPlusCore
 
+private enum EndpointStatisticsToolbarItem {
+    static let endpointTypes = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.endpointTypes")
+    static let displayedPackets = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.displayedPackets")
+    static let showPackets = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.showPackets")
+    static let copy = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.copy")
+    static let search = NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.search")
+}
+
 final class EndpointStatisticsWindowController: NSWindowController, NSWindowDelegate {
     var closeHandler: (() -> Void)?
 
@@ -26,7 +34,7 @@ final class EndpointStatisticsWindowController: NSWindowController, NSWindowDele
             latestIngestStateProvider: latestIngestStateProvider
         )
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 1_240, height: 720),
+            contentRect: NSRect(x: 0, y: 0, width: 1_340, height: 720),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
@@ -38,6 +46,7 @@ final class EndpointStatisticsWindowController: NSWindowController, NSWindowDele
         super.init(window: window)
         window.delegate = self
         window.contentViewController = statisticsViewController
+        statisticsViewController.installToolbar(in: window)
     }
 
     @available(*, unavailable)
@@ -1180,7 +1189,7 @@ final class EndpointStatisticsRawReplacementWork {
     }
 }
 
-private final class EndpointStatisticsViewController: NSViewController {
+private final class EndpointStatisticsViewController: NSViewController, NSToolbarDelegate {
     private let configuration: AppConfiguration
     private let packetProvider: ([PacketSummary.ID]) -> [PacketSummary]
     private let showRelatedPackets: (EndpointStatisticsRow.ID) -> Void
@@ -1204,7 +1213,12 @@ private final class EndpointStatisticsViewController: NSViewController {
 
     private let segmentControl = NSSegmentedControl()
     private let displayedPacketsCheckbox = NSButton(checkboxWithTitle: "Displayed packets only", target: nil, action: nil)
-    private let searchField = NSSearchField()
+    private let endpointTypesToolbarItem = NSToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.endpointTypes)
+    private let displayedPacketsToolbarItem = NSToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.displayedPackets)
+    private let showPacketsToolbarItem = NSToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.showPackets)
+    private let copyToolbarItem = NSMenuToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.copy)
+    private let searchToolbarItem = NSSearchToolbarItem(itemIdentifier: EndpointStatisticsToolbarItem.search)
+    private let copyMenu = NSMenu(title: "Copy Endpoints")
     private let scrollView = NSScrollView()
     private let tableView = EndpointStatisticsTableView()
     private let footerLabel = NSTextField(labelWithString: "No endpoints")
@@ -1265,6 +1279,10 @@ private final class EndpointStatisticsViewController: NSViewController {
     private var isWaitingForDisplayFilter = false
     private var committedActionState: EndpointStatisticsActionState?
     private var isCancelled = false
+
+    private var searchField: NSSearchField {
+        searchToolbarItem.searchField
+    }
 
     init(
         configuration: AppConfiguration,
@@ -1342,6 +1360,7 @@ private final class EndpointStatisticsViewController: NSViewController {
     override func loadView() {
         view = NSView()
         setupControls()
+        setupToolbarItems()
         setupTable()
         setupLayout()
         applyColumnLayout(for: selectedGroup)
@@ -1353,6 +1372,18 @@ private final class EndpointStatisticsViewController: NSViewController {
             name: AppConfiguration.didChangeNotification,
             object: configuration
         )
+    }
+
+    // Keep navigation and common table actions in the native window toolbar.
+    func installToolbar(in window: NSWindow) {
+        loadViewIfNeeded()
+        let toolbar = NSToolbar(identifier: "TCPViewer.EndpointStatisticsToolbar.v1")
+        toolbar.delegate = self
+        toolbar.displayMode = .iconOnly
+        toolbar.allowsUserCustomization = false
+        toolbar.autosavesConfiguration = false
+        window.toolbarStyle = .unified
+        window.toolbar = toolbar
     }
 
     // Convert a main-thread ingest state into a small owned update before crossing queues.
@@ -1609,6 +1640,42 @@ private final class EndpointStatisticsViewController: NSViewController {
         refreshButton.isHidden = true
     }
 
+    private func setupToolbarItems() {
+        endpointTypesToolbarItem.label = "Endpoint Type"
+        endpointTypesToolbarItem.paletteLabel = "Endpoint Type"
+        endpointTypesToolbarItem.view = segmentControl
+        endpointTypesToolbarItem.visibilityPriority = .user
+
+        displayedPacketsCheckbox.controlSize = .small
+        displayedPacketsToolbarItem.label = "Displayed Packets"
+        displayedPacketsToolbarItem.paletteLabel = "Displayed Packets Only"
+        displayedPacketsToolbarItem.view = displayedPacketsCheckbox
+        displayedPacketsToolbarItem.visibilityPriority = .high
+
+        showPacketsToolbarItem.label = "Show Packets"
+        showPacketsToolbarItem.paletteLabel = "Show Related Packets"
+        showPacketsToolbarItem.toolTip = "Show packets for the selected endpoint"
+        showPacketsToolbarItem.image = TCPViewerUI.image("list.bullet.rectangle")
+        showPacketsToolbarItem.target = self
+        showPacketsToolbarItem.action = #selector(showRelatedPacketsFromToolbar(_:))
+        showPacketsToolbarItem.visibilityPriority = .high
+        showPacketsToolbarItem.isEnabled = false
+
+        copyToolbarItem.label = "Copy"
+        copyToolbarItem.paletteLabel = "Copy Endpoints"
+        copyToolbarItem.toolTip = "Copy endpoint rows as CSV or JSON"
+        copyToolbarItem.image = TCPViewerUI.image("doc.on.doc")
+        copyToolbarItem.menu = copyMenu
+        copyToolbarItem.visibilityPriority = .high
+        copyToolbarItem.isEnabled = false
+        copyMenu.autoenablesItems = false
+        copyMenu.delegate = self
+
+        searchToolbarItem.label = "Search"
+        searchToolbarItem.paletteLabel = "Search Endpoints"
+        searchToolbarItem.visibilityPriority = .high
+    }
+
     private func setupTable() {
         tableView.delegate = self
         tableView.dataSource = self
@@ -1637,15 +1704,8 @@ private final class EndpointStatisticsViewController: NSViewController {
         scrollView.backgroundColor = .controlBackgroundColor
     }
 
-    // Keep the common controls visible while the table consumes the flexible window area.
+    // Let the table use the space freed by moving its common controls into the toolbar.
     private func setupLayout() {
-        let topStack = NSStackView(views: [segmentControl, displayedPacketsCheckbox, searchField])
-        topStack.orientation = .horizontal
-        topStack.alignment = .centerY
-        topStack.spacing = 12
-        segmentControl.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        searchField.setContentHuggingPriority(.required, for: .horizontal)
-
         let refreshStack = NSStackView(views: [refreshNoticeLabel, refreshButton])
         refreshStack.orientation = .horizontal
         refreshStack.alignment = .centerY
@@ -1659,20 +1719,15 @@ private final class EndpointStatisticsViewController: NSViewController {
         refreshNoticeLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         refreshStack.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
-        [topStack, scrollView, footerStack].forEach {
+        [scrollView, footerStack].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
         }
 
         NSLayoutConstraint.activate([
-            topStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
-            topStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
-            topStack.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
-            searchField.widthAnchor.constraint(equalToConstant: 220),
-
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.topAnchor.constraint(equalTo: topStack.bottomAnchor, constant: 10),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: footerStack.topAnchor, constant: -6),
 
             footerStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
@@ -1680,6 +1735,42 @@ private final class EndpointStatisticsViewController: NSViewController {
             footerStack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -7),
             footerStack.heightAnchor.constraint(greaterThanOrEqualToConstant: 20),
         ])
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [
+            EndpointStatisticsToolbarItem.endpointTypes,
+            .flexibleSpace,
+            EndpointStatisticsToolbarItem.displayedPackets,
+            EndpointStatisticsToolbarItem.showPackets,
+            EndpointStatisticsToolbarItem.copy,
+            EndpointStatisticsToolbarItem.search,
+        ]
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        toolbarAllowedItemIdentifiers(toolbar)
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        switch itemIdentifier {
+        case EndpointStatisticsToolbarItem.endpointTypes:
+            endpointTypesToolbarItem
+        case EndpointStatisticsToolbarItem.displayedPackets:
+            displayedPacketsToolbarItem
+        case EndpointStatisticsToolbarItem.showPackets:
+            showPacketsToolbarItem
+        case EndpointStatisticsToolbarItem.copy:
+            copyToolbarItem
+        case EndpointStatisticsToolbarItem.search:
+            searchToolbarItem
+        default:
+            nil
+        }
     }
 
     private func addColumn(_ definition: PacketTableColumnDefinition) {
@@ -2622,6 +2713,7 @@ private final class EndpointStatisticsViewController: NSViewController {
                 context: request.context,
                 classificationRevision: request.classificationRevision
             )
+            updateToolbarActions()
             automaticRefreshPolicy.didCommit(
                 unfilteredEndpointCount: result.table.unfilteredRowCount
             )
@@ -2755,10 +2847,12 @@ private final class EndpointStatisticsViewController: NSViewController {
         selectedGroup = EndpointStatisticsGroup.allCases[sender.selectedSegment]
         applyColumnLayout(for: selectedGroup)
         applySortDescriptor(currentSort)
+        updateToolbarActions()
         requestPresentation(intent: .explicit)
     }
 
     @objc private func displayedPacketsScopeChanged(_ sender: NSButton) {
+        updateToolbarActions()
         var waitsForAggregation = false
         if usesDisplayedPackets {
             needsDisplayedReplacement = true
@@ -2804,6 +2898,11 @@ private final class EndpointStatisticsViewController: NSViewController {
             return
         }
         showRelatedPackets(rows[rowIndex].id)
+    }
+
+    @objc private func showRelatedPacketsFromToolbar(_ sender: Any?) {
+        contextTarget = .none
+        showRelatedPacketsFromMenu(sender)
     }
 
     @objc private func showRelatedPacketsFromMenu(_ sender: Any?) {
@@ -3051,6 +3150,26 @@ private final class EndpointStatisticsViewController: NSViewController {
         menu.addItem(menuItem("Copy All Rows as JSON", action: #selector(copyAllJSONFromMenu(_:)), isEnabled: rowsAreActionable && !rows.isEmpty))
     }
 
+    private func updateCopyMenu(_ menu: NSMenu) {
+        contextTarget = .none
+        menu.removeAllItems()
+        let selection = targetSelection()
+        let hasSelection = rowsAreActionable && !selection.isEmpty(rowCount: rows.count)
+        let hasRows = rowsAreActionable && !rows.isEmpty
+
+        menu.addItem(menuItem("Copy Selected Rows as CSV", action: #selector(copySelectedCSVFromMenu(_:)), isEnabled: hasSelection))
+        menu.addItem(menuItem("Copy Selected Rows as JSON", action: #selector(copySelectedJSONFromMenu(_:)), isEnabled: hasSelection))
+        menu.addItem(.separator())
+        menu.addItem(menuItem("Copy All Rows as CSV", action: #selector(copyAllCSVFromMenu(_:)), isEnabled: hasRows))
+        menu.addItem(menuItem("Copy All Rows as JSON", action: #selector(copyAllJSONFromMenu(_:)), isEnabled: hasRows))
+    }
+
+    private func updateToolbarActions() {
+        let hasSelection = rowsAreActionable && !tableView.selectedRowIndexes.isEmpty
+        showPacketsToolbarItem.isEnabled = hasSelection
+        copyToolbarItem.isEnabled = rowsAreActionable && !rows.isEmpty
+    }
+
     private func menuItem(_ title: String, action: Selector, isEnabled: Bool) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
@@ -3231,6 +3350,7 @@ private final class EndpointStatisticsViewController: NSViewController {
 
 extension EndpointStatisticsViewController: NSSearchFieldDelegate {
     func controlTextDidChange(_ obj: Notification) {
+        updateToolbarActions()
         requestPresentation(intent: .explicit)
     }
 }
@@ -3275,7 +3395,7 @@ extension EndpointStatisticsViewController: NSTableViewDataSource, NSTableViewDe
         } else if let cell = cell as? PacketClientCell {
             cell.configure(
                 displayName: endpoint.client ?? "",
-                iconFilePath: nil,
+                iconFilePath: endpoint.clientIconFilePath,
                 textStyle: .plain,
                 configuration: configuration
             )
@@ -3299,6 +3419,7 @@ extension EndpointStatisticsViewController: NSTableViewDataSource, NSTableViewDe
               let key = descriptor.key,
               let column = EndpointStatisticsTableColumn(rawValue: key) else {
             sortByGroup[selectedGroup] = .busiestFirst
+            updateToolbarActions()
             requestPresentation(intent: .explicit)
             return
         }
@@ -3306,7 +3427,12 @@ extension EndpointStatisticsViewController: NSTableViewDataSource, NSTableViewDe
             column: column,
             isAscending: descriptor.ascending
         )
+        updateToolbarActions()
         requestPresentation(intent: .explicit)
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        updateToolbarActions()
     }
 
     func tableViewColumnDidMove(_ notification: Notification) {
@@ -3322,6 +3448,8 @@ extension EndpointStatisticsViewController: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         if menu === tableView.menu {
             updateContextMenu(menu)
+        } else if menu === copyMenu {
+            updateCopyMenu(menu)
         }
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
@@ -80,6 +80,7 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     private let resetSeparator = NSBox()
     private let bottomSeparator = NSBox()
     private let resetButton = NSButton(title: "Reset Filters", target: nil, action: nil)
+    private var heightConstraint: NSLayoutConstraint?
     private var buttons: [PacketQuickFilterID: PacketQuickFilterButton] = [:]
     private var customButtons: [PacketCustomFilter.ID: PacketCustomFilterButton] = [:]
     private var customItemsByID: [PacketCustomFilter.ID: PacketCustomFilterItem] = [:]
@@ -108,6 +109,10 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     }
 
     func render(snapshot: NetworkInspectorSnapshot) {
+        let isAvailable = snapshot.workspaceMode != .overview
+        view.isHidden = !isAvailable
+        preferredContentSize = NSSize(width: 0, height: isAvailable ? Metrics.height : 0)
+        heightConstraint?.constant = isAvailable ? Metrics.height : 0
         ensureButtons(for: snapshot.quickFilterItems, customItems: snapshot.customFilterItems)
         customItemsByID = [:]
         for item in snapshot.customFilterItems {
@@ -167,8 +172,10 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
 
         view.addSubview(stackView)
         view.addSubview(bottomSeparator)
+        let heightConstraint = view.heightAnchor.constraint(equalToConstant: Metrics.height)
+        self.heightConstraint = heightConstraint
         NSLayoutConstraint.activate([
-            view.heightAnchor.constraint(equalToConstant: Metrics.height),
+            heightConstraint,
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.topAnchor),

--- a/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketWorkspaceViewController.swift
@@ -41,6 +41,7 @@ protocol PacketWorkspaceViewControllerDelegate: AnyObject {
         group: PacketStructuredFilterGroup
     )
     func packetWorkspaceViewControllerDidRequestResetQuickFilters(_ controller: PacketWorkspaceViewController)
+    func packetWorkspaceViewControllerDidRequestClearEndpointStatisticsFilter(_ controller: PacketWorkspaceViewController)
     func packetWorkspaceViewControllerCanAddStructuredFilter(_ controller: PacketWorkspaceViewController) -> Bool
     func packetWorkspaceViewControllerCanSaveCustomFilter(_ controller: PacketWorkspaceViewController) -> Bool
     func packetWorkspaceViewControllerDidRequestStructuredFilterPaywall(_ controller: PacketWorkspaceViewController)
@@ -68,6 +69,7 @@ final class PacketWorkspaceViewModel {
     private(set) var emptyImageName = "list.bullet.rectangle"
     private(set) var showsResetFiltersButton = false
     private(set) var activeFilterLabels: [String] = []
+    private(set) var endpointStatisticsFilterLabel: String?
 
     // Convert the root snapshot into packet-workspace-only render data.
     func render(snapshot: NetworkInspectorSnapshot) {
@@ -77,6 +79,7 @@ final class PacketWorkspaceViewModel {
         isEmpty = snapshot.packetRows.isEmpty
         showsResetFiltersButton = isEmpty && snapshot.isQuickFilterActive
         activeFilterLabels = isEmpty ? snapshot.activeFilterBarLabels : []
+        endpointStatisticsFilterLabel = snapshot.endpointStatisticsFilterLabel
 
         if snapshot.isPacketTableFiltering && isEmpty {
             showsResetFiltersButton = false
@@ -118,12 +121,16 @@ final class PacketWorkspaceViewController: NSViewController {
 
     private let viewModel = PacketWorkspaceViewModel()
     private let contentContainer = NSView()
+    private let contentBodyContainer = NSView()
+    private let endpointFilterBar = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
+    private let endpointFilterLabel = NSTextField(labelWithString: "")
     private let structuredFilterController = PacketStructuredFilterViewController()
     private let tableController: PacketTableViewController
     private var placeholderView: NSView?
     private var isStructuredFilterVisible = false
     private var contentTopToBuilderBottomConstraint: NSLayoutConstraint?
     private var contentTopToSafeAreaConstraint: NSLayoutConstraint?
+    private var endpointFilterBarHeightConstraint: NSLayoutConstraint?
 
     init(configuration: AppConfiguration) {
         self.tableController = PacketTableViewController(configuration: configuration)
@@ -155,6 +162,7 @@ final class PacketWorkspaceViewController: NSViewController {
             customFilterItems: snapshot.customFilterItems
         )
         applyFilterVisibility(snapshot.isStructuredFilterVisible)
+        renderEndpointFilterBar(label: viewModel.endpointStatisticsFilterLabel)
 
         if viewModel.isEmpty {
             showPlaceholder(
@@ -194,6 +202,10 @@ final class PacketWorkspaceViewController: NSViewController {
         contentContainer.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(contentContainer)
 
+        setupEndpointFilterBar()
+        contentBodyContainer.translatesAutoresizingMaskIntoConstraints = false
+        contentContainer.addSubview(contentBodyContainer)
+
         addChild(structuredFilterController)
         addChild(tableController)
         structuredFilterController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -211,10 +223,71 @@ final class PacketWorkspaceViewController: NSViewController {
             contentTopToSafeAreaConstraint,
             contentContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
+            endpointFilterBar.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+            endpointFilterBar.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+            endpointFilterBar.topAnchor.constraint(equalTo: contentContainer.topAnchor),
+
+            contentBodyContainer.leadingAnchor.constraint(equalTo: contentContainer.leadingAnchor),
+            contentBodyContainer.trailingAnchor.constraint(equalTo: contentContainer.trailingAnchor),
+            contentBodyContainer.topAnchor.constraint(equalTo: endpointFilterBar.bottomAnchor),
+            contentBodyContainer.bottomAnchor.constraint(equalTo: contentContainer.bottomAnchor),
+
             structuredFilterController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             structuredFilterController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             structuredFilterController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
         ])
+    }
+
+    private func setupEndpointFilterBar() {
+        endpointFilterBar.translatesAutoresizingMaskIntoConstraints = false
+        contentContainer.addSubview(endpointFilterBar)
+
+        let iconView = NSImageView(image: TCPViewerUI.image("line.3.horizontal.decrease.circle.fill") ?? NSImage())
+        iconView.contentTintColor = .controlAccentColor
+        iconView.setContentHuggingPriority(.required, for: .horizontal)
+
+        endpointFilterLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium)
+        endpointFilterLabel.lineBreakMode = .byTruncatingMiddle
+
+        let clearButton = NSButton(image: TCPViewerUI.image("xmark.circle.fill") ?? NSImage(), target: self, action: #selector(clearEndpointStatisticsFilter(_:)))
+        clearButton.isBordered = false
+        clearButton.contentTintColor = .secondaryLabelColor
+        clearButton.toolTip = "Clear endpoint filter"
+        clearButton.setAccessibilityLabel("Clear endpoint filter")
+        clearButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        let stack = NSStackView(views: [iconView, endpointFilterLabel, clearButton])
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 7
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        endpointFilterBar.addSubview(stack)
+
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        endpointFilterBar.addSubview(separator)
+
+        let heightConstraint = endpointFilterBar.heightAnchor.constraint(equalToConstant: 0)
+        endpointFilterBarHeightConstraint = heightConstraint
+        NSLayoutConstraint.activate([
+            heightConstraint,
+            stack.leadingAnchor.constraint(equalTo: endpointFilterBar.leadingAnchor, constant: 10),
+            stack.trailingAnchor.constraint(equalTo: endpointFilterBar.trailingAnchor, constant: -8),
+            stack.centerYAnchor.constraint(equalTo: endpointFilterBar.centerYAnchor),
+            separator.leadingAnchor.constraint(equalTo: endpointFilterBar.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: endpointFilterBar.trailingAnchor),
+            separator.bottomAnchor.constraint(equalTo: endpointFilterBar.bottomAnchor),
+        ])
+        endpointFilterBar.isHidden = true
+    }
+
+    private func renderEndpointFilterBar(label: String?) {
+        let normalizedLabel = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isVisible = normalizedLabel?.isEmpty == false
+        endpointFilterLabel.stringValue = normalizedLabel ?? ""
+        endpointFilterBar.isHidden = !isVisible
+        endpointFilterBarHeightConstraint?.constant = isVisible ? 32 : 0
     }
 
     private func applyFilterVisibility(_ isVisible: Bool) {
@@ -252,7 +325,7 @@ final class PacketWorkspaceViewController: NSViewController {
             showsResetFiltersButton: showsResetFiltersButton,
             activeFilterLabels: activeFilterLabels
         )
-        TCPViewerUI.pin(placeholder, to: contentContainer)
+        TCPViewerUI.pin(placeholder, to: contentBodyContainer)
         placeholderView = placeholder
     }
 
@@ -361,12 +434,16 @@ final class PacketWorkspaceViewController: NSViewController {
         placeholderView = nil
 
         if tableController.view.superview == nil {
-            TCPViewerUI.pin(tableController.view, to: contentContainer)
+            TCPViewerUI.pin(tableController.view, to: contentBodyContainer)
         }
     }
 
     @objc private func resetQuickFilters(_ sender: Any?) {
         delegate?.packetWorkspaceViewControllerDidRequestResetQuickFilters(self)
+    }
+
+    @objc private func clearEndpointStatisticsFilter(_ sender: Any?) {
+        delegate?.packetWorkspaceViewControllerDidRequestClearEndpointStatisticsFilter(self)
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -10,6 +10,7 @@ import PcapPlusPlusCore
 
 protocol SidebarViewControllerDelegate: AnyObject {
     func sidebarViewController(_ controller: SidebarViewController, didSelect selection: PacketSourceListSelection?)
+    func sidebarViewController(_ controller: SidebarViewController, didSelectWorkspaceMode mode: NetworkInspectorWorkspaceMode)
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String)
     func sidebarViewController(_ controller: SidebarViewController, didRequestPin targets: [PacketSourceListPinTarget])
     func sidebarViewController(_ controller: SidebarViewController, didRequestDelete action: PacketSourceListDeletionAction)
@@ -26,17 +27,20 @@ struct SidebarOutlineReloadState: Equatable {
     let sourceListSnapshot: PacketSourceListSnapshot
     let filterText: String
     let selectedSelection: PacketSourceListSelection
+    let workspaceMode: NetworkInspectorWorkspaceMode
     let packetMutation: PacketIngestMutation
 
     init(
         sourceListSnapshot: PacketSourceListSnapshot,
         filterText: String,
         selectedSelection: PacketSourceListSelection,
+        workspaceMode: NetworkInspectorWorkspaceMode = .packets,
         packetMutation: PacketIngestMutation
     ) {
         self.sourceListSnapshot = sourceListSnapshot
         self.filterText = filterText
         self.selectedSelection = selectedSelection
+        self.workspaceMode = workspaceMode
         self.packetMutation = packetMutation
     }
 
@@ -45,6 +49,7 @@ struct SidebarOutlineReloadState: Equatable {
             sourceListSnapshot: snapshot.sourceListSnapshot,
             filterText: snapshot.sourceListFilterText,
             selectedSelection: snapshot.selectedSourceListSelection,
+            workspaceMode: snapshot.workspaceMode,
             packetMutation: snapshot.base.packetIngestState.lastMutation
         )
     }
@@ -61,12 +66,14 @@ enum SidebarOutlineReloadPolicy {
 
         guard previous.sourceListSnapshot != next.sourceListSnapshot ||
                 previous.filterText != next.filterText ||
-                previous.selectedSelection != next.selectedSelection else {
+                previous.selectedSelection != next.selectedSelection ||
+                previous.workspaceMode != next.workspaceMode else {
             return .none
         }
 
         if previous.filterText != next.filterText ||
-            previous.selectedSelection != next.selectedSelection {
+            previous.selectedSelection != next.selectedSelection ||
+            previous.workspaceMode != next.workspaceMode {
             return .immediate
         }
 
@@ -163,14 +170,17 @@ private final class SidebarOutlineItem: NSObject {
 private final class SidebarViewModel {
     private(set) var roots: [SidebarOutlineItem] = []
     private(set) var selectedSelection: PacketSourceListSelection = .allPackets
+    private(set) var workspaceMode: NetworkInspectorWorkspaceMode = .packets
     private(set) var filterText = ""
 
     private var itemsByID: [String: SidebarOutlineItem] = [:]
     private var itemIDBySelection: [PacketSourceListSelection: String] = [:]
+    private var itemIDByWorkspaceMode: [NetworkInspectorWorkspaceMode: String] = [:]
 
     // Convert source-list render data into outline-view objects with no parent references.
     func render(state: SidebarOutlineReloadState) {
         selectedSelection = state.selectedSelection
+        workspaceMode = state.workspaceMode
         filterText = state.filterText
         let filteredSnapshot = state.sourceListSnapshot.filtered(matching: filterText)
         roots = filteredSnapshot.roots.map(SidebarOutlineItem.init)
@@ -185,6 +195,13 @@ private final class SidebarViewModel {
         return itemsByID[itemID]
     }
 
+    func item(for workspaceMode: NetworkInspectorWorkspaceMode) -> SidebarOutlineItem? {
+        guard let itemID = itemIDByWorkspaceMode[workspaceMode] else {
+            return nil
+        }
+        return itemsByID[itemID]
+    }
+
     func item(withID itemID: String) -> SidebarOutlineItem? {
         itemsByID[itemID]
     }
@@ -196,6 +213,7 @@ private final class SidebarViewModel {
     private func rebuildLookupTables() {
         itemsByID = [:]
         itemIDBySelection = [:]
+        itemIDByWorkspaceMode = [:]
 
         for item in roots {
             register(item)
@@ -206,6 +224,9 @@ private final class SidebarViewModel {
         itemsByID[item.sourceItem.id] = item
         if let selection = item.sourceItem.selection {
             itemIDBySelection[selection] = item.sourceItem.id
+        }
+        if let workspaceMode = item.sourceItem.workspaceMode {
+            itemIDByWorkspaceMode[workspaceMode] = item.sourceItem.id
         }
 
         for child in item.children {
@@ -289,6 +310,26 @@ final class SidebarViewController: NSViewController {
         expandedItemIDs.insert(PacketSourceListTreeBuilder.filesGroupID)
         if let filesItem = viewModel.item(withID: PacketSourceListTreeBuilder.filesGroupID) {
             outlineView.expandItem(filesItem)
+        }
+        syncSelection(scrollToSelection: true)
+    }
+
+    // Reveal programmatic Overview drill-downs even when the user collapsed their parent folders.
+    func revealSourceListSelection(_ selection: PacketSourceListSelection) {
+        let ancestorIDs: [String]
+        switch selection {
+        case .app:
+            ancestorIDs = [PacketSourceListTreeBuilder.allGroupID, PacketSourceListTreeBuilder.appsFolderID]
+        case .domain:
+            ancestorIDs = [PacketSourceListTreeBuilder.allGroupID, PacketSourceListTreeBuilder.domainsFolderID]
+        default:
+            ancestorIDs = []
+        }
+        for itemID in ancestorIDs {
+            expandedItemIDs.insert(itemID)
+            if let item = viewModel.item(withID: itemID) {
+                outlineView.expandItem(item)
+            }
         }
         syncSelection(scrollToSelection: true)
     }
@@ -455,6 +496,7 @@ final class SidebarViewController: NSViewController {
         expandedItemIDs = Set(viewModel.allItems().compactMap { item in
             outlineView.isItemExpanded(item) ? item.sourceItem.id : nil
         })
+        expandedItemIDs.insert(PacketSourceListTreeBuilder.captureGroupID)
     }
 
     private func restoreExpandedItems(expandAll: Bool) {
@@ -474,7 +516,8 @@ final class SidebarViewController: NSViewController {
 
         // Preserve the user's outline position only for source data refreshes, not filter or selection changes.
         return appliedReloadState.filterText == state.filterText &&
-            appliedReloadState.selectedSelection == state.selectedSelection
+            appliedReloadState.selectedSelection == state.selectedSelection &&
+            appliedReloadState.workspaceMode == state.workspaceMode
     }
 
     private func captureOutlineState() -> SidebarOutlineState {
@@ -578,6 +621,14 @@ final class SidebarViewController: NSViewController {
     }
 
     private func syncSelection(scrollToSelection: Bool = false) {
+        if viewModel.workspaceMode == .overview,
+           let selectedItem = viewModel.item(for: .overview) {
+            let row = outlineView.row(forItem: selectedItem)
+            if row >= 0 {
+                selectOutlineRows(IndexSet(integer: row), scrollToSelection: scrollToSelection)
+                return
+            }
+        }
         guard viewModel.selectedSelection != .allPackets,
               let selectedItem = viewModel.item(for: viewModel.selectedSelection) else {
             outlineView.deselectAll(nil)
@@ -683,7 +734,7 @@ final class SidebarViewController: NSViewController {
         let row = outlineView.row(at: point)
         guard row >= 0,
               let item = outlineView.item(atRow: row),
-              sourceItem(for: item)?.selection != nil else {
+              sourceItem(for: item)?.isNavigable == true else {
             outlineView.deselectAll(nil)
             return
         }
@@ -785,7 +836,11 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
     }
 
     func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
-        sourceItem(for: item)?.selection != nil
+        sourceItem(for: item)?.isNavigable == true
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, shouldCollapseItem item: Any) -> Bool {
+        sourceItem(for: item)?.id != PacketSourceListTreeBuilder.captureGroupID
     }
 
     func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
@@ -875,7 +930,11 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
             return
         }
 
-        delegate?.sidebarViewController(self, didSelect: item.sourceItem.selection)
+        if let workspaceMode = item.sourceItem.workspaceMode {
+            delegate?.sidebarViewController(self, didSelectWorkspaceMode: workspaceMode)
+        } else {
+            delegate?.sidebarViewController(self, didSelect: item.sourceItem.selection)
+        }
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {
@@ -891,6 +950,10 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
             return
         }
 
+        guard item.sourceItem.id != PacketSourceListTreeBuilder.captureGroupID else {
+            outlineView.expandItem(item)
+            return
+        }
         expandedItemIDs.remove(item.sourceItem.id)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -268,6 +268,7 @@ final class SidebarViewController: NSViewController {
     private var pendingReloadState: SidebarOutlineReloadState?
     private var pendingReloadWorkItem: DispatchWorkItem?
     private var isSyncingSelection = false
+    private var isSyncingExpansion = false
     private var isSyncingFilter = false
     private var contextMenuItemID: String?
     private var outlineReloadGeneration = 0
@@ -342,18 +343,13 @@ final class SidebarViewController: NSViewController {
         normalizeOutlineScrollOriginIfNeeded()
         let shouldPreserveOutlineState = shouldPreserveOutlineState(for: state)
         let preservedOutlineState = shouldPreserveOutlineState ? captureOutlineState() : nil
-        if hasRenderedOutline, viewModel.filterText.isEmpty {
-            captureExpandedItemIDs()
-        }
-
         isSyncingSelection = true
         viewModel.render(state: state)
         syncSearchField(state.filterText)
         if shouldRevealSelectedImportedFile {
             expandedItemIDs.insert(PacketSourceListTreeBuilder.filesGroupID)
         }
-        outlineView.reloadData()
-        restoreExpandedItems(expandAll: !viewModel.filterText.isEmpty)
+        reloadOutlinePreservingExpansion(expandAll: !viewModel.filterText.isEmpty)
         if let preservedOutlineState {
             restoreOutlineState(preservedOutlineState)
         } else {
@@ -492,10 +488,12 @@ final class SidebarViewController: NSViewController {
         scrollView.reflectScrolledClipView(clipView)
     }
 
-    private func captureExpandedItemIDs() {
-        expandedItemIDs = Set(viewModel.allItems().compactMap { item in
-            outlineView.isItemExpanded(item) ? item.sourceItem.id : nil
-        })
+    private func reloadOutlinePreservingExpansion(expandAll: Bool) {
+        // Ignore AppKit's collapse notifications while reloadData temporarily rebuilds the outline.
+        isSyncingExpansion = true
+        outlineView.reloadData()
+        restoreExpandedItems(expandAll: expandAll)
+        isSyncingExpansion = false
     }
 
     private func restoreExpandedItems(expandAll: Bool) {
@@ -933,7 +931,9 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
     }
 
     func outlineViewItemDidExpand(_ notification: Notification) {
-        guard let item = notification.userInfo?["NSObject"] as? SidebarOutlineItem else {
+        guard !isSyncingExpansion,
+              let item = notification.userInfo?["NSObject"] as? SidebarOutlineItem,
+              viewModel.item(withID: item.sourceItem.id) === item else {
             return
         }
 
@@ -941,7 +941,9 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
     }
 
     func outlineViewItemDidCollapse(_ notification: Notification) {
-        guard let item = notification.userInfo?["NSObject"] as? SidebarOutlineItem else {
+        guard !isSyncingExpansion,
+              let item = notification.userInfo?["NSObject"] as? SidebarOutlineItem,
+              viewModel.item(withID: item.sourceItem.id) === item else {
             return
         }
 

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -264,6 +264,7 @@ final class SidebarViewController: NSViewController {
 
     private var expandedItemIDs = PacketSourceListTreeBuilder.defaultExpandedItemIDs
     private var hasRenderedOutline = false
+    private var hasRestoredInitialExpansion = false
     private var appliedReloadState: SidebarOutlineReloadState?
     private var pendingReloadState: SidebarOutlineReloadState?
     private var pendingReloadWorkItem: DispatchWorkItem?
@@ -288,6 +289,19 @@ final class SidebarViewController: NSViewController {
     override func viewDidLayout() {
         super.viewDidLayout()
         normalizeOutlineScrollOriginIfNeeded()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        // Restore defaults after AppKit finishes attaching the source list to its window.
+        guard hasRenderedOutline, !hasRestoredInitialExpansion else {
+            return
+        }
+
+        hasRestoredInitialExpansion = true
+        expandedItemIDs.formUnion(PacketSourceListTreeBuilder.defaultExpandedItemIDs)
+        restoreExpandedItems(expandAll: false)
+        syncSelection()
     }
 
     func render(snapshot: NetworkInspectorSnapshot) {

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -315,7 +315,7 @@ final class SidebarViewController: NSViewController {
         syncSelection(scrollToSelection: true)
     }
 
-    // Reveal programmatic Overview drill-downs even when the user collapsed their parent folders.
+    // Reveal programmatic drill-downs even when the user collapsed their parent folders.
     func revealSourceListSelection(_ selection: PacketSourceListSelection) {
         let ancestorIDs: [String]
         switch selection {
@@ -323,6 +323,14 @@ final class SidebarViewController: NSViewController {
             ancestorIDs = [PacketSourceListTreeBuilder.allGroupID, PacketSourceListTreeBuilder.appsFolderID]
         case .domain:
             ancestorIDs = [PacketSourceListTreeBuilder.allGroupID, PacketSourceListTreeBuilder.domainsFolderID]
+        case .apps, .domains:
+            ancestorIDs = [PacketSourceListTreeBuilder.allGroupID]
+        case .ipAddress:
+            ancestorIDs = [
+                PacketSourceListTreeBuilder.allGroupID,
+                PacketSourceListTreeBuilder.domainsFolderID,
+                viewModel.item(for: .domain(.ipAddresses))?.sourceItem.id,
+            ].compactMap { $0 }
         default:
             ancestorIDs = []
         }

--- a/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/SidebarViewController.swift
@@ -496,7 +496,6 @@ final class SidebarViewController: NSViewController {
         expandedItemIDs = Set(viewModel.allItems().compactMap { item in
             outlineView.isItemExpanded(item) ? item.sourceItem.id : nil
         })
-        expandedItemIDs.insert(PacketSourceListTreeBuilder.captureGroupID)
     }
 
     private func restoreExpandedItems(expandAll: Bool) {
@@ -839,10 +838,6 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
         sourceItem(for: item)?.isNavigable == true
     }
 
-    func outlineView(_ outlineView: NSOutlineView, shouldCollapseItem item: Any) -> Bool {
-        sourceItem(for: item)?.id != PacketSourceListTreeBuilder.captureGroupID
-    }
-
     func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
         guard let sourceItem = sourceItem(for: item) else {
             return nil
@@ -950,10 +945,6 @@ extension SidebarViewController: NSOutlineViewDataSource, NSOutlineViewDelegate 
             return
         }
 
-        guard item.sourceItem.id != PacketSourceListTreeBuilder.captureGroupID else {
-            outlineView.expandItem(item)
-            return
-        }
         expandedItemIDs.remove(item.sourceItem.id)
     }
 }

--- a/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/StatusStripViewController.swift
@@ -19,6 +19,7 @@ final class StatusStripViewModel {
     private(set) var canCancelLoad = false
     private(set) var canClear = false
     private(set) var isStructuredFilterVisible = false
+    private(set) var showsFilterButton = true
     private(set) var metricsText = TCPViewerStatusMetricsFormatter.displayText(for: .empty)
 
     // Build the compact bottom strip controls from the current packet/capture snapshot.
@@ -28,6 +29,7 @@ final class StatusStripViewModel {
         canCancelLoad = snapshot.base.loadState.canCancel
         canClear = snapshot.visiblePacketCount > 0 && !canCancelLoad
         isStructuredFilterVisible = snapshot.isStructuredFilterVisible
+        showsFilterButton = snapshot.workspaceMode != .overview
     }
 
     // Format the lightweight process and captured-traffic metrics for the strip.
@@ -76,6 +78,7 @@ final class StatusStripViewController: NSViewController {
         clearButton.isHidden = viewModel.canCancelLoad
         clearButton.isEnabled = viewModel.canClear
         filterButton.state = viewModel.isStructuredFilterVisible ? .on : .off
+        filterButton.isHidden = !viewModel.showsFilterButton
         totalLabel.stringValue = viewModel.totalText
         metricsLabel.stringValue = viewModel.metricsText
     }

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -215,7 +215,6 @@ final class TCPViewerRootViewController: NSViewController {
     private var followStreamWindowControllers: [TCPFollowStreamWindowController] = []
     private var endpointStatisticsWindowController: EndpointStatisticsWindowController?
     private var pendingTCPFollowReveal: PendingTCPFollowReveal?
-    private var isMainEmptyStateVisible = false
     private lazy var overviewViewController = CaptureOverviewViewController(
         latestIngestStateProvider: { [weak self] in
             self?.viewModel.currentPacketIngestStateForEndpointStatistics() ?? .empty
@@ -275,6 +274,7 @@ final class TCPViewerRootViewController: NSViewController {
 
     override func viewDidLayout() {
         super.viewDidLayout()
+        applyMainEmptyStateVisibility(viewModel.snapshot)
         if needsSidebarDividerRefresh, sidebarItem?.isCollapsed == false {
             needsSidebarDividerRefresh = false
             applySidebarDividerPosition()
@@ -642,11 +642,7 @@ final class TCPViewerRootViewController: NSViewController {
     private func applyMainEmptyStateVisibility(_ snapshot: NetworkInspectorSnapshot) {
         // Swap only the central content region so sidebar and status remain available.
         let shouldShowEmptyState = snapshot.workspaceMode != .overview && snapshot.shouldShowMainEmptyState
-        guard isMainEmptyStateVisible != shouldShowEmptyState else {
-            return
-        }
-
-        isMainEmptyStateVisible = shouldShowEmptyState
+        // Reapply both flags because AppKit can restore split-item visibility during initial layout.
         contentSplitViewController.view.isHidden = shouldShowEmptyState
         mainEmptyStateViewController.view.isHidden = !shouldShowEmptyState
     }
@@ -1325,11 +1321,18 @@ extension TCPViewerRootViewController {
     }
 
     var isMainEmptyStateVisibleForTesting: Bool {
-        isMainEmptyStateVisible
+        !mainEmptyStateViewController.view.isHidden
     }
 
     var isContentSplitViewHiddenForTesting: Bool {
         contentSplitViewController.view.isHidden
+    }
+
+    // Mimic AppKit restoring split visibility before the next layout repairs it.
+    func simulateInitialSplitVisibilityRestoreForTesting() {
+        contentSplitViewController.view.isHidden = false
+        mainEmptyStateViewController.view.isHidden = true
+        viewDidLayout()
     }
 
     var isOverviewWorkspaceVisibleForTesting: Bool {

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -191,6 +191,7 @@ final class TCPViewerRootViewController: NSViewController {
 
     let viewModel: NetworkInspectorViewModel
 
+    private let configuration: AppConfiguration
     private let mainSplitViewController = NSSplitViewController()
     private let contentSplitViewController = TCPViewerInspectorSplitViewController()
     private let mainContainerViewController = NSViewController()
@@ -211,6 +212,7 @@ final class TCPViewerRootViewController: NSViewController {
     private var hasRenderedHelperOnboarding = false
     private var sessionImportSheetViewController: TCPViewSessionImportSheetViewController?
     private var followStreamWindowControllers: [TCPFollowStreamWindowController] = []
+    private var endpointStatisticsWindowController: EndpointStatisticsWindowController?
     private var pendingTCPFollowReveal: PendingTCPFollowReveal?
     private var isMainEmptyStateVisible = false
     #if DEBUG
@@ -226,6 +228,7 @@ final class TCPViewerRootViewController: NSViewController {
 
     init(viewModel: NetworkInspectorViewModel, configuration: AppConfiguration) {
         self.viewModel = viewModel
+        self.configuration = configuration
         self.workspaceViewController = PacketWorkspaceViewController(configuration: configuration)
         self.inspectorViewController = PacketInspectorViewController(configuration: configuration)
         super.init(nibName: nil, bundle: nil)
@@ -317,6 +320,12 @@ final class TCPViewerRootViewController: NSViewController {
 
     func clearAllPackets() {
         viewModel.clearPackets()
+    }
+
+    func showEndpointStatistics() {
+        let controller = endpointStatisticsWindowController ?? makeEndpointStatisticsWindowController()
+        controller.render(snapshot: viewModel.snapshot)
+        controller.present(title: endpointStatisticsWindowTitle)
     }
 
     func saveDocument() {
@@ -549,6 +558,8 @@ final class TCPViewerRootViewController: NSViewController {
         let snapshot = viewModel.snapshot
         sidebarViewController.render(snapshot: snapshot)
         workspaceViewController.render(snapshot: snapshot)
+        endpointStatisticsWindowController?.render(snapshot: snapshot)
+        endpointStatisticsWindowController?.updateTitle(endpointStatisticsWindowTitle)
         inspectorViewController.render(snapshot: snapshot)
         applyPendingTCPFollowReveal(snapshot)
         mainEmptyStateViewController.render(snapshot: snapshot)
@@ -1415,6 +1426,10 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
         viewModel.resetQuickFilters()
     }
 
+    func packetWorkspaceViewControllerDidRequestClearEndpointStatisticsFilter(_ controller: PacketWorkspaceViewController) {
+        viewModel.clearEndpointStatisticsFilter()
+    }
+
     func packetWorkspaceViewControllerCanAddStructuredFilter(_ controller: PacketWorkspaceViewController) -> Bool {
         TCPViewerLicenseService.shared.isLicenseAuthorized
     }
@@ -1486,6 +1501,47 @@ extension TCPViewerRootViewController: PacketWorkspaceViewControllerDelegate {
 }
 
 private extension TCPViewerRootViewController {
+    // Keep one statistics window per document and resolve packet IDs against its latest capture snapshot.
+    func makeEndpointStatisticsWindowController() -> EndpointStatisticsWindowController {
+        let controller = EndpointStatisticsWindowController(
+            configuration: configuration,
+            packetProvider: { [weak self] packetIDs in
+                self?.viewModel.packetSummariesForEndpointStatistics(packetIDs) ?? []
+            },
+            showRelatedPackets: { [weak self] rowID in
+                guard let self else {
+                    return
+                }
+                self.viewModel.showRelatedPackets(forEndpoint: rowID)
+                self.view.window?.makeKeyAndOrderFront(nil)
+            },
+            latestIngestStateProvider: { [weak self] in
+                self?.viewModel.currentPacketIngestStateForEndpointStatistics()
+            }
+        )
+        controller.consume(ingestState: viewModel.currentPacketIngestStateForEndpointStatistics())
+        viewModel.endpointStatisticsIngestHandler = { [weak controller] ingestState in
+            controller?.consume(ingestState: ingestState)
+        }
+        endpointStatisticsWindowController = controller
+        controller.closeHandler = { [weak self, weak controller] in
+            guard let self, let controller,
+                  self.endpointStatisticsWindowController === controller else {
+                return
+            }
+            self.viewModel.endpointStatisticsIngestHandler = nil
+            self.endpointStatisticsWindowController = nil
+        }
+        return controller
+    }
+
+    var endpointStatisticsWindowTitle: String {
+        guard let fileName = viewModel.snapshot.base.documentState.fileURL?.lastPathComponent else {
+            return "Endpoints"
+        }
+        return "Endpoints - \(fileName)"
+    }
+
     // Open a dedicated native workspace and keep its bounded background operation cancellable.
     func presentFollowTCPStreamWindow(packetID: PacketSummary.ID) {
         let captureIdentity = viewModel.tcpFollowCaptureIdentity

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -198,6 +198,7 @@ final class TCPViewerRootViewController: NSViewController {
     private let mainEmptyStateViewController = TCPViewerMainEmptyStateViewController()
     private let sidebarViewController = SidebarViewController()
     private let workspaceViewController: PacketWorkspaceViewController
+    private let workspaceContainerViewController = NSViewController()
     private let inspectorViewController: PacketInspectorViewController
     private let statusStripViewController = StatusStripViewController()
     private var sidebarItem: NSSplitViewItem?
@@ -215,6 +216,11 @@ final class TCPViewerRootViewController: NSViewController {
     private var endpointStatisticsWindowController: EndpointStatisticsWindowController?
     private var pendingTCPFollowReveal: PendingTCPFollowReveal?
     private var isMainEmptyStateVisible = false
+    private lazy var overviewViewController = CaptureOverviewViewController(
+        latestIngestStateProvider: { [weak self] in
+            self?.viewModel.currentPacketIngestStateForEndpointStatistics() ?? .empty
+        }
+    )
     #if DEBUG
     private var packetSelectionCrashReproducer: TCPViewerPacketSelectionCrashReproducer?
     #endif
@@ -322,10 +328,10 @@ final class TCPViewerRootViewController: NSViewController {
         viewModel.clearPackets()
     }
 
-    func showEndpointStatistics() {
+    func showEndpointStatistics(forceAllPackets: Bool = false) {
         let controller = endpointStatisticsWindowController ?? makeEndpointStatisticsWindowController()
         controller.render(snapshot: viewModel.snapshot)
-        controller.present(title: endpointStatisticsWindowTitle)
+        controller.present(title: endpointStatisticsWindowTitle, forceAllPackets: forceAllPackets)
     }
 
     func saveDocument() {
@@ -353,10 +359,16 @@ final class TCPViewerRootViewController: NSViewController {
     }
 
     func toggleInspector() {
+        guard viewModel.snapshot.workspaceMode != .overview else {
+            return
+        }
         viewModel.toggleInspector()
     }
 
     func toggleInspector(placement: NetworkInspectorPlacement) {
+        guard viewModel.snapshot.workspaceMode != .overview else {
+            return
+        }
         viewModel.toggleInspector(placement: placement)
     }
 
@@ -405,6 +417,9 @@ final class TCPViewerRootViewController: NSViewController {
     }
 
     func focusStructuredFilter() {
+        guard viewModel.snapshot.workspaceMode != .overview else {
+            return
+        }
         viewModel.setStructuredFilterVisible(true)
         workspaceViewController.focusStructuredFilter()
     }
@@ -423,6 +438,9 @@ final class TCPViewerRootViewController: NSViewController {
     }
 
     func focusPacketDetailFilter() {
+        guard viewModel.snapshot.workspaceMode != .overview else {
+            return
+        }
         guard inspectorItem?.isCollapsed == true else {
             inspectorViewController.focusFilterField()
             return
@@ -479,6 +497,7 @@ final class TCPViewerRootViewController: NSViewController {
         // Build the two-level split layout: sidebar | (workspace + inspector).
         sidebarViewController.delegate = self
         workspaceViewController.delegate = self
+        overviewViewController.delegate = self
         inspectorViewController.delegate = self
         statusStripViewController.delegate = self
         mainEmptyStateViewController.delegate = self
@@ -486,8 +505,23 @@ final class TCPViewerRootViewController: NSViewController {
         mainSplitViewController.splitView.isVertical = true
         contentSplitViewController.splitView.isVertical = true
 
-        // Keep the table and inspector inside the main container split.
-        let workspaceItem = NSSplitViewItem(contentListWithViewController: workspaceViewController)
+        workspaceContainerViewController.view = TCPViewerDynamicBackgroundView(backgroundColor: .controlBackgroundColor)
+        workspaceContainerViewController.addChild(workspaceViewController)
+        workspaceContainerViewController.addChild(overviewViewController)
+        for childView in [workspaceViewController.view, overviewViewController.view] {
+            childView.translatesAutoresizingMaskIntoConstraints = false
+            workspaceContainerViewController.view.addSubview(childView)
+            NSLayoutConstraint.activate([
+                childView.leadingAnchor.constraint(equalTo: workspaceContainerViewController.view.leadingAnchor),
+                childView.trailingAnchor.constraint(equalTo: workspaceContainerViewController.view.trailingAnchor),
+                childView.topAnchor.constraint(equalTo: workspaceContainerViewController.view.topAnchor),
+                childView.bottomAnchor.constraint(equalTo: workspaceContainerViewController.view.bottomAnchor),
+            ])
+        }
+        overviewViewController.view.isHidden = true
+
+        // Keep the selected workspace and inspector inside the main container split.
+        let workspaceItem = NSSplitViewItem(contentListWithViewController: workspaceContainerViewController)
         contentSplitViewController.addSplitViewItem(workspaceItem)
         self.workspaceItem = workspaceItem
 
@@ -558,12 +592,14 @@ final class TCPViewerRootViewController: NSViewController {
         let snapshot = viewModel.snapshot
         sidebarViewController.render(snapshot: snapshot)
         workspaceViewController.render(snapshot: snapshot)
+        overviewViewController.render(snapshot: snapshot)
         endpointStatisticsWindowController?.render(snapshot: snapshot)
         endpointStatisticsWindowController?.updateTitle(endpointStatisticsWindowTitle)
         inspectorViewController.render(snapshot: snapshot)
         applyPendingTCPFollowReveal(snapshot)
         mainEmptyStateViewController.render(snapshot: snapshot)
         statusStripViewController.render(snapshot: snapshot, metrics: viewModel.statusMetricsSnapshot)
+        applyWorkspaceVisibility(snapshot)
         applyMainEmptyStateVisibility(snapshot)
         renderSessionImportSheet(snapshot.base.sessionImportState)
         applyInspectorLayout(snapshot)
@@ -605,7 +641,7 @@ final class TCPViewerRootViewController: NSViewController {
 
     private func applyMainEmptyStateVisibility(_ snapshot: NetworkInspectorSnapshot) {
         // Swap only the central content region so sidebar and status remain available.
-        let shouldShowEmptyState = snapshot.shouldShowMainEmptyState
+        let shouldShowEmptyState = snapshot.workspaceMode != .overview && snapshot.shouldShowMainEmptyState
         guard isMainEmptyStateVisible != shouldShowEmptyState else {
             return
         }
@@ -613,6 +649,12 @@ final class TCPViewerRootViewController: NSViewController {
         isMainEmptyStateVisible = shouldShowEmptyState
         contentSplitViewController.view.isHidden = shouldShowEmptyState
         mainEmptyStateViewController.view.isHidden = !shouldShowEmptyState
+    }
+
+    private func applyWorkspaceVisibility(_ snapshot: NetworkInspectorSnapshot) {
+        let showsOverview = snapshot.workspaceMode == .overview
+        workspaceViewController.view.isHidden = showsOverview
+        overviewViewController.view.isHidden = !showsOverview
     }
 
     private func renderSessionImportSheet(_ state: TCPViewSessionImportState) {
@@ -687,7 +729,8 @@ final class TCPViewerRootViewController: NSViewController {
     // Keep inspector placement and collapse state in sync with toolbar/view-model state.
     private func applyInspectorLayout(_ snapshot: NetworkInspectorSnapshot) {
         let placementChanged = appliedInspectorPlacement != snapshot.inspectorPlacement
-        let visibilityChanged = appliedInspectorVisibility != snapshot.isInspectorVisible
+        let shouldShowInspector = snapshot.isInspectorVisible && snapshot.workspaceMode != .overview
+        let visibilityChanged = appliedInspectorVisibility != shouldShowInspector
         let previousPlacement = appliedInspectorPlacement ?? snapshot.inspectorPlacement
 
         if placementChanged, appliedInspectorVisibility == true {
@@ -702,20 +745,20 @@ final class TCPViewerRootViewController: NSViewController {
 
         appliedInspectorPlacement = snapshot.inspectorPlacement
         if visibilityChanged {
-            if !snapshot.isInspectorVisible {
+            if !shouldShowInspector {
                 persistCurrentInspectorThicknessIfVisible(placement: snapshot.inspectorPlacement)
                 inspectorItem?.isCollapsed = true
             } else {
                 restoreInspectorDividerAfterOpening(placement: snapshot.inspectorPlacement)
             }
-        } else if placementChanged, snapshot.isInspectorVisible {
+        } else if placementChanged, shouldShowInspector {
             restoreInspectorDividerAfterOpening(placement: snapshot.inspectorPlacement)
         } else if placementChanged {
             clearTemporaryInspectorRestoreThickness()
             isRestoringInspectorDivider = false
         }
 
-        appliedInspectorVisibility = snapshot.isInspectorVisible
+        appliedInspectorVisibility = shouldShowInspector
     }
 
     private func configureInspectorPlacement(_ placement: NetworkInspectorPlacement) {
@@ -1288,6 +1331,18 @@ extension TCPViewerRootViewController {
     var isContentSplitViewHiddenForTesting: Bool {
         contentSplitViewController.view.isHidden
     }
+
+    var isOverviewWorkspaceVisibleForTesting: Bool {
+        !overviewViewController.view.isHidden
+    }
+
+    var isPacketWorkspaceVisibleForTesting: Bool {
+        !workspaceViewController.view.isHidden
+    }
+
+    var isInspectorCollapsedForTesting: Bool {
+        inspectorItem?.isCollapsed ?? true
+    }
 }
 #endif
 
@@ -1319,6 +1374,13 @@ extension TCPViewerRootViewController: SidebarViewControllerDelegate {
         viewModel.selectSourceList(selection)
     }
 
+    func sidebarViewController(
+        _ controller: SidebarViewController,
+        didSelectWorkspaceMode mode: NetworkInspectorWorkspaceMode
+    ) {
+        viewModel.selectWorkspaceMode(mode)
+    }
+
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String) {
         viewModel.updateSourceListFilterText(text)
     }
@@ -1338,6 +1400,26 @@ extension TCPViewerRootViewController: SidebarViewControllerDelegate {
 
     func sidebarViewController(_ controller: SidebarViewController, didRequestExport selection: PacketSourceListSelection, format: CaptureFileFormat) {
         viewModel.presentSourceListExportPanel(selection: selection, format: format, attachedTo: view.window)
+    }
+}
+
+extension TCPViewerRootViewController: CaptureOverviewViewControllerDelegate {
+    func captureOverviewViewControllerDidRequestPackets(_ controller: CaptureOverviewViewController) {
+        viewModel.showPacketsFromOverview()
+    }
+
+    func captureOverviewViewControllerDidRequestEndpoints(_ controller: CaptureOverviewViewController) {
+        showEndpointStatistics(forceAllPackets: true)
+    }
+
+    func captureOverviewViewController(
+        _ controller: CaptureOverviewViewController,
+        didSelect selection: PacketSourceListSelection
+    ) {
+        viewModel.showSourceListSelectionFromOverview(selection)
+        DispatchQueue.main.async { [weak self] in
+            self?.sidebarViewController.revealSourceListSelection(selection)
+        }
     }
 }
 

--- a/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/TCPViewerRootViewController.swift
@@ -1597,7 +1597,8 @@ private extension TCPViewerRootViewController {
                 guard let self else {
                     return
                 }
-                self.viewModel.showRelatedPackets(forEndpoint: rowID)
+                let selection = self.viewModel.showRelatedPackets(forEndpoint: rowID)
+                self.sidebarViewController.revealSourceListSelection(selection)
                 self.view.window?.makeKeyAndOrderFront(nil)
             },
             latestIngestStateProvider: { [weak self] in

--- a/TCPViewerTests/Features/NetworkInspector/CaptureOverviewServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/CaptureOverviewServiceTests.swift
@@ -29,7 +29,7 @@ struct CaptureOverviewServiceTests {
 
         let snapshot = replacementSnapshot(packets)
         let app = try #require(snapshot.topApps.first)
-        let domain = try #require(snapshot.topDomains.first)
+        let domain = try #require(snapshot.topDestinations.first)
 
         #expect(snapshot.totals.packets == 3)
         #expect(snapshot.totals.bytes == 350)
@@ -75,7 +75,7 @@ struct CaptureOverviewServiceTests {
         #expect(snapshot.appCount == 1)
         #expect(snapshot.domainCount == 1)
         #expect(snapshot.topApps.map(\.title) == ["New App"])
-        #expect(snapshot.topDomains.map(\.title) == ["new.example"])
+        #expect(snapshot.topDestinations.map(\.title) == ["new.example"])
         #expect(snapshot.totals.sentBytes == 0)
         #expect(snapshot.totals.receivedBytes == 128)
         #expect(snapshot.totals.bytes == 128)
@@ -95,7 +95,7 @@ struct CaptureOverviewServiceTests {
         let snapshot = accumulator.snapshot()
         #expect(snapshot.totals.packets == 1)
         #expect(snapshot.totals.bytes == 512)
-        #expect(snapshot.topDomains.map(\.title) == ["new.example"])
+        #expect(snapshot.topDestinations.map(\.title) == ["new.example"])
     }
 
     @Test func topRowsAreBoundedAndUseStableTieOrdering() {
@@ -111,12 +111,31 @@ struct CaptureOverviewServiceTests {
 
         let snapshot = replacementSnapshot(tiedPackets + extraPackets)
 
-        #expect(snapshot.topDomains.count == CaptureOverviewAccumulator.maximumTopRowCount)
-        #expect(snapshot.topDomains.prefix(3).map(\.title) == [
+        #expect(snapshot.topDestinations.count == CaptureOverviewAccumulator.maximumTopRowCount)
+        #expect(snapshot.topDestinations.prefix(3).map(\.title) == [
             "gamma.example",
             "alpha.example",
             "beta.example",
         ])
+    }
+
+    @Test func unresolvedAddressesJoinDomainsInTheDestinationRanking() {
+        let snapshot = replacementSnapshot([
+            makePacket(id: 1, length: 256),
+            makePacket(id: 2, length: 128, domain: "api.example"),
+        ])
+
+        #expect(snapshot.topDestinations.map(\.title) == [
+            "10.0.0.2",
+            "93.184.216.34",
+            "api.example",
+        ])
+        #expect(snapshot.topDestinations[0].selection == .ipAddress(
+            PacketSourceIPAddressKey(rawValue: "10.0.0.2")
+        ))
+        #expect(snapshot.topDestinations[2].selection == .domain(
+            PacketSourceDomainKey(rawValue: "api.example", isMissingDomain: false)
+        ))
     }
 
     @Test func protocolTotalsAndRenderedTimelineStayBounded() {
@@ -170,7 +189,7 @@ struct CaptureOverviewServiceTests {
         var latestSnapshot = CaptureOverviewSnapshot.empty
         service.snapshotHandler = { latestSnapshot = $0 }
         service.consume(state)
-        try await waitUntil { latestSnapshot.topDomains.first?.title == "old.example" }
+        try await waitUntil { latestSnapshot.topDestinations.first?.title == "old.example" }
 
         var replacement = PacketIngestState.empty
         replacement.backingIdentity = "capture-b"
@@ -179,7 +198,7 @@ struct CaptureOverviewServiceTests {
         #expect(replacement.packetLineageRevision == state.packetLineageRevision)
         state = replacement
         service.consume(state)
-        try await waitUntil(timeout: 2) { latestSnapshot.topDomains.first?.title == "new.example" }
+        try await waitUntil(timeout: 2) { latestSnapshot.topDestinations.first?.title == "new.example" }
 
         #expect(latestSnapshot.totals.packets == 1)
         service.cancel()

--- a/TCPViewerTests/Features/NetworkInspector/CaptureOverviewServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/CaptureOverviewServiceTests.swift
@@ -1,0 +1,259 @@
+//
+//  CaptureOverviewServiceTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/9/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct CaptureOverviewServiceTests {
+    @Test func duplicateAppsAndDomainsUseLocalDirectionAndOriginalLength() throws {
+        let client = makeClient(name: "Browser", bundleIdentifier: "com.example.browser")
+        let packets = [
+            makePacket(id: 1, length: 200, direction: .outbound, domain: "Example.COM.", client: client),
+            makePacket(id: 2, length: 100, direction: .inbound, domain: "example.com", client: client),
+            makePacket(
+                id: 3,
+                length: 50,
+                direction: .unknown,
+                domain: " EXAMPLE.COM ",
+                client: client,
+                decodeStatus: PacketDecodeStatus(kind: .malformed)
+            ),
+        ]
+
+        let snapshot = replacementSnapshot(packets)
+        let app = try #require(snapshot.topApps.first)
+        let domain = try #require(snapshot.topDomains.first)
+
+        #expect(snapshot.totals.packets == 3)
+        #expect(snapshot.totals.bytes == 350)
+        #expect(snapshot.totals.sentBytes == 200)
+        #expect(snapshot.totals.receivedBytes == 100)
+        #expect(snapshot.totals.unclassifiedBytes == 50)
+        #expect(snapshot.malformedPacketCount == 1)
+        #expect(snapshot.appCount == 1)
+        #expect(snapshot.domainCount == 1)
+        #expect(app.selection == .app(PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.browser")))
+        #expect(domain.selection == .domain(PacketSourceDomainKey(rawValue: "example.com", isMissingDomain: false)))
+        #expect(app.totals == snapshot.totals)
+        #expect(domain.totals == snapshot.totals)
+    }
+
+    @Test func metadataReclassificationRemovesThePreviousContribution() throws {
+        let oldClient = makeClient(name: "Old App", bundleIdentifier: "com.example.old")
+        let newClient = makeClient(name: "New App", bundleIdentifier: "com.example.new")
+        var accumulator = CaptureOverviewAccumulator()
+        accumulator.appendReplacementChunk([
+            makePacket(id: 1, length: 128, direction: .outbound, domain: "old.example", client: oldClient),
+        ])
+        let didFinishInitialReplacement = accumulator.finishReplacement(cursor: cursor(revision: 1, count: 1))
+        #expect(didFinishInitialReplacement)
+
+        let updatedPacket = makePacket(
+            id: 1,
+            length: 128,
+            direction: .inbound,
+            domain: "new.example",
+            client: newClient
+        )
+        let didConsumeMetadata = accumulator.consume(EndpointStatisticsIngestUpdate(
+            packetRevision: 2,
+            packetLineageRevision: 1,
+            totalPacketCount: 1,
+            kind: .metadata([updatedPacket]),
+            previousPacketRevision: 1
+        ))
+        #expect(didConsumeMetadata)
+
+        let snapshot = accumulator.snapshot()
+        #expect(snapshot.appCount == 1)
+        #expect(snapshot.domainCount == 1)
+        #expect(snapshot.topApps.map(\.title) == ["New App"])
+        #expect(snapshot.topDomains.map(\.title) == ["new.example"])
+        #expect(snapshot.totals.sentBytes == 0)
+        #expect(snapshot.totals.receivedBytes == 128)
+        #expect(snapshot.totals.bytes == 128)
+    }
+
+    @Test func resetDropsThePreviousCaptureLineage() {
+        var accumulator = CaptureOverviewAccumulator()
+        accumulator.appendReplacementChunk([makePacket(id: 1, domain: "old.example")])
+        let didFinishOldReplacement = accumulator.finishReplacement(cursor: cursor(revision: 1, count: 1))
+        #expect(didFinishOldReplacement)
+
+        accumulator.reset()
+        accumulator.appendReplacementChunk([makePacket(id: 2, length: 512, domain: "new.example")])
+        let didFinishNewReplacement = accumulator.finishReplacement(cursor: cursor(revision: 1, lineage: 2, count: 1))
+        #expect(didFinishNewReplacement)
+
+        let snapshot = accumulator.snapshot()
+        #expect(snapshot.totals.packets == 1)
+        #expect(snapshot.totals.bytes == 512)
+        #expect(snapshot.topDomains.map(\.title) == ["new.example"])
+    }
+
+    @Test func topRowsAreBoundedAndUseStableTieOrdering() {
+        let tiedPackets = [
+            makePacket(id: 1, length: 50, domain: "gamma.example"),
+            makePacket(id: 2, length: 50, domain: "gamma.example"),
+            makePacket(id: 3, length: 100, domain: "beta.example"),
+            makePacket(id: 4, length: 100, domain: "alpha.example"),
+        ]
+        let extraPackets = (0..<8).map { index in
+            makePacket(id: UInt64(index + 10), length: 10 - index, domain: "extra-\(index).example")
+        }
+
+        let snapshot = replacementSnapshot(tiedPackets + extraPackets)
+
+        #expect(snapshot.topDomains.count == CaptureOverviewAccumulator.maximumTopRowCount)
+        #expect(snapshot.topDomains.prefix(3).map(\.title) == [
+            "gamma.example",
+            "alpha.example",
+            "beta.example",
+        ])
+    }
+
+    @Test func protocolTotalsAndRenderedTimelineStayBounded() {
+        let hints: [TransportProtocolHint] = [.tcp, .udp, .dns, .tls, .http1, .arp, .icmp]
+        var packets = hints.enumerated().map { index, hint in
+            makePacket(id: UInt64(index + 1), length: (index + 1) * 10, transportHint: hint)
+        }
+        packets += (0..<2_000).map { index in
+            makePacket(
+                id: UInt64(index + 100),
+                timestamp: Date(timeIntervalSince1970: TimeInterval(index)),
+                transportHint: .tcp
+            )
+        }
+
+        let snapshot = replacementSnapshot(packets)
+        let protocolBytes = snapshot.protocols.reduce(UInt64(0)) { $0 + $1.totals.bytes }
+
+        #expect(snapshot.protocols.count == CaptureOverviewAccumulator.maximumProtocolRowCount + 1)
+        #expect(snapshot.protocols.last?.title == "Other")
+        #expect(protocolBytes == snapshot.totals.bytes)
+        #expect(snapshot.timeline.count <= CaptureOverviewAccumulator.maximumRenderedTimelinePointCount)
+    }
+
+    @MainActor
+    @Test func livePublishingIsThrottledToOneSnapshotPerInterval() async throws {
+        var state = PacketIngestState.empty
+        state.append([makePacket(id: 1)], source: .live)
+        let service = CaptureOverviewService(latestIngestStateProvider: { state })
+        var snapshots: [CaptureOverviewSnapshot] = []
+        service.snapshotHandler = { snapshots.append($0) }
+        service.consume(state)
+        try await waitUntil { snapshots.count == 1 }
+
+        for id in 2...24 {
+            state.append([makePacket(id: UInt64(id))], source: .live)
+            service.consume(state)
+        }
+        try await waitUntil(timeout: 2) { snapshots.last?.totals.packets == 24 }
+
+        #expect(snapshots.count == 2)
+        service.cancel()
+    }
+
+    @MainActor
+    @Test func backingIdentityChangeRebuildsEvenWhenTheCursorValuesMatch() async throws {
+        var state = PacketIngestState.empty
+        state.backingIdentity = "capture-a"
+        state.append([makePacket(id: 1, domain: "old.example")], source: .live)
+        let service = CaptureOverviewService(latestIngestStateProvider: { state })
+        var latestSnapshot = CaptureOverviewSnapshot.empty
+        service.snapshotHandler = { latestSnapshot = $0 }
+        service.consume(state)
+        try await waitUntil { latestSnapshot.topDomains.first?.title == "old.example" }
+
+        var replacement = PacketIngestState.empty
+        replacement.backingIdentity = "capture-b"
+        replacement.append([makePacket(id: 2, domain: "new.example")], source: .live)
+        #expect(replacement.packetRevision == state.packetRevision)
+        #expect(replacement.packetLineageRevision == state.packetLineageRevision)
+        state = replacement
+        service.consume(state)
+        try await waitUntil(timeout: 2) { latestSnapshot.topDomains.first?.title == "new.example" }
+
+        #expect(latestSnapshot.totals.packets == 1)
+        service.cancel()
+    }
+
+    private func replacementSnapshot(_ packets: [PacketSummary]) -> CaptureOverviewSnapshot {
+        var accumulator = CaptureOverviewAccumulator()
+        accumulator.appendReplacementChunk(packets)
+        let didFinish = accumulator.finishReplacement(cursor: cursor(revision: 1, count: packets.count))
+        #expect(didFinish)
+        return accumulator.snapshot()
+    }
+
+    private func cursor(revision: UInt64, lineage: UInt64 = 1, count: Int) -> EndpointStatisticsIngestCursor {
+        EndpointStatisticsIngestCursor(
+            packetRevision: revision,
+            packetLineageRevision: lineage,
+            totalPacketCount: count
+        )
+    }
+
+    private func makePacket(
+        id: UInt64,
+        length: Int = 128,
+        timestamp: Date? = nil,
+        direction: PacketDirection? = .outbound,
+        domain: String? = nil,
+        client: PacketClient? = nil,
+        transportHint: TransportProtocolHint = .tcp,
+        decodeStatus: PacketDecodeStatus = PacketDecodeStatus(kind: .complete)
+    ) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: id,
+            timestamp: timestamp ?? Date(timeIntervalSince1970: TimeInterval(id)),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: transportHint,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.2", port: 51_000),
+                destination: PacketEndpoint(address: "93.184.216.34", port: 443)
+            ),
+            originalLength: length,
+            capturedLength: min(length, 64),
+            direction: direction,
+            infoSummary: "Packet \(id)",
+            layers: [PacketLayer(name: transportHint.rawValue.uppercased())],
+            decodeStatus: decodeStatus,
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: domain,
+            client: client
+        )
+    }
+
+    private func makeClient(name: String, bundleIdentifier: String) -> PacketClient {
+        PacketClient(
+            pid: 123,
+            name: name,
+            displayName: name,
+            executablePath: "/Applications/\(name).app/Contents/MacOS/\(name)",
+            bundleIdentifier: bundleIdentifier,
+            bundlePath: "/Applications/\(name).app"
+        )
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(condition())
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/CaptureOverviewServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/CaptureOverviewServiceTests.swift
@@ -160,6 +160,72 @@ struct CaptureOverviewServiceTests {
         #expect(snapshot.timeline.count <= CaptureOverviewAccumulator.maximumRenderedTimelinePointCount)
     }
 
+    @Test func trafficChartHoverSelectsTheNearestTimestamp() {
+        let firstDate = Date(timeIntervalSince1970: 100)
+        let secondDate = Date(timeIntervalSince1970: 110)
+        let points = [
+            CaptureOverviewChartPoint(
+                id: .init(date: firstDate, direction: .sent),
+                date: firstDate,
+                direction: .sent,
+                bytes: 100
+            ),
+            CaptureOverviewChartPoint(
+                id: .init(date: secondDate, direction: .sent),
+                date: secondDate,
+                direction: .sent,
+                bytes: 200
+            ),
+        ]
+
+        #expect(CaptureOverviewChartHoverSelection.nearestDate(
+            to: Date(timeIntervalSince1970: 104),
+            in: points
+        ) == firstDate)
+        #expect(CaptureOverviewChartHoverSelection.nearestDate(
+            to: Date(timeIntervalSince1970: 106),
+            in: points
+        ) == secondDate)
+        #expect(CaptureOverviewChartHoverSelection.nearestDate(
+            to: Date(timeIntervalSince1970: 105),
+            in: points
+        ) == firstDate)
+    }
+
+    @Test func protocolChartHoverSelectsOnlyDonutSegments() {
+        let rows = [
+            makeProtocolRow(id: "tcp", fraction: 0.25),
+            makeProtocolRow(id: "tls", fraction: 0.5),
+            makeProtocolRow(id: "dns", fraction: 0.25),
+        ]
+        let size = CGSize(width: 100, height: 100)
+
+        #expect(CaptureOverviewChartHoverSelection.protocolRow(
+            at: CGPoint(x: 50, y: 0),
+            in: size,
+            innerRadiusRatio: 0.67,
+            rows: rows
+        )?.id == "tcp")
+        #expect(CaptureOverviewChartHoverSelection.protocolRow(
+            at: CGPoint(x: 90, y: 70),
+            in: size,
+            innerRadiusRatio: 0.67,
+            rows: rows
+        )?.id == "tls")
+        #expect(CaptureOverviewChartHoverSelection.protocolRow(
+            at: CGPoint(x: 30, y: 10),
+            in: size,
+            innerRadiusRatio: 0.67,
+            rows: rows
+        )?.id == "dns")
+        #expect(CaptureOverviewChartHoverSelection.protocolRow(
+            at: CGPoint(x: 50, y: 50),
+            in: size,
+            innerRadiusRatio: 0.67,
+            rows: rows
+        ) == nil)
+    }
+
     @MainActor
     @Test func livePublishingIsThrottledToOneSnapshotPerInterval() async throws {
         var state = PacketIngestState.empty
@@ -261,6 +327,17 @@ struct CaptureOverviewServiceTests {
             executablePath: "/Applications/\(name).app/Contents/MacOS/\(name)",
             bundleIdentifier: bundleIdentifier,
             bundlePath: "/Applications/\(name).app"
+        )
+    }
+
+    private func makeProtocolRow(id: String, fraction: Double) -> CaptureOverviewProtocolPresentation {
+        CaptureOverviewProtocolPresentation(
+            id: id,
+            title: id.uppercased(),
+            totalText: "1 KB",
+            percentageText: "25%",
+            fraction: fraction,
+            colorIndex: 0
         )
     }
 

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDisplayedScopeForwarderTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDisplayedScopeForwarderTests.swift
@@ -51,6 +51,64 @@ struct EndpointStatisticsDisplayedScopeForwarderTests {
         #expect(forwarder.packetCount == 3)
     }
 
+    @Test func sameGenerationDoesNotReplayAnAlreadyConsumedUpdatePlan() throws {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 3)
+        Self.prime(&forwarder, source: Self.source(
+            generation: 1,
+            packetIDs: [1, 2],
+            updatePlan: .reload
+        ), packets: Array(packets.prefix(2)))
+
+        let appended = Self.update(from: forwarder.forwardingResult(
+            from: Self.source(generation: 2, packetIDs: [1, 2, 3], updatePlan: .append(2..<3)),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        ))
+        _ = try #require(appended)
+        var providerCallCount = 0
+
+        let replayedAppend = forwarder.forwardingResult(
+            from: Self.source(generation: 2, packetIDs: [1, 2, 3], updatePlan: .append(2..<3)),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: { _ in
+                providerCallCount += 1
+                return []
+            }
+        )
+        let replayedReload = forwarder.forwardingResult(
+            from: Self.source(generation: 2, packetIDs: [1, 2, 3], updatePlan: .reload),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: { _ in
+                providerCallCount += 1
+                return []
+            }
+        )
+
+        #expect(Self.isNone(replayedAppend))
+        #expect(Self.isNone(replayedReload))
+        #expect(providerCallCount == 0)
+        #expect(forwarder.packetCount == 3)
+    }
+
+    @Test func settledFilterWithoutADeltaRequestsAPresentation() {
+        #expect(EndpointStatisticsDisplayedSourcePolicy.shouldPresentAfterFiltering(
+            wasWaitingForFilter: true,
+            didForward: false
+        ))
+        #expect(!EndpointStatisticsDisplayedSourcePolicy.shouldPresentAfterFiltering(
+            wasWaitingForFilter: false,
+            didForward: false
+        ))
+        #expect(!EndpointStatisticsDisplayedSourcePolicy.shouldPresentAfterFiltering(
+            wasWaitingForFilter: true,
+            didForward: true
+        ))
+    }
+
     @Test func reloadRowsCopiesOnlyUpdatedPackets() throws {
         var forwarder = EndpointStatisticsDisplayedScopeForwarder()
         let packets = Self.packets(count: 2)

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDisplayedScopeForwarderTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDisplayedScopeForwarderTests.swift
@@ -1,0 +1,587 @@
+//
+//  EndpointStatisticsDisplayedScopeForwarderTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+import Testing
+@testable import TCPViewer
+
+struct EndpointStatisticsDisplayedScopeForwarderTests {
+    @Test func initialStateRequiresAChunkedReplacement() {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 2)
+
+        let result = forwarder.forwardingResult(
+            from: Self.source(generation: 1, packetIDs: [1, 2], updatePlan: .reload),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        )
+        #expect(Self.isReplacementRequired(result))
+        #expect(forwarder.packetCount == 0)
+    }
+
+    @Test func consecutiveAppendCopiesOnlyNewPackets() throws {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 3)
+        Self.prime(&forwarder, source: Self.source(
+            generation: 1,
+            packetIDs: [1, 2],
+            updatePlan: .reload
+        ), packets: Array(packets.prefix(2)))
+
+        let candidate = Self.update(from: forwarder.forwardingResult(
+            from: Self.source(generation: 2, packetIDs: [1, 2, 3], updatePlan: .append(2..<3)),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        ))
+        let update = try #require(candidate)
+
+        guard case .append(let appendedPackets) = update.kind else {
+            Issue.record("Expected an append update.")
+            return
+        }
+        #expect(appendedPackets.map { $0.id } == [3])
+        #expect(update.totalPacketCount == 3)
+        #expect(forwarder.packetCount == 3)
+    }
+
+    @Test func reloadRowsCopiesOnlyUpdatedPackets() throws {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 2)
+        Self.prime(&forwarder, source: Self.source(
+            generation: 1,
+            packetIDs: [1, 2],
+            updatePlan: .reload
+        ), packets: packets)
+
+        let candidate = Self.update(from: forwarder.forwardingResult(
+            from: Self.source(
+                generation: 2,
+                packetIDs: [1, 2],
+                updatePlan: .reloadRows(IndexSet(integer: 1))
+            ),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        ))
+        let update = try #require(candidate)
+
+        guard case .metadata(let updatedPackets) = update.kind else {
+            Issue.record("Expected a metadata update.")
+            return
+        }
+        #expect(updatedPackets.map { $0.id } == [2])
+        #expect(update.totalPacketCount == 2)
+    }
+
+    @Test func skippedTableGenerationRequiresAChunkedReplacement() {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 3)
+        Self.prime(&forwarder, source: Self.source(
+            generation: 1,
+            packetIDs: [1, 2],
+            updatePlan: .reload
+        ), packets: Array(packets.prefix(2)))
+
+        let result = forwarder.forwardingResult(
+            from: Self.source(generation: 3, packetIDs: [1, 2, 3], updatePlan: .append(2..<3)),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        )
+        #expect(Self.isReplacementRequired(result))
+    }
+
+    @Test func inFlightDisplayFilterKeepsLastConfirmedState() {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 2)
+        Self.prime(&forwarder, source: Self.source(
+            generation: 1,
+            packetIDs: [1],
+            updatePlan: .reload
+        ), packets: Array(packets.prefix(1)))
+        let previousCursor = forwarder.cursor
+
+        let result = forwarder.forwardingResult(
+            from: Self.source(
+                generation: 2,
+                packetIDs: [2],
+                updatePlan: .reload,
+                isFiltering: true
+            ),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        )
+
+        #expect(Self.isNone(result))
+        #expect(forwarder.packetCount == 1)
+        #expect(forwarder.cursor == previousCursor)
+    }
+
+    @Test func sourceDefersPacketIDLoadingUntilDisplayedScopeConsumesIt() {
+        var loadedSelections: [Int] = []
+
+        _ = Self.source(
+            generation: 1,
+            packetIDs: Array(1...100_000).map(UInt64.init),
+            updatePlan: .reload,
+            didLoadSelection: { loadedSelections.append($0.count) }
+        )
+
+        #expect(loadedSelections.isEmpty)
+    }
+
+    @Test func appendLoadsOnlyTheBoundedDelta() throws {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let packets = Self.packets(count: 3)
+        Self.prime(&forwarder, source: Self.source(
+            generation: 1,
+            packetIDs: [1, 2],
+            updatePlan: .reload
+        ), packets: Array(packets.prefix(2)))
+        var loadedSelections: [Int] = []
+
+        let candidate = Self.update(from: forwarder.forwardingResult(
+            from: Self.source(
+                generation: 2,
+                packetIDs: [1, 2, 3],
+                updatePlan: .append(2..<3),
+                didLoadSelection: { loadedSelections.append($0.count) }
+            ),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: Self.provider(packets)
+        ))
+        _ = try #require(candidate)
+
+        #expect(loadedSelections == [1])
+    }
+
+    @Test func staleRenderedSourceDoesNotLoadOrResolvePacketIDsFromANewCapture() {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        var loadedSelectionCount = 0
+        var providerCallCount = 0
+        let staleSource = Self.source(
+            generation: 1,
+            packetIDs: [1],
+            updatePlan: .reload,
+            didLoadSelection: { loadedSelectionCount += $0.count }
+        )
+
+        let result = forwarder.forwardingResult(
+            from: staleSource,
+            expectedSourceIdentity: EndpointStatisticsSourceIdentity(
+                backingIdentity: "capture-b",
+                packetLineageRevision: 2
+            ),
+            forceReplacement: true,
+            packetProvider: { _ in
+                providerCallCount += 1
+                return []
+            }
+        )
+
+        #expect(Self.isNone(result))
+        #expect(loadedSelectionCount == 0)
+        #expect(providerCallCount == 0)
+        #expect(forwarder.cursor == nil)
+    }
+
+    @Test func replacementAccumulatorKeepsEveryMainTurnBoundedAcrossAnExtendedTail() throws {
+        var accumulator = EndpointStatisticsDisplayedReplacementAccumulator(
+            packetCount: 1_000,
+            chunkSize: 512
+        )
+        var observedRanges: [Range<Int>] = []
+        while let range = accumulator.nextRange {
+            observedRanges.append(range)
+            let packets = range.map { Self.makePacket(id: UInt64($0 + 1)) }
+            let didAppend = accumulator.append(packetIDs: packets.map(\.id), packets: packets)
+            #expect(didAppend)
+        }
+        let didExtend = accumulator.extend(to: 2_000)
+        #expect(didExtend)
+        while let range = accumulator.nextRange {
+            observedRanges.append(range)
+            let packets = range.map { Self.makePacket(id: UInt64($0 + 1)) }
+            let didAppend = accumulator.append(packetIDs: packets.map(\.id), packets: packets)
+            #expect(didAppend)
+        }
+
+        let replacement = Self.makePacket(id: 99_999)
+        accumulator.replaceLoadedPacket(at: 1_500, with: replacement)
+        let flattened = accumulator.packetChunks.flatMap(\.packets)
+
+        #expect(observedRanges.allSatisfy { $0.count <= 512 })
+        #expect(flattened.count == 2_000)
+        #expect(flattened[1_500].id == replacement.id)
+    }
+
+    @Test func replacementStopsForSameGenerationFilteringOrScopeChange() {
+        let source = Self.source(generation: 7, packetIDs: [1], updatePlan: .reload)
+        let filteringSource = Self.source(
+            generation: 7,
+            packetIDs: [1],
+            updatePlan: .reload,
+            isFiltering: true
+        )
+
+        #expect(!EndpointStatisticsDisplayedSourcePolicy.canLoadReplacement(
+            source: source,
+            latestSource: filteringSource,
+            expectedIdentity: Self.sourceIdentity,
+            usesDisplayedPackets: true
+        ))
+        #expect(!EndpointStatisticsDisplayedSourcePolicy.canLoadReplacement(
+            source: source,
+            latestSource: source,
+            expectedIdentity: Self.sourceIdentity,
+            usesDisplayedPackets: false
+        ))
+    }
+
+    @Test func displayedReplacementSurvivesAppendWhileLoadingAndRejectsOldFlatten() throws {
+        let initialPackets = Self.packets(count: 3_000)
+        let initialSource = Self.source(
+            generation: 1,
+            packetIDs: initialPackets.map(\.id),
+            updatePlan: .reload
+        )
+        let work = EndpointStatisticsDisplayedReplacementWork(source: initialSource, mode: .enqueue)
+        let firstRange = try #require(work.accumulator.nextRange)
+        let firstPackets = Array(initialPackets[firstRange])
+        let didAppendFirstChunk = work.accumulator.append(
+            packetIDs: firstPackets.map(\.id),
+            packets: firstPackets
+        )
+        #expect(didAppendFirstChunk)
+        let staleFlattenToken = work.cancellationToken
+        let staleFlattenCount = work.accumulator.packetCount
+
+        let appendedPackets = (3_001...4_000).map { Self.makePacket(id: UInt64($0)) }
+        let allPackets = initialPackets + appendedPackets
+        let appendedSource = Self.source(
+            generation: 2,
+            packetIDs: allPackets.map(\.id),
+            updatePlan: .append(3_000..<4_000)
+        )
+
+        #expect(work.update(to: appendedSource, packetProvider: Self.provider(allPackets)) == .updated)
+        #expect(work.accumulator.nextPacketIndex == firstRange.upperBound)
+        #expect(work.accumulator.packetCount == 4_000)
+        #expect(!work.acceptsFlattenedPackets(
+            token: staleFlattenToken,
+            packetCount: staleFlattenCount,
+            flattenedPacketCount: staleFlattenCount
+        ))
+
+        while let range = work.accumulator.nextRange {
+            let packetIDs = try #require(work.source.packetIDs(in: range))
+            let packets = Self.provider(allPackets)(packetIDs)
+            let didAppendChunk = work.accumulator.append(packetIDs: packetIDs, packets: packets)
+            #expect(didAppendChunk)
+        }
+        #expect(work.acceptsFlattenedPackets(
+            token: work.cancellationToken,
+            packetCount: 4_000,
+            flattenedPacketCount: 4_000
+        ))
+        #expect(work.accumulator.packetChunks.flatMap(\.packets).map(\.id) == allPackets.map(\.id))
+    }
+
+    @Test func rawReplacementRejectsAFlattenCapturedBeforeAnAppend() throws {
+        let work = EndpointStatisticsRawReplacementWork(
+            sourceIdentity: Self.sourceIdentity,
+            packetRevision: 1,
+            packetCount: 1,
+            mode: .enqueue
+        )
+        let packet = Self.makePacket(id: 1)
+        let didAppendPacket = work.accumulator.append(packetIDs: [packet.id], packets: [packet])
+        #expect(didAppendPacket)
+        let staleFlattenToken = work.cancellationToken
+
+        #expect(work.prepareForMorePackets(packetRevision: 2, packetCount: 2))
+        #expect(!work.acceptsFlattenedPackets(
+            token: staleFlattenToken,
+            packetRevision: 1,
+            packetCount: 1,
+            flattenedPacketCount: 1
+        ))
+    }
+
+    @Test func sustainedAppendsDuringDisplayedFlattenKeepTheFrozenBoundaryValid() throws {
+        var allPackets = Self.packets(count: 100)
+        var source = Self.source(
+            generation: 1,
+            packetIDs: allPackets.map(\.id),
+            updatePlan: .reload
+        )
+        let work = EndpointStatisticsDisplayedReplacementWork(source: source, mode: .enqueue)
+        while let range = work.accumulator.nextRange {
+            let packets = Array(allPackets[range])
+            let didAppend = work.accumulator.append(packetIDs: packets.map(\.id), packets: packets)
+            #expect(didAppend)
+        }
+        work.isFlattening = true
+        let flattenToken = work.cancellationToken
+        let flattenCount = work.accumulator.packetCount
+
+        for generation in 2...101 {
+            let oldCount = allPackets.count
+            allPackets.append(Self.makePacket(id: UInt64(oldCount + 1)))
+            source = Self.source(
+                generation: UInt64(generation),
+                packetIDs: allPackets.map(\.id),
+                updatePlan: .append(oldCount..<allPackets.count)
+            )
+            #expect(work.update(to: source, packetProvider: Self.provider(allPackets)) == .updated)
+        }
+
+        #expect(work.cancellationToken === flattenToken)
+        #expect(work.deferredUpdates.count == 100)
+        #expect(work.retainedDeferredPacketCount == 100)
+        #expect(work.acceptsFlattenedPackets(
+            token: flattenToken,
+            packetCount: flattenCount,
+            flattenedPacketCount: flattenCount
+        ))
+
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let replacementCandidate = forwarder.replacementUpdate(
+            from: Self.source(
+                generation: 1,
+                packetIDs: Array(allPackets.prefix(flattenCount)).map(\.id),
+                updatePlan: .reload
+            ),
+            packets: Array(allPackets.prefix(flattenCount))
+        )
+        let replacement = try #require(replacementCandidate)
+        var latestUpdate = replacement
+        for deferredUpdate in work.deferredUpdates {
+            let candidate = forwarder.deferredUpdate(deferredUpdate)
+            latestUpdate = try #require(candidate)
+        }
+        #expect(latestUpdate.totalPacketCount == allPackets.count)
+    }
+
+    @Test func rawReplacementExtendsLargeContiguousAppendsInChunksBeforeFlattening() {
+        let work = EndpointStatisticsRawReplacementWork(
+            sourceIdentity: Self.sourceIdentity,
+            packetRevision: 1,
+            packetCount: 100,
+            mode: .enqueue
+        )
+
+        #expect(work.prepareForMorePackets(packetRevision: 2, packetCount: 20_100))
+        #expect(work.prepareForMorePackets(packetRevision: 3, packetCount: 40_100))
+        #expect(work.accumulator.packetCount == 40_100)
+        #expect(work.accumulator.nextRange?.count == EndpointStatisticsDisplayedReplacementAccumulator.defaultChunkSize)
+    }
+
+    @Test func rawFlattenBoundaryRemainsValidWhileBoundedAppendsAreDeferred() {
+        let work = EndpointStatisticsRawReplacementWork(
+            sourceIdentity: Self.sourceIdentity,
+            packetRevision: 1,
+            packetCount: 100,
+            mode: .enqueue
+        )
+        work.isFlattening = true
+        let flattenToken = work.cancellationToken
+
+        for revision in 2...101 {
+            let packet = Self.makePacket(id: UInt64(99 + revision))
+            let update = EndpointStatisticsIngestUpdate(
+                packetRevision: UInt64(revision),
+                packetLineageRevision: Self.sourceIdentity.packetLineageRevision,
+                totalPacketCount: 99 + revision,
+                kind: .append([packet])
+            )
+            #expect(work.deferUpdate(update, maximumPacketCount: 10_000))
+        }
+
+        #expect(work.cancellationToken === flattenToken)
+        #expect(work.deferredUpdates.count == 100)
+        #expect(work.logicalPacketCount == 200)
+        #expect(work.acceptsFlattenedPackets(
+            token: flattenToken,
+            packetRevision: 1,
+            packetCount: 100,
+            flattenedPacketCount: 100
+        ))
+    }
+
+    @Test func oversizedDisplayedDeltasRequireReplacementBeforeLoadingIDs() {
+        var forwarder = EndpointStatisticsDisplayedScopeForwarder()
+        let firstPacket = Self.makePacket(id: 1)
+        Self.prime(
+            &forwarder,
+            source: Self.source(generation: 1, packetIDs: [1], updatePlan: .reload),
+            packets: [firstPacket]
+        )
+        let packetIDs = (1...10_002).map(UInt64.init)
+        var loadedSelectionCount = 0
+        var providerCallCount = 0
+
+        let appendResult = forwarder.forwardingResult(
+            from: Self.source(
+                generation: 2,
+                packetIDs: packetIDs,
+                updatePlan: .append(1..<10_002),
+                didLoadSelection: { loadedSelectionCount += $0.count }
+            ),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: { _ in
+                providerCallCount += 1
+                return []
+            }
+        )
+
+        #expect(Self.isReplacementRequired(appendResult))
+        #expect(loadedSelectionCount == 0)
+        #expect(providerCallCount == 0)
+
+        let reloadResult = forwarder.forwardingResult(
+            from: Self.source(
+                generation: 2,
+                packetIDs: [1],
+                updatePlan: .reloadRows(IndexSet(integersIn: 0..<10_001)),
+                didLoadSelection: { loadedSelectionCount += $0.count }
+            ),
+            expectedSourceIdentity: Self.sourceIdentity,
+            forceReplacement: false,
+            packetProvider: { _ in
+                providerCallCount += 1
+                return []
+            }
+        )
+
+        #expect(Self.isReplacementRequired(reloadResult))
+        #expect(loadedSelectionCount == 0)
+        #expect(providerCallCount == 0)
+    }
+
+    @Test func rawDeltaPolicyCapsAppendAndMetadataBeforeMaterialization() {
+        #expect(EndpointStatisticsRawDeltaPolicy.exceedsAutomaticLimit(
+            .append(0..<10_001)
+        ))
+        #expect(EndpointStatisticsRawDeltaPolicy.exceedsAutomaticLimit(
+            .appendWithMetadataUpdates(
+                range: 0..<9_500,
+                updatedPacketIDs: Array(1...501).map(UInt64.init)
+            )
+        ))
+        #expect(EndpointStatisticsRawDeltaPolicy.exceedsAutomaticLimit(
+            .metadataUpdate(packetIDs: Array(1...10_001).map(UInt64.init))
+        ))
+        #expect(!EndpointStatisticsRawDeltaPolicy.exceedsAutomaticLimit(
+            .append(0..<10_000)
+        ))
+    }
+}
+
+private extension EndpointStatisticsDisplayedScopeForwarderTests {
+    static let sourceIdentity = EndpointStatisticsSourceIdentity(
+        backingIdentity: "capture-a",
+        packetLineageRevision: 1
+    )
+
+    static func prime(
+        _ forwarder: inout EndpointStatisticsDisplayedScopeForwarder,
+        source: EndpointStatisticsRenderedSource,
+        packets: [PacketSummary]
+    ) {
+        _ = forwarder.replacementUpdate(from: source, packets: packets)
+    }
+
+    static func update(
+        from result: EndpointStatisticsDisplayedScopeForwardingResult
+    ) -> EndpointStatisticsIngestUpdate? {
+        guard case .update(let update) = result else {
+            return nil
+        }
+        return update
+    }
+
+    static func isNone(_ result: EndpointStatisticsDisplayedScopeForwardingResult) -> Bool {
+        if case .none = result {
+            return true
+        }
+        return false
+    }
+
+    static func isReplacementRequired(
+        _ result: EndpointStatisticsDisplayedScopeForwardingResult
+    ) -> Bool {
+        if case .replacementRequired = result {
+            return true
+        }
+        return false
+    }
+
+    static func source(
+        generation: UInt64,
+        packetIDs: [PacketSummary.ID],
+        updatePlan: PacketTableUpdatePlan,
+        isFiltering: Bool = false,
+        didLoadSelection: ((EndpointStatisticsPacketIDSelection) -> Void)? = nil
+    ) -> EndpointStatisticsRenderedSource {
+        EndpointStatisticsRenderedSource(
+            identity: sourceIdentity,
+            packetTableGeneration: generation,
+            visiblePacketCount: packetIDs.count,
+            updatePlan: updatePlan,
+            isFiltering: isFiltering,
+            packetIDLoader: { selection in
+                didLoadSelection?(selection)
+                switch selection {
+                case .range(let range):
+                    return Array(packetIDs[range])
+                case .indexes(let indexes):
+                    return indexes.map { packetIDs[$0] }
+                }
+            }
+        )
+    }
+
+    static func provider(_ packets: [PacketSummary]) -> ([PacketSummary.ID]) -> [PacketSummary] {
+        let packetsByID = Dictionary(uniqueKeysWithValues: packets.map { ($0.id, $0) })
+        return { packetIDs in
+            packetIDs.compactMap { packetsByID[$0] }
+        }
+    }
+
+    static func packets(count: Int) -> [PacketSummary] {
+        (1...count).map { makePacket(id: UInt64($0)) }
+    }
+
+    static func makePacket(id: UInt64) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: id,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(id)),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.2", port: 51_000),
+                destination: PacketEndpoint(address: "93.184.216.34", port: 443)
+            ),
+            originalLength: 128,
+            capturedLength: 128,
+            direction: .outbound,
+            infoSummary: "Packet \(id)",
+            layers: [PacketLayer(name: "IPv4"), PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false)
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDrillDownTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDrillDownTests.swift
@@ -1,0 +1,534 @@
+//
+//  EndpointStatisticsDrillDownTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+import Testing
+import PcapPlusPlusCore
+@testable import TCPViewer
+
+@Suite(.serialized)
+@MainActor
+struct EndpointStatisticsDrillDownTests {
+
+    @Test func filtersExactAppDomainIPAndTransportEndpointIdentities() async {
+        let alphaClient = makeClient(name: "Alpha", bundleIdentifier: "com.example.alpha")
+        let betaClient = makeClient(name: "Beta", bundleIdentifier: "com.example.beta")
+        let packets = [
+            makePacket(number: 1, transport: .tcp, client: alphaClient),
+            makePacket(number: 2, transport: .udp, client: alphaClient),
+            makePacket(number: 3, transport: .tcp, client: betaClient),
+            makePacket(number: 4, transport: .tls, domain: "api.example.com", layers: ["Ethernet", "TCP", "TLS"]),
+            makePacket(number: 5, transport: .tcp, domain: " API.EXAMPLE.COM. "),
+            makePacket(number: 6, transport: .tcp, domain: "cdn.api.example.com"),
+            makePacket(number: 7, transport: .tcp, sourceAddress: "198.51.100.8", destinationAddress: "192.0.2.1"),
+            makePacket(number: 8, transport: .udp, sourceAddress: "192.0.2.1", destinationAddress: "198.51.100.8"),
+            makePacket(number: 9, transport: .tcp, sourceAddress: "198.51.100.80", destinationAddress: "192.0.2.1"),
+            makePacket(number: 10, transport: .tcp, sourceAddress: "2001:0db8:0:0:0:0:0:8", destinationAddress: "2001:db8::1"),
+            makePacket(number: 11, transport: .udp, sourceAddress: "2001:db8::1", destinationAddress: "2001:db8::8"),
+            makePacket(number: 12, transport: .tcp, sourceAddress: "2001:db8::80", destinationAddress: "2001:db8::1"),
+            makePacket(
+                number: 13,
+                transport: .tls,
+                destinationPort: 443,
+                sourceAddress: "10.0.0.1",
+                destinationAddress: "192.0.2.20",
+                layers: ["Ethernet", "TCP", "TLS"]
+            ),
+            makePacket(
+                number: 14,
+                transport: .udp,
+                destinationPort: 443,
+                sourceAddress: "10.0.0.1",
+                destinationAddress: "192.0.2.20"
+            ),
+            makePacket(
+                number: 15,
+                transport: .tcp,
+                destinationPort: 444,
+                sourceAddress: "10.0.0.1",
+                destinationAddress: "192.0.2.20"
+            ),
+            makePacket(
+                number: 16,
+                transport: .dns,
+                destinationPort: 53,
+                sourceAddress: "10.0.0.1",
+                destinationAddress: "192.0.2.30",
+                layers: ["Ethernet", "UDP", "DNS"]
+            ),
+            makePacket(
+                number: 17,
+                transport: .tcp,
+                destinationPort: 53,
+                sourceAddress: "10.0.0.1",
+                destinationAddress: "192.0.2.30"
+            ),
+        ]
+        let viewModel = makeOfflineViewModel(packets: packets)
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/endpoint-drilldown-identities.pcapng"))
+        await waitUntil { viewModel.snapshot.packetRows.count == packets.count }
+
+        let cases: [(String, EndpointStatisticsRow.ID, [PacketSummary.ID])] = [
+            (
+                "app",
+                EndpointStatisticsRow.ID(group: .apps, key: "bundleIdentifier:com.example.alpha"),
+                [packets[0].id, packets[1].id]
+            ),
+            (
+                "domain",
+                EndpointStatisticsRow.ID(group: .domains, key: "api.example.com"),
+                [packets[3].id, packets[4].id]
+            ),
+            (
+                "IPv4",
+                EndpointStatisticsRow.ID(group: .ipv4, key: "198.51.100.8"),
+                [packets[6].id, packets[7].id]
+            ),
+            (
+                "IPv6",
+                EndpointStatisticsRow.ID(group: .ipv6, key: "2001:db8::8"),
+                [packets[9].id, packets[10].id]
+            ),
+            (
+                "TCP",
+                EndpointStatisticsRow.ID(group: .tcp, key: "192.0.2.20:443"),
+                [packets[12].id]
+            ),
+            (
+                "UDP",
+                EndpointStatisticsRow.ID(group: .udp, key: "192.0.2.30:53"),
+                [packets[15].id]
+            ),
+        ]
+
+        for (name, rowID, expectedPacketIDs) in cases {
+            viewModel.showRelatedPackets(forEndpoint: rowID)
+
+            #expect(viewModel.snapshot.packetRows.map(\.id) == expectedPacketIDs, "Wrong exact match for \(name)")
+            #expect(viewModel.snapshot.selectedPacket?.id == expectedPacketIDs.first, "Wrong first selection for \(name)")
+
+            viewModel.clearEndpointStatisticsFilter()
+            #expect(viewModel.snapshot.packetRows.map(\.id) == packets.map(\.id), "Clear did not restore rows after \(name)")
+        }
+    }
+
+    @Test func composesWithExistingFiltersAndClearRestoresTheirScope() async {
+        let alphaClient = makeClient(name: "Alpha", bundleIdentifier: "com.example.alpha")
+        let betaClient = makeClient(name: "Beta", bundleIdentifier: "com.example.beta")
+        let packets = [
+            makePacket(number: 1, transport: .tcp, destinationPort: 443, client: alphaClient),
+            makePacket(number: 2, transport: .udp, destinationPort: 443, client: alphaClient),
+            makePacket(number: 3, transport: .tcp, destinationPort: 443, client: betaClient),
+            makePacket(number: 4, transport: .tcp, destinationPort: 80, client: alphaClient),
+        ]
+        let viewModel = makeOfflineViewModel(packets: packets)
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/endpoint-drilldown-filter-composition.pcapng"))
+        await waitUntil { viewModel.snapshot.packetRows.count == packets.count }
+
+        viewModel.toggleQuickFilter(.tcp)
+        viewModel.updateDisplayFilterText("port:443")
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[2].id])
+
+        viewModel.showRelatedPackets(forEndpoint: EndpointStatisticsRow.ID(
+            group: .apps,
+            key: "bundleIdentifier:com.example.alpha"
+        ))
+
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id])
+        #expect(viewModel.snapshot.selectedPacket?.id == packets[0].id)
+        #expect(viewModel.snapshot.endpointStatisticsFilterLabel == "Apps: com.example.alpha")
+        #expect(viewModel.snapshot.quickFilterSelection.activeIDs == [.tcp])
+        #expect(viewModel.snapshot.displayFilterText == "port:443")
+
+        viewModel.clearEndpointStatisticsFilter()
+
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[2].id])
+        #expect(viewModel.snapshot.endpointStatisticsFilterLabel == nil)
+        #expect(viewModel.snapshot.quickFilterSelection.activeIDs == [.tcp])
+        #expect(viewModel.snapshot.displayFilterText == "port:443")
+    }
+
+    @Test func liveMetadataBackfillRevealsDomainMatchesWithoutAnotherUserAction() async {
+        let liveSession = EndpointDrilldownFakeLiveSession()
+        let viewModel = makeLiveViewModel(liveSession: liveSession)
+        let firstPacket = makePacket(number: 1, source: .live, transport: .tcp, streamID: 77)
+        let resolvingPacket = makePacket(
+            number: 2,
+            source: .live,
+            transport: .tls,
+            streamID: 77,
+            domain: "late.example.com",
+            layers: ["Ethernet", "TCP", "TLS"]
+        )
+
+        await viewModel.performInitialLoadIfNeeded()
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+        liveSession.send(.packetBatch([firstPacket], disposition: .append))
+        await waitUntil { viewModel.snapshot.totalPacketCount == 1 }
+
+        viewModel.showRelatedPackets(forEndpoint: EndpointStatisticsRow.ID(
+            group: .domains,
+            key: "late.example.com"
+        ))
+        #expect(viewModel.snapshot.packetRows.isEmpty)
+
+        liveSession.send(.packetBatch([resolvingPacket], disposition: .append))
+        await waitUntil {
+            viewModel.snapshot.packetRows.map(\.id) == [firstPacket.id, resolvingPacket.id]
+        }
+
+        #expect(viewModel.snapshot.packetRows.map(\.domainText) == ["late.example.com", "late.example.com"])
+        #expect(viewModel.snapshot.endpointStatisticsFilterLabel == "Domains: late.example.com")
+    }
+
+    private func makeOfflineViewModel(packets: [PacketSummary]) -> NetworkInspectorViewModel {
+        let document = EndpointDrilldownFakeDocument(
+            url: URL(fileURLWithPath: "/tmp/endpoint-drilldown-fixture.pcapng"),
+            packets: packets
+        )
+        return makeViewModel(core: EndpointDrilldownFakeCore(document: document))
+    }
+
+    private func makeLiveViewModel(liveSession: EndpointDrilldownFakeLiveSession) -> NetworkInspectorViewModel {
+        makeViewModel(core: EndpointDrilldownFakeCore(liveSession: liveSession))
+    }
+
+    private func makeViewModel(core: EndpointDrilldownFakeCore) -> NetworkInspectorViewModel {
+        let storageDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: storageDirectory, withIntermediateDirectories: true)
+        return NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(
+                core: core,
+                packetMetadataEnricher: PacketMetadataEnrichmentService(
+                    clientResolver: EndpointDrilldownNilClientResolver()
+                )
+            ),
+            userDefaults: isolatedDefaults(),
+            pinService: PacketPinService(storageURL: storageDirectory.appendingPathComponent("Pins.json")),
+            savedPacketService: SavedPacketService(storageURL: storageDirectory.appendingPathComponent("Saved.json")),
+            customFilterService: PacketCustomFilterService(storageURL: storageDirectory.appendingPathComponent("Filters.json"))
+        )
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "TCPViewer.EndpointStatisticsDrillDownTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeClient(name: String, bundleIdentifier: String) -> PacketClient {
+        PacketClient(
+            pid: 123,
+            name: name,
+            displayName: name,
+            executablePath: "/Applications/\(name).app/Contents/MacOS/\(name)",
+            bundleIdentifier: bundleIdentifier,
+            bundlePath: "/Applications/\(name).app"
+        )
+    }
+
+    private func makePacket(
+        number: UInt64,
+        source: CaptureSource = .offline,
+        transport: TransportProtocolHint,
+        sourcePort: UInt16 = 50_000,
+        destinationPort: UInt16 = 80,
+        streamID: UInt32? = nil,
+        domain: String? = nil,
+        client: PacketClient? = nil,
+        sourceAddress: String = "10.0.0.1",
+        destinationAddress: String = "10.0.0.2",
+        layers: [String]? = nil
+    ) -> PacketSummary {
+        PacketSummary(
+            packetNumber: number,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(number)),
+            source: source,
+            interfaceID: source == .live ? "en0" : nil,
+            transportHint: transport,
+            protocolSummary: nil,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: sourceAddress, port: sourcePort),
+                destination: PacketEndpoint(address: destinationAddress, port: destinationPort)
+            ),
+            originalLength: 128,
+            capturedLength: 128,
+            streamID: streamID,
+            direction: nil,
+            infoSummary: "Packet \(number)",
+            layers: (layers ?? defaultLayers(for: transport)).map { PacketLayer(name: $0) },
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: domain,
+            client: client
+        )
+    }
+
+    private func defaultLayers(for transport: TransportProtocolHint) -> [String] {
+        switch transport {
+        case .udp, .dns:
+            return ["Ethernet", "UDP"]
+        default:
+            return ["Ethernet", "TCP"]
+        }
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 3_000_000_000,
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + .nanoseconds(Int64(timeoutNanoseconds))
+        while ContinuousClock.now < deadline {
+            if condition() {
+                return
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}
+
+private final class EndpointDrilldownFakeCore: TCPViewerCoreProviding, @unchecked Sendable {
+    private let document: EndpointDrilldownFakeDocument
+    private let liveSession: EndpointDrilldownFakeLiveSession
+
+    init(
+        document: EndpointDrilldownFakeDocument = EndpointDrilldownFakeDocument(
+            url: URL(fileURLWithPath: "/tmp/empty-endpoint-drilldown.pcapng"),
+            packets: []
+        ),
+        liveSession: EndpointDrilldownFakeLiveSession = EndpointDrilldownFakeLiveSession()
+    ) {
+        self.document = document
+        self.liveSession = liveSession
+    }
+
+    func listInterfaces(completion: @escaping TCPViewerCompletion<[CaptureInterfaceSummary]>) {
+        completion(.success([CaptureInterfaceSummary(
+            id: "en0",
+            technicalName: "en0",
+            displayName: "Wi-Fi",
+            friendlyName: nil,
+            interfaceDescription: nil,
+            isLoopback: false,
+            addresses: [],
+            linkType: .ethernet,
+            availability: .available,
+            capabilities: CaptureInterfaceCapabilities(
+                canCapture: true,
+                supportsPromiscuousMode: true,
+                requiresBPFPermissionSetup: true,
+                providesMacOSMetadata: true
+            )
+        )]))
+    }
+
+    func validateCaptureFilter(_ expression: String, completion: @escaping (CaptureFilterValidation) -> Void) {
+        completion(CaptureFilterValidation(
+            disposition: expression.isEmpty ? .invalid : .valid,
+            normalizedExpression: expression,
+            message: nil
+        ))
+    }
+
+    func validateCaptureOptions(_ options: CaptureOptions, for interface: CaptureInterfaceSummary?) throws -> CaptureOptions {
+        try options.validated(for: interface)
+    }
+
+    func makeLiveCaptureSession(
+        interfaceID: String,
+        options: CaptureOptions,
+        completion: @escaping TCPViewerCompletion<any LiveCaptureSessionProviding>
+    ) {
+        completion(.success(liveSession))
+    }
+
+    func supportedOfflineFormats() -> [CaptureFileFormat] {
+        [.pcap, .pcapng]
+    }
+
+    func openOfflineCaptureDocument(
+        at fileURL: URL,
+        completion: @escaping TCPViewerCompletion<any OfflineCaptureDocumentProviding>
+    ) {
+        completion(.success(document))
+    }
+
+    func loadPacketSummaries(
+        from fileURL: URL,
+        completion: @escaping TCPViewerCompletion<[PacketSummary]>
+    ) {
+        completion(.success(document.packetSummaries()))
+    }
+}
+
+private final class EndpointDrilldownFakeDocument: OfflineCaptureDocumentProviding, @unchecked Sendable {
+    var eventHandler: PacketIngestEventHandler?
+    private let url: URL
+    private let packets: [PacketSummary]
+    private let metadata = CaptureDocumentMetadata(format: .pcapng)
+    private var progress = PacketLoadProgress.idle
+
+    init(url: URL, packets: [PacketSummary]) {
+        self.url = url
+        self.packets = packets
+    }
+
+    func open(completion: @escaping TCPViewerCompletion<[PacketSummary]>) {
+        progress = PacketLoadProgress(
+            phase: .completed,
+            loadedPacketCount: packets.count,
+            message: "Loaded \(packets.count) packets."
+        )
+        send(.documentMetadataChanged(metadata))
+        send(.packetBatch(packets, disposition: .append))
+        send(.loadProgressChanged(progress))
+        send(.documentStateChanged(phase: .loaded, message: progress.message))
+        completion(.success(packets))
+    }
+
+    func reopen(completion: @escaping TCPViewerCompletion<[PacketSummary]>) {
+        open(completion: completion)
+    }
+
+    func cancelLoading(completion: (() -> Void)?) {
+        completion?()
+    }
+
+    func inspectPacket(id: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>) {
+        guard let packet = packets.first(where: { $0.id == id }) else {
+            completion(.failure(TCPViewerCoreError(code: .offlineFileOpenFailed, message: "Missing packet.")))
+            return
+        }
+        completion(.success(PacketInspection(
+            packetID: packet.id,
+            packetNumber: packet.packetNumber,
+            rawBytes: Data(repeating: 0, count: 8),
+            detailNodes: [],
+            decodeStatus: packet.decodeStatus
+        )))
+    }
+
+    func save(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
+    func save(to url: URL, format: CaptureFileFormat, completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        progress?(PacketExportProgress(exportedPacketCount: identifiers.count, totalPacketCount: identifiers.count))
+        completion(.success(()))
+    }
+
+    func currentURL() -> URL {
+        url
+    }
+
+    func currentMetadata() -> CaptureDocumentMetadata {
+        metadata
+    }
+
+    func packetSummaries() -> [PacketSummary] {
+        packets
+    }
+
+    func loadProgress() -> PacketLoadProgress {
+        progress
+    }
+
+    private func send(_ event: PacketIngestEvent) {
+        eventHandler?(.success(event))
+    }
+}
+
+private final class EndpointDrilldownFakeLiveSession: LiveCaptureSessionProviding, @unchecked Sendable {
+    var eventHandler: PacketIngestEventHandler?
+    private var packetsByID: [PacketSummary.ID: PacketSummary] = [:]
+
+    func start(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
+    func pause(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
+    func resume(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
+    func stop(completion: @escaping TCPViewerVoidCompletion) {
+        completion(.success(()))
+    }
+
+    func clearCapturedPackets(completion: @escaping TCPViewerVoidCompletion) {
+        packetsByID.removeAll()
+        completion(.success(()))
+    }
+
+    func inspectPacket(id: PacketSummary.ID, completion: @escaping TCPViewerCompletion<PacketInspection>) {
+        guard let packet = packetsByID[id] else {
+            completion(.failure(TCPViewerCoreError(code: .liveSessionControlFailed, message: "Missing packet.")))
+            return
+        }
+        completion(.success(PacketInspection(
+            packetID: packet.id,
+            packetNumber: packet.packetNumber,
+            rawBytes: Data(repeating: 0, count: 8),
+            detailNodes: [],
+            decodeStatus: packet.decodeStatus
+        )))
+    }
+
+    func exportPackets(
+        withIDs identifiers: [PacketSummary.ID],
+        to url: URL,
+        format: CaptureFileFormat,
+        progress: PacketExportProgressHandler?,
+        shouldCancel: PacketExportCancellationCheck?,
+        completion: @escaping TCPViewerVoidCompletion
+    ) {
+        progress?(PacketExportProgress(exportedPacketCount: identifiers.count, totalPacketCount: identifiers.count))
+        completion(.success(()))
+    }
+
+    func healthSnapshot(completion: @escaping (CaptureHealthSnapshot) -> Void) {
+        completion(.empty)
+    }
+
+    func send(_ event: PacketIngestEvent) {
+        if case .packetBatch(let packets, let disposition) = event {
+            if disposition == .replace {
+                packetsByID.removeAll()
+            }
+            for packet in packets {
+                packetsByID[packet.id] = packet
+            }
+        }
+        eventHandler?(.success(event))
+    }
+}
+
+private final class EndpointDrilldownNilClientResolver: PacketClientResolving {
+    func reset() {}
+
+    func client(for packet: PacketSummary) -> PacketClient? {
+        nil
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDrillDownTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsDrillDownTests.swift
@@ -72,51 +72,60 @@ struct EndpointStatisticsDrillDownTests {
         await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/endpoint-drilldown-identities.pcapng"))
         await waitUntil { viewModel.snapshot.packetRows.count == packets.count }
 
-        let cases: [(String, EndpointStatisticsRow.ID, [PacketSummary.ID])] = [
+        let cases: [(String, EndpointStatisticsRow.ID, PacketSourceListSelection, [PacketSummary.ID])] = [
             (
                 "app",
                 EndpointStatisticsRow.ID(group: .apps, key: "bundleIdentifier:com.example.alpha"),
+                .app(PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.alpha")),
                 [packets[0].id, packets[1].id]
             ),
             (
                 "domain",
                 EndpointStatisticsRow.ID(group: .domains, key: "api.example.com"),
+                .domain(PacketSourceDomainKey(rawValue: "api.example.com", isMissingDomain: false)),
                 [packets[3].id, packets[4].id]
             ),
             (
                 "IPv4",
                 EndpointStatisticsRow.ID(group: .ipv4, key: "198.51.100.8"),
+                .ipAddress(PacketSourceIPAddressKey(rawValue: "198.51.100.8")),
                 [packets[6].id, packets[7].id]
             ),
             (
                 "IPv6",
                 EndpointStatisticsRow.ID(group: .ipv6, key: "2001:db8::8"),
+                .ipAddress(PacketSourceIPAddressKey(rawValue: "2001:db8::8")),
                 [packets[9].id, packets[10].id]
             ),
             (
                 "TCP",
                 EndpointStatisticsRow.ID(group: .tcp, key: "192.0.2.20:443"),
+                .allPackets,
                 [packets[12].id]
             ),
             (
                 "UDP",
                 EndpointStatisticsRow.ID(group: .udp, key: "192.0.2.30:53"),
+                .allPackets,
                 [packets[15].id]
             ),
         ]
 
-        for (name, rowID, expectedPacketIDs) in cases {
+        for (name, rowID, expectedSelection, expectedPacketIDs) in cases {
+            viewModel.selectSourceList(.saved)
             viewModel.showRelatedPackets(forEndpoint: rowID)
 
+            #expect(viewModel.snapshot.selectedSourceListSelection == expectedSelection, "Wrong sidebar selection for \(name)")
             #expect(viewModel.snapshot.packetRows.map(\.id) == expectedPacketIDs, "Wrong exact match for \(name)")
             #expect(viewModel.snapshot.selectedPacket?.id == expectedPacketIDs.first, "Wrong first selection for \(name)")
 
             viewModel.clearEndpointStatisticsFilter()
+            viewModel.selectSourceList(.allPackets)
             #expect(viewModel.snapshot.packetRows.map(\.id) == packets.map(\.id), "Clear did not restore rows after \(name)")
         }
     }
 
-    @Test func composesWithExistingFiltersAndClearRestoresTheirScope() async {
+    @Test func preservesExistingFiltersAndClearKeepsTheSelectedEndpointScope() async {
         let alphaClient = makeClient(name: "Alpha", bundleIdentifier: "com.example.alpha")
         let betaClient = makeClient(name: "Beta", bundleIdentifier: "com.example.beta")
         let packets = [
@@ -140,13 +149,16 @@ struct EndpointStatisticsDrillDownTests {
 
         #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id])
         #expect(viewModel.snapshot.selectedPacket?.id == packets[0].id)
+        #expect(viewModel.snapshot.selectedSourceListSelection == .app(
+            PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.alpha")
+        ))
         #expect(viewModel.snapshot.endpointStatisticsFilterLabel == "Apps: com.example.alpha")
         #expect(viewModel.snapshot.quickFilterSelection.activeIDs == [.tcp])
         #expect(viewModel.snapshot.displayFilterText == "port:443")
 
         viewModel.clearEndpointStatisticsFilter()
 
-        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[2].id])
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id])
         #expect(viewModel.snapshot.endpointStatisticsFilterLabel == nil)
         #expect(viewModel.snapshot.quickFilterSelection.activeIDs == [.tcp])
         #expect(viewModel.snapshot.displayFilterText == "port:443")

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsServiceTests.swift
@@ -1,0 +1,534 @@
+//
+//  EndpointStatisticsServiceTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+import Testing
+@testable import TCPViewer
+
+@Suite(.serialized)
+struct EndpointStatisticsServiceTests {
+    @Test func endpointRowsUseOriginalLengthAndEndpointRelativeDirection() throws {
+        let packet = makePacket(
+            id: 1,
+            transportHint: .tls,
+            layerNames: ["Ethernet", "IPv4", "TCP"],
+            direction: .outbound,
+            originalLength: 400,
+            capturedLength: 80,
+            sourceAddress: "10.0.0.2",
+            sourcePort: 51_000,
+            destinationAddress: "93.184.216.34",
+            destinationPort: 443
+        )
+
+        let snapshot = EndpointStatisticsService().rebuild(from: [packet])
+        let sourceIP = try row(in: snapshot, group: .ipv4, key: "10.0.0.2")
+        let destinationIP = try row(in: snapshot, group: .ipv4, key: "93.184.216.34")
+        let sourceTCP = try row(in: snapshot, group: .tcp, key: "10.0.0.2:51000")
+        let destinationTCP = try row(in: snapshot, group: .tcp, key: "93.184.216.34:443")
+
+        #expect(sourceIP.packets == 1)
+        #expect(sourceIP.bytes == 400)
+        #expect(sourceIP.txPackets == 1)
+        #expect(sourceIP.txBytes == 400)
+        #expect(sourceIP.rxPackets == 0)
+        #expect(sourceIP.port == "51000")
+        #expect(sourceIP.protocolName == "TLS")
+        #expect(destinationIP.rxPackets == 1)
+        #expect(destinationIP.rxBytes == 400)
+        #expect(sourceTCP.txPackets == 1)
+        #expect(sourceTCP.port == "51000")
+        #expect(destinationTCP.rxPackets == 1)
+        #expect(destinationTCP.port == "443")
+        #expect(snapshot.footerTotals.bytes == 400)
+        #expect(EndpointStatisticsRowID(group: .tcp, key: "93.184.216.34:443").matches(packet))
+    }
+
+    @Test func appAndDomainRowsUseOppositeDirectionalSemantics() throws {
+        let client = makeClient(displayName: "Example Browser", bundleIdentifier: "com.example.browser")
+        let packets = [
+            makePacket(id: 1, direction: .outbound, originalLength: 200, domain: "Example.COM.", client: client),
+            makePacket(
+                id: 2,
+                direction: .inbound,
+                originalLength: 100,
+                sourceAddress: "93.184.216.34",
+                sourcePort: 443,
+                destinationAddress: "10.0.0.2",
+                destinationPort: 51_000,
+                domain: "example.com",
+                client: client
+            ),
+            makePacket(id: 3, direction: .unknown, originalLength: 50, domain: "EXAMPLE.COM", client: client),
+        ]
+
+        let snapshot = EndpointStatisticsService().rebuild(from: packets)
+        let app = try row(
+            in: snapshot,
+            group: .apps,
+            key: "bundleIdentifier:com.example.browser"
+        )
+        let domain = try row(in: snapshot, group: .domains, key: "example.com")
+
+        #expect(snapshot.endpointCount(for: .apps) == 1)
+        #expect(snapshot.endpointCount(for: .domains) == 1)
+        #expect(app.client == "Example Browser")
+        #expect(app.packets == 3)
+        #expect(app.bytes == 350)
+        #expect(app.txPackets == 1)
+        #expect(app.txBytes == 200)
+        #expect(app.rxPackets == 1)
+        #expect(app.rxBytes == 100)
+        #expect(app.unclassifiedPackets == 1)
+        #expect(app.unclassifiedBytes == 50)
+        #expect(app.summary == "Tx 57% · Rx 29% · Unclassified 14%")
+        #expect(domain.txBytes == 100)
+        #expect(domain.rxBytes == 200)
+        #expect(domain.unclassifiedBytes == 50)
+        #expect(snapshot.footerTotals == app.totals)
+    }
+
+    @Test func summaryPercentagesDoNotOverflowAtUInt64Limits() {
+        let totals = EndpointStatisticsTotals(
+            packets: 3,
+            bytes: .max,
+            txPackets: 1,
+            txBytes: .max,
+            rxPackets: 1,
+            rxBytes: .max,
+            unclassifiedPackets: 1,
+            unclassifiedBytes: .max
+        )
+
+        #expect(totals.summary == "Tx 33% · Rx 33% · Unclassified 33%")
+    }
+
+    @Test func canonicalDomainsAndIPv6AddressesMergeEquivalentRows() throws {
+        let packets = [
+            makePacket(
+                id: 1,
+                sourceAddress: "2001:0db8:0:0:0:0:0:1",
+                destinationAddress: "2001:db8::2",
+                domain: " API.Example.COM. "
+            ),
+            makePacket(
+                id: 2,
+                sourceAddress: "[2001:db8::1]",
+                destinationAddress: "2001:0DB8:0:0:0:0:0:2",
+                domain: "api.example.com"
+            ),
+        ]
+
+        let snapshot = EndpointStatisticsService().rebuild(from: packets)
+        let source = try row(in: snapshot, group: .ipv6, key: "2001:db8::1")
+        let domain = try row(in: snapshot, group: .domains, key: "api.example.com")
+
+        #expect(snapshot.endpointCount(for: .ipv6) == 2)
+        #expect(snapshot.endpointCount(for: .domains) == 1)
+        #expect(source.packets == 2)
+        #expect(domain.packets == 2)
+        #expect(EndpointStatisticsRowID(group: .tcp, key: "[2001:db8::1]:51000").matches(packets[0]))
+    }
+
+    @Test func relatedFieldsChangeBetweenOneValueAndMultipleAfterBackfill() throws {
+        let client = makeClient(displayName: "Browser", bundleIdentifier: "com.example.browser")
+        var state = PacketIngestState.empty
+        state.append([
+            makePacket(id: 1, domain: "one.example", client: client),
+            makePacket(id: 2, domain: "two.example", client: client),
+        ], source: .live)
+        let service = EndpointStatisticsService()
+
+        var snapshot = service.snapshot(for: state)
+        var app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.browser")
+        #expect(app.domain == EndpointStatisticsRow.multipleValue)
+        #expect(app.isDomainMultiple)
+
+        state.applyMetadataUpdates([
+            PacketMetadataUpdate(
+                packetIDs: [2],
+                sniDomainName: "one.example",
+                client: client,
+                direction: .outbound
+            ),
+        ])
+        snapshot = service.snapshot(for: state)
+        app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.browser")
+
+        #expect(app.domain == "one.example")
+        #expect(!app.isDomainMultiple)
+        #expect(snapshot.endpointCount(for: .domains) == 1)
+        #expect(try row(in: snapshot, group: .domains, key: "one.example").packets == 2)
+        #expect(service.debugSnapshot().metadataPacketCount == 1)
+    }
+
+    @Test func literalMultipleClientNameIsNotMarkedAsAnAggregatePlaceholder() throws {
+        let client = makeClient(displayName: EndpointStatisticsRow.multipleValue, bundleIdentifier: "com.example.multiple")
+        let snapshot = EndpointStatisticsService().rebuild(from: [makePacket(id: 1, client: client)])
+        let app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.multiple")
+
+        #expect(app.client == EndpointStatisticsRow.multipleValue)
+        #expect(!app.isClientMultiple)
+    }
+
+    @Test func appDisplayNameUpdatesWhenMetadataImprovesForTheSameStableKey() throws {
+        let originalClient = makeClient(displayName: "Helper", bundleIdentifier: "com.example.browser")
+        let improvedClient = makeClient(displayName: "Example Browser", bundleIdentifier: "com.example.browser")
+        var state = PacketIngestState.empty
+        state.append([makePacket(id: 1, client: originalClient)], source: .live)
+        let service = EndpointStatisticsService()
+
+        _ = service.snapshot(for: state)
+        state.applyMetadataUpdates([
+            PacketMetadataUpdate(
+                packetIDs: [1],
+                sniDomainName: nil,
+                client: improvedClient,
+                direction: .outbound
+            ),
+        ])
+        let snapshot = service.snapshot(for: state)
+        let app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.browser")
+
+        #expect(app.client == "Example Browser")
+        #expect(app.packets == 1)
+    }
+
+    @Test func layerNamesClassifyApplicationHintsIntoTCPAndUDP() {
+        let packets = [
+            makePacket(id: 1, transportHint: .tls, layerNames: ["Ethernet", "IPv4", "TCP"]),
+            makePacket(id: 2, transportHint: .dns, layerNames: ["Ethernet", "IPv4", "UDP"]),
+            makePacket(id: 3, transportHint: .dns, layerNames: ["Ethernet", "IPv4"]),
+        ]
+
+        let snapshot = EndpointStatisticsService().rebuild(from: packets)
+
+        #expect(snapshot.endpointCount(for: .tcp) == 2)
+        #expect(snapshot.endpointCount(for: .udp) == 2)
+        #expect(snapshot.rows(for: .tcp).allSatisfy { $0.protocolName == "TLS" })
+        #expect(snapshot.rows(for: .udp).allSatisfy { $0.protocolName == "DNS" })
+    }
+
+    @Test func sameSourceAndDestinationCountsBothEndpointOccurrences() throws {
+        let packet = makePacket(
+            id: 1,
+            originalLength: 64,
+            sourceAddress: "127.0.0.1",
+            sourcePort: 8_080,
+            destinationAddress: "127.0.0.1",
+            destinationPort: 8_080
+        )
+
+        let snapshot = EndpointStatisticsService().rebuild(from: [packet])
+        let ip = try row(in: snapshot, group: .ipv4, key: "127.0.0.1")
+        let tcp = try row(in: snapshot, group: .tcp, key: "127.0.0.1:8080")
+
+        for endpoint in [ip, tcp] {
+            #expect(endpoint.packets == 2)
+            #expect(endpoint.bytes == 128)
+            #expect(endpoint.txPackets == 1)
+            #expect(endpoint.txBytes == 64)
+            #expect(endpoint.rxPackets == 1)
+            #expect(endpoint.rxBytes == 64)
+            #expect(endpoint.summary == "Tx 50% · Rx 50%")
+        }
+    }
+
+    @Test func missingAddressAndPortSkipOnlyUnavailableEndpointRows() {
+        let missingSourceAddress = makePacket(
+            id: 1,
+            sourceAddress: nil,
+            sourcePort: 51_000,
+            destinationAddress: "93.184.216.34",
+            destinationPort: 443
+        )
+        let missingDestinationPort = makePacket(
+            id: 2,
+            sourceAddress: "10.0.0.2",
+            sourcePort: 51_000,
+            destinationAddress: "93.184.216.34",
+            destinationPort: nil
+        )
+
+        let snapshot = EndpointStatisticsService().rebuild(from: [missingSourceAddress, missingDestinationPort])
+
+        #expect(snapshot.endpointCount(for: .ipv4) == 2)
+        #expect(snapshot.endpointCount(for: .tcp) == 2)
+        #expect(snapshot.rows(for: .tcp).contains { $0.id.key == "93.184.216.34:443" })
+        #expect(snapshot.rows(for: .tcp).contains { $0.id.key == "10.0.0.2:51000" })
+    }
+
+    @Test func invalidInboundSourceDoesNotUseTheLocalDestinationAsRemoteAddress() throws {
+        let client = makeClient(displayName: "Browser", bundleIdentifier: "com.example.browser")
+        let packet = makePacket(
+            id: 1,
+            direction: .inbound,
+            sourceAddress: "not-an-ip",
+            sourcePort: 443,
+            destinationAddress: "10.0.0.2",
+            destinationPort: 51_000,
+            domain: "example.com",
+            client: client
+        )
+
+        let snapshot = EndpointStatisticsService().rebuild(from: [packet])
+        let app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.browser")
+        let domain = try row(in: snapshot, group: .domains, key: "example.com")
+        let localIP = try row(in: snapshot, group: .ipv4, key: "10.0.0.2")
+
+        #expect(app.address == nil)
+        #expect(app.port == nil)
+        #expect(domain.address == nil)
+        #expect(domain.port == nil)
+        #expect(localIP.rxPackets == 1)
+    }
+
+    @Test func ingestMutationsAppendAndReclassifyOnlyAffectedPackets() throws {
+        let client = makeClient(displayName: "Browser", bundleIdentifier: "com.example.browser")
+        var state = PacketIngestState.empty
+        state.append([makePacket(id: 1, direction: nil)], source: .live)
+        let service = EndpointStatisticsService()
+
+        _ = service.snapshot(for: state)
+        state.appendAndApplyMetadataUpdates(
+            [makePacket(id: 2, direction: .inbound)],
+            metadataUpdates: [
+                PacketMetadataUpdate(
+                    packetIDs: [1],
+                    sniDomainName: "example.com",
+                    client: client,
+                    direction: .outbound
+                ),
+            ],
+            source: .live
+        )
+        let snapshot = service.snapshot(for: state)
+        _ = service.snapshot(for: state)
+        let debug = service.debugSnapshot()
+
+        #expect(debug.fullRebuildCount == 1)
+        #expect(debug.processedPacketCount == 2)
+        #expect(debug.appendedPacketCount == 1)
+        #expect(debug.metadataPacketCount == 1)
+        #expect(debug.unchangedSnapshotCount == 1)
+        #expect(snapshot.footerTotals.txPackets == 1)
+        #expect(snapshot.footerTotals.rxPackets == 1)
+        #expect(snapshot.footerTotals.unclassifiedPackets == 0)
+        #expect(try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.browser").packets == 1)
+    }
+
+    @Test func lineageReplacementClearsRowsFromThePreviousCapture() {
+        var state = PacketIngestState.empty
+        state.append([makePacket(id: 1, domain: "old.example")], source: .live)
+        let service = EndpointStatisticsService()
+        _ = service.snapshot(for: state)
+
+        state.reset(source: .live, message: "Cleared")
+        let emptySnapshot = service.snapshot(for: state)
+
+        #expect(emptySnapshot.footerTotals == .zero)
+        #expect(EndpointStatisticsGroup.allCases.allSatisfy { emptySnapshot.rows(for: $0).isEmpty })
+        #expect(service.debugSnapshot().fullRebuildCount == 2)
+    }
+
+    @Test func slimIngestUpdatesCarryOnlyChangedPacketsAndRejectRevisionGaps() {
+        var state = PacketIngestState.empty
+        state.append([makePacket(id: 1)], source: .live)
+        let service = EndpointStatisticsService()
+        let initial = EndpointStatisticsIngestUpdate(ingestState: state, previousCursor: nil)
+
+        guard case .replace(let initialPackets) = initial.kind else {
+            Issue.record("Expected an initial replacement update.")
+            return
+        }
+        #expect(initialPackets.count == 1)
+        #expect(service.consume(initial))
+
+        state.append([makePacket(id: 2)], source: .live)
+        let append = EndpointStatisticsIngestUpdate(ingestState: state, previousCursor: initial.cursor)
+        guard case .append(let appendedPackets) = append.kind else {
+            Issue.record("Expected a slim append update.")
+            return
+        }
+        #expect(appendedPackets.map(\.id) == [2])
+        #expect(service.consume(append))
+
+        state.append([makePacket(id: 3)], source: .live)
+        let recovery = EndpointStatisticsIngestUpdate(ingestState: state, previousCursor: initial.cursor)
+        guard case .replace(let recoveryPackets) = recovery.kind else {
+            Issue.record("Expected a replacement after a skipped revision.")
+            return
+        }
+        #expect(recoveryPackets.count == 3)
+        #expect(service.consume(recovery))
+
+        let skippedRevision = EndpointStatisticsIngestUpdate(
+            packetRevision: recovery.packetRevision + 2,
+            packetLineageRevision: recovery.packetLineageRevision,
+            totalPacketCount: recovery.totalPacketCount,
+            kind: .metadata([])
+        )
+        #expect(!service.consume(skippedRevision))
+        #expect(service.currentSnapshot().footerTotals.packets == 3)
+    }
+
+    @Test func oneHundredThousandPacketBaselineKeepsAppendWorkBounded() {
+        let baseline = (1...100_000).map { makePacket(id: UInt64($0), layerNames: []) }
+        var state = PacketIngestState.empty
+        state.append(baseline, source: .live)
+        let service = EndpointStatisticsService()
+
+        _ = service.snapshot(for: state)
+        let appended = (100_001...100_128).map { makePacket(id: UInt64($0), layerNames: []) }
+        state.append(appended, source: .live)
+        let snapshot = service.snapshot(for: state)
+        _ = service.snapshot(for: state)
+        let debug = service.debugSnapshot()
+
+        #expect(debug.fullRebuildCount == 1)
+        #expect(debug.processedPacketCount == 100_128)
+        #expect(debug.appendedPacketCount == 128)
+        #expect(debug.metadataPacketCount == 0)
+        #expect(debug.unchangedSnapshotCount == 1)
+        #expect(snapshot.footerTotals.packets == 100_128)
+        #expect(snapshot.endpointCount(for: .ipv4) == 2)
+        #expect(snapshot.endpointCount(for: .tcp) == 2)
+    }
+
+    @Test func selectedGroupSnapshotDoesNotMaterializeHighCardinalityTransportRows() {
+        let client = makeClient(displayName: "Browser", bundleIdentifier: "com.example.browser")
+        let packets = (1...10_000).map { value in
+            makePacket(
+                id: UInt64(value),
+                destinationPort: UInt16(value + 1_000),
+                client: client
+            )
+        }
+        let service = EndpointStatisticsService()
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: 1,
+            packetLineageRevision: 1,
+            totalPacketCount: packets.count,
+            kind: .replace(packets)
+        )
+
+        #expect(service.consume(update))
+        let snapshot = service.currentSnapshot(for: .apps)
+        let firstDebug = service.debugSnapshot()
+        _ = service.currentSnapshot(for: .apps)
+        let secondDebug = service.debugSnapshot()
+
+        #expect(snapshot.rows.count == 1)
+        #expect(snapshot.endpointCount(for: .apps) == 1)
+        #expect(snapshot.endpointCount(for: .tcp) == 10_001)
+        #expect(firstDebug.rowMaterializationCountByGroup == [.apps: 1])
+        #expect(firstDebug.materializedRowCount == 1)
+        #expect(secondDebug.rowMaterializationCountByGroup == firstDebug.rowMaterializationCountByGroup)
+        #expect(secondDebug.materializedRowCount == firstDebug.materializedRowCount)
+    }
+
+    @Test func cancellationStopsAndDiscardsAPartialLargeReplacement() {
+        let packets = (1...10_000).map { makePacket(id: UInt64($0), layerNames: []) }
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: 1,
+            packetLineageRevision: 1,
+            totalPacketCount: packets.count,
+            kind: .replace(packets)
+        )
+        let cancellationToken = EndpointStatisticsCancellationToken(cancelAfterCheckCount: 2)
+        let service = EndpointStatisticsService()
+
+        let result = service.consume(update, cancellationToken: cancellationToken)
+        let snapshot = service.currentSnapshot(for: .ipv4)
+
+        #expect(result == .cancelled)
+        #expect(snapshot.rows.isEmpty)
+        #expect(snapshot.footerTotals == .zero)
+        #expect(service.debugSnapshot().processedPacketCount == 0)
+    }
+
+    @Test func cancellationDoesNotCachePartiallyMaterializedRows() {
+        let packets = (1...10_000).map { value in
+            makePacket(id: UInt64(value), destinationPort: UInt16(value + 1_000))
+        }
+        let update = EndpointStatisticsIngestUpdate(
+            packetRevision: 1,
+            packetLineageRevision: 1,
+            totalPacketCount: packets.count,
+            kind: .replace(packets)
+        )
+        let service = EndpointStatisticsService()
+        #expect(service.consume(update))
+        let cancellationToken = EndpointStatisticsCancellationToken(cancelAfterCheckCount: 2)
+
+        let cancelledSnapshot = service.currentSnapshot(for: .tcp, cancellationToken: cancellationToken)
+        let cancelledDebug = service.debugSnapshot()
+        let completeSnapshot = service.currentSnapshot(for: .tcp)
+
+        #expect(cancelledSnapshot == nil)
+        #expect(cancelledDebug.rowMaterializationCountByGroup[.tcp] == nil)
+        #expect(cancelledDebug.materializedRowCount == 0)
+        #expect(completeSnapshot.rows.count == 10_001)
+    }
+
+    private func row(
+        in snapshot: EndpointStatisticsSnapshot,
+        group: EndpointStatisticsGroup,
+        key: String
+    ) throws -> EndpointStatisticsRow {
+        try #require(snapshot.rows(for: group).first { $0.id.key == key })
+    }
+
+    private func makePacket(
+        id: UInt64,
+        transportHint: TransportProtocolHint = .tcp,
+        layerNames: [String] = ["Ethernet", "IPv4", "TCP"],
+        direction: PacketDirection? = .outbound,
+        originalLength: Int = 128,
+        capturedLength: Int? = nil,
+        sourceAddress: String? = "10.0.0.2",
+        sourcePort: UInt16? = 51_000,
+        destinationAddress: String? = "93.184.216.34",
+        destinationPort: UInt16? = 443,
+        domain: String? = nil,
+        client: PacketClient? = nil
+    ) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: id,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(id)),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: transportHint,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: sourceAddress, port: sourcePort),
+                destination: PacketEndpoint(address: destinationAddress, port: destinationPort)
+            ),
+            originalLength: originalLength,
+            capturedLength: capturedLength ?? originalLength,
+            direction: direction,
+            infoSummary: "Packet \(id)",
+            layers: layerNames.map { PacketLayer(name: $0) },
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: domain,
+            client: client
+        )
+    }
+
+    private func makeClient(displayName: String, bundleIdentifier: String) -> PacketClient {
+        PacketClient(
+            pid: 123,
+            name: displayName,
+            displayName: displayName,
+            executablePath: "/Applications/\(displayName).app/Contents/MacOS/\(displayName)",
+            bundleIdentifier: bundleIdentifier,
+            bundlePath: "/Applications/\(displayName).app"
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsServiceTests.swift
@@ -78,6 +78,8 @@ struct EndpointStatisticsServiceTests {
         #expect(snapshot.endpointCount(for: .apps) == 1)
         #expect(snapshot.endpointCount(for: .domains) == 1)
         #expect(app.client == "Example Browser")
+        #expect(app.clientIconFilePath == "/Applications/Example Browser.app")
+        #expect(domain.clientIconFilePath == "/Applications/Example Browser.app")
         #expect(app.packets == 3)
         #expect(app.bytes == 350)
         #expect(app.txPackets == 1)
@@ -196,7 +198,24 @@ struct EndpointStatisticsServiceTests {
         let app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.browser")
 
         #expect(app.client == "Example Browser")
+        #expect(app.clientIconFilePath == "/Applications/Example Browser.app")
         #expect(app.packets == 1)
+    }
+
+    @Test func aggregateRowsShowAnIconOnlyForOneClient() throws {
+        let firstClient = makeClient(displayName: "First App", bundleIdentifier: "com.example.first")
+        let secondClient = makeClient(displayName: "Second App", bundleIdentifier: "com.example.second")
+        let snapshot = EndpointStatisticsService().rebuild(from: [
+            makePacket(id: 1, client: firstClient),
+            makePacket(id: 2, client: secondClient),
+        ])
+
+        let app = try row(in: snapshot, group: .apps, key: "bundleIdentifier:com.example.first")
+        let address = try row(in: snapshot, group: .ipv4, key: "10.0.0.2")
+
+        #expect(app.clientIconFilePath == "/Applications/First App.app")
+        #expect(address.client == EndpointStatisticsRow.multipleValue)
+        #expect(address.clientIconFilePath == nil)
     }
 
     @Test func layerNamesClassifyApplicationHintsIntoTCPAndUDP() {

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsTablePresentationTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsTablePresentationTests.swift
@@ -296,6 +296,31 @@ struct EndpointStatisticsTablePresentationTests {
 }
 
 struct EndpointStatisticsPresentationCommitPolicyTests {
+    @Test func automaticRefreshWaitsForTheLastVisibleCommit() {
+        let automaticDelay = EndpointStatisticsPresentationCadence.delay(
+            for: .automatic,
+            lastCommitTime: 10,
+            nextAllowedTime: 0,
+            now: 10.1
+        )
+        let explicitDelay = EndpointStatisticsPresentationCadence.delay(
+            for: .explicit,
+            lastCommitTime: 10,
+            nextAllowedTime: 0,
+            now: 10.1
+        )
+        let backpressureDelay = EndpointStatisticsPresentationCadence.delay(
+            for: .automatic,
+            lastCommitTime: 10,
+            nextAllowedTime: 10.6,
+            now: 10.1
+        )
+
+        #expect(abs(automaticDelay - 0.15) < 0.000_001)
+        #expect(explicitDelay == 0)
+        #expect(abs(backpressureDelay - 0.5) < 0.000_001)
+    }
+
     @Test func slowPresentationsReceiveABoundedCooldown() {
         #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.1) == 0)
         #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.5) == 0.5)

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsTablePresentationTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsTablePresentationTests.swift
@@ -1,0 +1,610 @@
+//
+//  EndpointStatisticsTablePresentationTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+import Testing
+@testable import TCPViewer
+
+struct EndpointStatisticsTablePresentationTests {
+    @Test func numericSortUsesRawValuesAndStableEndpointKeys() {
+        let rows = [
+            Self.makeRow(key: "charlie", address: "10.0.0.3", bytes: 40),
+            Self.makeRow(key: "bravo", address: "10.0.0.2", bytes: 90),
+            Self.makeRow(key: "alpha", address: "10.0.0.1", bytes: 90),
+        ]
+
+        let result = EndpointStatisticsTablePresenter.presentation(
+            rows: rows,
+            searchText: "",
+            sort: .busiestFirst
+        )
+
+        #expect(result.rows.map { $0.id.key } == ["alpha", "bravo", "charlie"])
+        #expect(result.totals.bytes == 220)
+    }
+
+    @Test func missingStringValuesStayLastInBothSortDirections() {
+        let rows = [
+            Self.makeRow(key: "missing", domain: nil),
+            Self.makeRow(key: "beta", domain: "beta.example"),
+            Self.makeRow(key: "alpha", domain: "alpha.example"),
+        ]
+
+        let ascending = EndpointStatisticsTablePresenter.presentation(
+            rows: rows,
+            searchText: "",
+            sort: EndpointStatisticsTableSort(column: .domain, isAscending: true)
+        )
+        let descending = EndpointStatisticsTablePresenter.presentation(
+            rows: rows,
+            searchText: "",
+            sort: EndpointStatisticsTableSort(column: .domain, isAscending: false)
+        )
+
+        #expect(ascending.rows.map { $0.id.key } == ["alpha", "beta", "missing"])
+        #expect(descending.rows.map { $0.id.key } == ["beta", "alpha", "missing"])
+    }
+
+    @Test func multiTermSearchMatchesAcrossDifferentIdentityColumns() {
+        let rows = [
+            Self.makeRow(
+                key: "one",
+                address: "93.184.216.34",
+                port: "443",
+                client: "Example Browser",
+                domain: "api.example.com"
+            ),
+            Self.makeRow(
+                key: "two",
+                address: "1.1.1.1",
+                port: "53",
+                client: "Resolver",
+                domain: "cloudflare-dns.com"
+            ),
+        ]
+
+        let result = EndpointStatisticsTablePresenter.presentation(
+            rows: rows,
+            searchText: "browser 443 API",
+            sort: .busiestFirst
+        )
+
+        #expect(result.rows.map { $0.id.key } == ["one"])
+        #expect(result.unfilteredRowCount == 2)
+    }
+
+    @Test func csvQuotesSpecialValuesAndProtectsFormulaAfterWhitespace() {
+        let row = Self.makeRow(
+            key: "formula",
+            client: "Browser, \"Beta\"",
+            domain: "  =SUM(A1:A2)",
+            bytes: 42
+        )
+
+        let csv = EndpointStatisticsTableExportFormatter.csv(
+            rows: [row],
+            columns: [.client, .domain, .bytes]
+        )
+
+        #expect(csv == "Client,Domain,Bytes\r\n\"Browser, \"\"Beta\"\"\",'  =SUM(A1:A2),42")
+    }
+
+    @Test func csvProtectsLeadingTabAndCarriageReturnFormulaBypasses() {
+        let tabRow = Self.makeRow(key: "tab", domain: "\tSUM(A1:A2)")
+        let carriageReturnRow = Self.makeRow(key: "return", domain: "\rSUM(A1:A2)")
+
+        let csv = EndpointStatisticsTableExportFormatter.csv(
+            rows: [tabRow, carriageReturnRow],
+            columns: [.domain]
+        )
+
+        #expect(csv == "Domain\r\n'\tSUM(A1:A2)\r\n\"'\rSUM(A1:A2)\"")
+    }
+
+    @Test func jsonUsesStableLowercaseKeysAndRawNumbers() throws {
+        let row = Self.makeRow(key: "json", domain: "api.example", bytes: 42, txPackets: 3)
+        let columns: [EndpointStatisticsTableColumn] = [.domain, .bytes, .txPackets]
+
+        let first = EndpointStatisticsTableExportFormatter.json(rows: [row], columns: columns)
+        let second = EndpointStatisticsTableExportFormatter.json(rows: [row], columns: columns)
+        let data = try #require(first.data(using: String.Encoding.utf8))
+        let objects = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let object = try #require(objects.first)
+
+        #expect(first == second)
+        #expect(Set(object.keys) == ["bytes", "domain", "tx_packets"])
+        #expect(object["domain"] as? String == "api.example")
+        #expect(object["bytes"] as? NSNumber == 42)
+        #expect(object["tx_packets"] as? NSNumber == 3)
+        #expect(!first.contains("\"42\""))
+    }
+
+    @Test func semanticCopySkipsAggregatePlaceholderValues() {
+        #expect(EndpointStatisticsSemanticCopyPolicy.copyableValue("api.example") == "api.example")
+        #expect(EndpointStatisticsSemanticCopyPolicy.copyableValue(
+            EndpointStatisticsRow.multipleValue
+        ) == EndpointStatisticsRow.multipleValue)
+        #expect(EndpointStatisticsSemanticCopyPolicy.copyableValue(
+            EndpointStatisticsRow.multipleValue,
+            isAggregatePlaceholder: true
+        ) == nil)
+        #expect(EndpointStatisticsSemanticCopyPolicy.copyableValue("") == nil)
+        #expect(EndpointStatisticsSemanticCopyPolicy.copyableValue(nil) == nil)
+    }
+
+    @Test func asyncExportCommitsOnlyWhileClipboardAndGenerationAreCurrent() {
+        let token = EndpointStatisticsExportCommitToken(
+            generation: 3,
+            pasteboardChangeCount: 12
+        )
+
+        #expect(EndpointStatisticsExportCommitPolicy.shouldCommit(
+            token,
+            currentGeneration: 3,
+            currentPasteboardChangeCount: 12
+        ))
+        #expect(!EndpointStatisticsExportCommitPolicy.shouldCommit(
+            token,
+            currentGeneration: 4,
+            currentPasteboardChangeCount: 12
+        ))
+        #expect(!EndpointStatisticsExportCommitPolicy.shouldCommit(
+            token,
+            currentGeneration: 3,
+            currentPasteboardChangeCount: 13
+        ))
+    }
+
+    @Test func selectionRestorationUsesThePresentedRowIndex() {
+        let rows = [
+            Self.makeRow(key: "alpha", bytes: 10),
+            Self.makeRow(key: "bravo", bytes: 30),
+            Self.makeRow(key: "charlie", bytes: 20),
+        ]
+        let selectedIDs = EndpointStatisticsSelectionRestoration.selectedRowIDs(
+            rows: rows,
+            selectedIndexes: IndexSet([0, 2])
+        )
+        let presentation = EndpointStatisticsTablePresenter.presentation(
+            rows: rows,
+            searchText: "",
+            sort: .busiestFirst
+        )
+
+        #expect(EndpointStatisticsSelectionRestoration.rowIndexes(
+            for: selectedIDs,
+            rowIndexByID: presentation.rowIndexByID
+        ) == IndexSet([1, 2]))
+        #expect(EndpointStatisticsSelectionRestoration.selectedRowIDs(
+            rows: rows,
+            selectedIndexes: []
+        ).isEmpty)
+        #expect(EndpointStatisticsSelectionRestoration.rowIndexes(
+            for: [],
+            rowIndexByID: presentation.rowIndexByID
+        ).isEmpty)
+    }
+
+    @Test func contextTargetKeepsEndpointAndColumnAcrossReorder() {
+        let alpha = Self.makeRow(key: "alpha", domain: "alpha.example", bytes: 10)
+        let bravo = Self.makeRow(key: "bravo", domain: "bravo.example", bytes: 30)
+        let context = EndpointStatisticsContextTarget(rowID: bravo.id, column: .domain)
+        let reordered = EndpointStatisticsTablePresenter.presentation(
+            rows: [alpha, bravo],
+            searchText: "",
+            sort: .busiestFirst
+        )
+
+        #expect(context.resolvedRowIndex(
+            rowIndexByID: reordered.rowIndexByID,
+            rowCount: reordered.rows.count
+        ) == 0)
+        #expect(context.column == .domain)
+        #expect(context.resolvedRowIndex(
+            rowIndexByID: [alpha.id: 0],
+            rowCount: 1
+        ) == nil)
+    }
+
+    @Test func rowSelectionResolvesSparseIndexesAndFormattingCanCancel() throws {
+        let rows = (0..<1_024).map { Self.makeRow(key: "row-\($0)", domain: "\($0).example") }
+        let selection = EndpointStatisticsRowSelection.indexes(IndexSet([1, 7, 1_500]))
+        let selectedRows = try #require(selection.resolvedRows(
+            from: rows,
+            cancellationToken: EndpointStatisticsCancellationToken()
+        ))
+
+        #expect(selectedRows.map { $0.id.key } == ["row-1", "row-7"])
+        #expect(EndpointStatisticsTableExportFormatter.csv(
+            rows: rows,
+            columns: [.domain],
+            cancellationToken: EndpointStatisticsCancellationToken(cancelAfterCheckCount: 0)
+        ) == nil)
+        #expect(EndpointStatisticsTableExportFormatter.json(
+            rows: rows,
+            columns: [.domain],
+            cancellationToken: EndpointStatisticsCancellationToken(cancelAfterCheckCount: 0)
+        ) == nil)
+        #expect(EndpointStatisticsSemanticValueFormatter.joinedValues(
+            rows: rows,
+            field: .domain,
+            cancellationToken: EndpointStatisticsCancellationToken(cancelAfterCheckCount: 0)
+        ) == nil)
+    }
+
+    @Test func semanticValueFormattingDeduplicatesOffMainAndUsesMultiplicityFlags() {
+        let rows = [
+            Self.makeRow(key: "literal", client: EndpointStatisticsRow.multipleValue),
+            Self.makeRow(
+                key: "aggregate",
+                client: EndpointStatisticsRow.multipleValue,
+                isClientMultiple: true
+            ),
+            Self.makeRow(key: "browser-a", client: "Browser"),
+            Self.makeRow(key: "browser-b", client: "Browser"),
+        ]
+
+        let value = EndpointStatisticsSemanticValueFormatter.joinedValues(
+            rows: rows,
+            field: .client,
+            cancellationToken: EndpointStatisticsCancellationToken()
+        )
+
+        #expect(value == "Multiple\nBrowser")
+    }
+
+    @Test func semanticSelectionEnablementScansIndexesWithoutMaterializingRows() {
+        let rows = [
+            Self.makeRow(key: "missing", client: nil),
+            Self.makeRow(key: "aggregate", client: "Multiple", isClientMultiple: true),
+            Self.makeRow(key: "copyable", client: "Browser"),
+        ]
+
+        #expect(!EndpointStatisticsRowSelection.indexes(IndexSet([0, 1])).containsCopyableValue(
+            in: rows,
+            field: .client
+        ))
+        #expect(EndpointStatisticsRowSelection.indexes(IndexSet([0, 2])).containsCopyableValue(
+            in: rows,
+            field: .client
+        ))
+    }
+
+    @Test func largeFormattersStopAfterMidLoopCancellation() {
+        let rows = (0..<1_024).map { Self.makeRow(key: "row-\($0)", domain: "\($0).example") }
+
+        #expect(EndpointStatisticsTableExportFormatter.csv(
+            rows: rows,
+            columns: [.domain, .bytes],
+            cancellationToken: EndpointStatisticsCancellationToken(cancelAfterCheckCount: 2)
+        ) == nil)
+        #expect(EndpointStatisticsTableExportFormatter.json(
+            rows: rows,
+            columns: [.domain, .bytes],
+            cancellationToken: EndpointStatisticsCancellationToken(cancelAfterCheckCount: 2)
+        ) == nil)
+        #expect(EndpointStatisticsSemanticValueFormatter.joinedValues(
+            rows: rows,
+            field: .domain,
+            cancellationToken: EndpointStatisticsCancellationToken(cancelAfterCheckCount: 2)
+        ) == nil)
+    }
+}
+
+struct EndpointStatisticsPresentationCommitPolicyTests {
+    @Test func slowPresentationsReceiveABoundedCooldown() {
+        #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.1) == 0)
+        #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.5) == 0.5)
+        #expect(EndpointStatisticsPresentationCadence.cooldown(after: 5) == 2)
+    }
+
+    @Test func footerAddsUnclassifiedBytesOnlyWhenPresent() {
+        var totals = EndpointStatisticsTotals.zero
+        totals.bytes = 80
+        totals.txBytes = 30
+        totals.rxBytes = 20
+
+        let knownDirection = EndpointStatisticsFooterFormatter.trafficParts(
+            totals: totals,
+            formatBytes: { "\($0) B" }
+        )
+        totals.unclassifiedBytes = 30
+        let mixedDirection = EndpointStatisticsFooterFormatter.trafficParts(
+            totals: totals,
+            formatBytes: { "\($0) B" }
+        )
+
+        #expect(knownDirection == ["80 B", "Tx 30 B", "Rx 20 B"])
+        #expect(mixedDirection == ["80 B", "Tx 30 B", "Rx 20 B", "Unclassified 30 B"])
+    }
+
+    @Test func continuousAllPacketAppendsCommitThenRequestAFresherResult() {
+        let context = Self.context(usesDisplayedPackets: false)
+
+        let decision = EndpointStatisticsPresentationCommitPolicy.decision(
+            requestContext: context,
+            currentContext: context,
+            requestIngestCursor: Self.cursor(revision: 1, lineage: 7, count: 10),
+            currentIngestCursor: Self.cursor(revision: 9, lineage: 7, count: 90),
+            requestDisplayedCursor: nil,
+            currentDisplayedCursor: nil,
+            requestClassificationRevision: 1,
+            currentClassificationRevision: 1,
+            isWaitingForDisplayFilter: false
+        )
+
+        #expect(decision == .commitAndRefresh)
+    }
+
+    @Test func displayedPresentationIgnoresUnrelatedRawIngestUpdates() {
+        let context = Self.context(usesDisplayedPackets: true)
+        let displayedCursor = Self.cursor(revision: 3, lineage: 4, count: 20)
+
+        let decision = EndpointStatisticsPresentationCommitPolicy.decision(
+            requestContext: context,
+            currentContext: context,
+            requestIngestCursor: Self.cursor(revision: 1, lineage: 7, count: 10),
+            currentIngestCursor: Self.cursor(revision: 9, lineage: 7, count: 90),
+            requestDisplayedCursor: displayedCursor,
+            currentDisplayedCursor: displayedCursor,
+            requestClassificationRevision: 1,
+            currentClassificationRevision: 1,
+            isWaitingForDisplayFilter: false
+        )
+
+        #expect(decision == .commit)
+    }
+
+    @Test func replacementLineageAndQueryChangesDiscardOldResults() {
+        let requestContext = Self.context(usesDisplayedPackets: true)
+        let changedContext = Self.context(usesDisplayedPackets: true, group: .domains)
+
+        let changedLineage = EndpointStatisticsPresentationCommitPolicy.decision(
+            requestContext: requestContext,
+            currentContext: requestContext,
+            requestIngestCursor: nil,
+            currentIngestCursor: nil,
+            requestDisplayedCursor: Self.cursor(revision: 1, lineage: 1, count: 10),
+            currentDisplayedCursor: Self.cursor(revision: 2, lineage: 2, count: 10),
+            requestClassificationRevision: 1,
+            currentClassificationRevision: 1,
+            isWaitingForDisplayFilter: false
+        )
+        let changedQuery = EndpointStatisticsPresentationCommitPolicy.decision(
+            requestContext: requestContext,
+            currentContext: changedContext,
+            requestIngestCursor: nil,
+            currentIngestCursor: nil,
+            requestDisplayedCursor: Self.cursor(revision: 1, lineage: 1, count: 10),
+            currentDisplayedCursor: Self.cursor(revision: 1, lineage: 1, count: 10),
+            requestClassificationRevision: 1,
+            currentClassificationRevision: 1,
+            isWaitingForDisplayFilter: false
+        )
+
+        #expect(changedLineage == .discard)
+        #expect(changedQuery == .discard)
+    }
+
+    @Test func rowActionsRequireTheCommittedGroupScopeAndLineage() {
+        let committed = EndpointStatisticsActionState(
+            context: Self.context(usesDisplayedPackets: false),
+            classificationRevision: 1
+        )
+        let changedGroup = EndpointStatisticsActionState(
+            context: Self.context(usesDisplayedPackets: false, group: .domains),
+            classificationRevision: 1
+        )
+
+        #expect(EndpointStatisticsRowActionPolicy.isEnabled(
+            committedState: committed,
+            currentState: committed,
+            isWaitingForDisplayFilter: false
+        ))
+        #expect(!EndpointStatisticsRowActionPolicy.isEnabled(
+            committedState: committed,
+            currentState: changedGroup,
+            isWaitingForDisplayFilter: false
+        ))
+        #expect(!EndpointStatisticsRowActionPolicy.isEnabled(
+            committedState: committed,
+            currentState: committed,
+            isWaitingForDisplayFilter: true
+        ))
+    }
+
+    @Test func metadataReclassificationDiscardsOldDomainPresentationAndActions() {
+        let context = Self.context(usesDisplayedPackets: false)
+        let decision = EndpointStatisticsPresentationCommitPolicy.decision(
+            requestContext: context,
+            currentContext: context,
+            requestIngestCursor: Self.cursor(revision: 1, lineage: 7, count: 1),
+            currentIngestCursor: Self.cursor(revision: 2, lineage: 7, count: 1),
+            requestDisplayedCursor: nil,
+            currentDisplayedCursor: nil,
+            requestClassificationRevision: 3,
+            currentClassificationRevision: 4,
+            isWaitingForDisplayFilter: false
+        )
+        let oldDomainState = EndpointStatisticsActionState(
+            context: context,
+            classificationRevision: 3
+        )
+        let newDomainState = EndpointStatisticsActionState(
+            context: context,
+            classificationRevision: 4
+        )
+
+        #expect(decision == .discard)
+        #expect(!EndpointStatisticsRowActionPolicy.isEnabled(
+            committedState: oldDomainState,
+            currentState: newDomainState,
+            isWaitingForDisplayFilter: false
+        ))
+    }
+
+    @Test func largeTablesStopAutomaticRefreshUntilAnExplicitRequest() {
+        var policy = EndpointStatisticsAutomaticRefreshPolicy()
+        #expect(policy.accepts(.automatic))
+
+        policy.didCommit(
+            unfilteredEndpointCount: EndpointStatisticsAutomaticRefreshPolicy.maximumLiveEndpointCount + 1
+        )
+
+        for _ in 0..<1_000 {
+            #expect(!policy.accepts(.automatic))
+        }
+        #expect(policy.accepts(.explicit))
+    }
+
+    @Test func pendingExplicitIntentOutranksFinalAutomaticDrainCallback() {
+        #expect(EndpointStatisticsPresentationIntent.automatic.merging(.explicit) == .explicit)
+        #expect(EndpointStatisticsPresentationIntent.explicit.merging(.automatic) == .explicit)
+        #expect(EndpointStatisticsPresentationIntent.automatic.merging(nil) == .automatic)
+    }
+
+    @Test func displayedRecoveryIntentIsConsumedBeforeALaterUnrelatedOverflow() {
+        var state = EndpointStatisticsDisplayedReplacementRecoveryState(
+            isPaused: false,
+            pendingSourceReplacement: true
+        )
+
+        state.replacementWasAccepted()
+
+        #expect(!state.isPaused)
+        #expect(!state.shouldResumeAutomatically)
+
+        state.pauseForOverflow()
+
+        #expect(state.isPaused)
+        #expect(!state.shouldResumeAutomatically)
+
+        state.pendingSourceReplacement = true
+        #expect(state.shouldResumeAutomatically)
+    }
+
+    @Test func presenterStopsSearchAndSortWhenCancelled() {
+        let rows = (0..<2_000).map { index in
+            EndpointStatisticsTablePresentationTests.makeRow(
+                key: "endpoint-\(index)",
+                domain: "\(index).example",
+                bytes: UInt64(index)
+            )
+        }
+        let token = EndpointStatisticsCancellationToken(cancelAfterCheckCount: 2)
+
+        let result = EndpointStatisticsTablePresenter.presentation(
+            rows: rows,
+            searchText: "example",
+            sort: .busiestFirst,
+            cancellationToken: token
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func classificationRevisionAdvancesForMetadataButNotPureAppends() {
+        var pipeline = EndpointStatisticsScopeUpdatePipeline()
+        let replacement = EndpointStatisticsIngestUpdate(
+            packetRevision: 1,
+            packetLineageRevision: 1,
+            totalPacketCount: 0,
+            kind: .replace([])
+        )
+        guard case .drain = pipeline.enqueue(replacement) else {
+            Issue.record("Expected the replacement to start a drain.")
+            return
+        }
+        _ = pipeline.drainCompleted(result: .consumed)
+        #expect(pipeline.latestClassificationRevision == 1)
+        #expect(pipeline.consumedClassificationRevision == 1)
+
+        let append = EndpointStatisticsIngestUpdate(
+            packetRevision: 2,
+            packetLineageRevision: 1,
+            totalPacketCount: 0,
+            kind: .append([])
+        )
+        _ = pipeline.enqueue(append)
+        #expect(pipeline.latestClassificationRevision == 1)
+
+        let metadata = EndpointStatisticsIngestUpdate(
+            packetRevision: 3,
+            packetLineageRevision: 1,
+            totalPacketCount: 0,
+            kind: .metadata([])
+        )
+        _ = pipeline.enqueue(metadata)
+        #expect(pipeline.latestClassificationRevision == 2)
+    }
+}
+
+private extension EndpointStatisticsPresentationCommitPolicyTests {
+    static func context(
+        usesDisplayedPackets: Bool,
+        group: EndpointStatisticsGroup = .apps
+    ) -> EndpointStatisticsPresentationContext {
+        EndpointStatisticsPresentationContext(
+            usesDisplayedPackets: usesDisplayedPackets,
+            sourceIdentity: EndpointStatisticsSourceIdentity(
+                backingIdentity: "capture-a",
+                packetLineageRevision: 7
+            ),
+            group: group,
+            searchText: "",
+            sort: .busiestFirst
+        )
+    }
+
+    static func cursor(
+        revision: UInt64,
+        lineage: UInt64,
+        count: Int
+    ) -> EndpointStatisticsIngestCursor {
+        EndpointStatisticsIngestCursor(
+            packetRevision: revision,
+            packetLineageRevision: lineage,
+            totalPacketCount: count
+        )
+    }
+}
+
+private extension EndpointStatisticsTablePresentationTests {
+    static func makeRow(
+        key: String,
+        address: String? = nil,
+        port: String? = nil,
+        protocolName: String? = "TCP",
+        client: String? = nil,
+        domain: String? = nil,
+        isClientMultiple: Bool = false,
+        packets: UInt64 = 1,
+        bytes: UInt64 = 0,
+        txPackets: UInt64 = 0,
+        txBytes: UInt64 = 0,
+        rxPackets: UInt64 = 0,
+        rxBytes: UInt64 = 0
+    ) -> EndpointStatisticsRow {
+        EndpointStatisticsRow(
+            id: EndpointStatisticsRowID(group: .tcp, key: key),
+            address: address,
+            port: port,
+            protocolName: protocolName,
+            client: client,
+            domain: domain,
+            isClientMultiple: isClientMultiple,
+            packets: packets,
+            bytes: bytes,
+            txPackets: txPackets,
+            txBytes: txBytes,
+            rxPackets: rxPackets,
+            rxBytes: rxBytes,
+            unclassifiedPackets: 0,
+            unclassifiedBytes: 0
+        )
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsTablePresentationTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsTablePresentationTests.swift
@@ -316,14 +316,15 @@ struct EndpointStatisticsPresentationCommitPolicyTests {
             now: 10.1
         )
 
-        #expect(abs(automaticDelay - 0.15) < 0.000_001)
+        #expect(abs(automaticDelay - 0.4) < 0.000_001)
         #expect(explicitDelay == 0)
         #expect(abs(backpressureDelay - 0.5) < 0.000_001)
     }
 
     @Test func slowPresentationsReceiveABoundedCooldown() {
         #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.1) == 0)
-        #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.5) == 0.5)
+        #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.5) == 0)
+        #expect(EndpointStatisticsPresentationCadence.cooldown(after: 0.75) == 0.75)
         #expect(EndpointStatisticsPresentationCadence.cooldown(after: 5) == 2)
     }
 

--- a/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsUpdateDrainCoordinatorTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/EndpointStatisticsUpdateDrainCoordinatorTests.swift
@@ -1,0 +1,197 @@
+//
+//  EndpointStatisticsUpdateDrainCoordinatorTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 1/9/26.
+//
+
+import Foundation
+import PcapPlusPlusCore
+import Testing
+@testable import TCPViewer
+
+struct EndpointStatisticsUpdateDrainCoordinatorTests {
+    @Test func sequentialDeltasCoalesceIntoOneRevisionSpanningDrain() throws {
+        let service = EndpointStatisticsService()
+        #expect(service.consume(Self.update(revision: 1, totalCount: 1, kind: .replace([Self.packet(id: 1)]))))
+        var coordinator = EndpointStatisticsUpdateDrainCoordinator(maximumPendingPacketCount: 10)
+
+        let firstAction = coordinator.enqueue(Self.update(
+            revision: 2,
+            totalCount: 2,
+            kind: .append([Self.packet(id: 2)])
+        ))
+        let firstUpdate = try Self.drainUpdate(from: firstAction)
+        #expect(service.consume(firstUpdate))
+
+        let metadataPacket = Self.packet(id: 1, domain: "api.example")
+        #expect(Self.isNone(coordinator.enqueue(Self.update(
+            revision: 3,
+            totalCount: 2,
+            kind: .metadata([metadataPacket])
+        ))))
+        #expect(Self.isNone(coordinator.enqueue(Self.update(
+            revision: 4,
+            totalCount: 3,
+            kind: .append([Self.packet(id: 3)])
+        ))))
+
+        let coalesced = try Self.drainUpdate(from: coordinator.drainCompleted(didConsume: true))
+        #expect(coalesced.previousPacketRevision == 2)
+        #expect(coalesced.packetRevision == 4)
+        #expect(coalesced.totalPacketCount == 3)
+        guard case .appendWithMetadata(let newPackets, let updatedPackets) = coalesced.kind else {
+            Issue.record("Expected coalesced append and metadata payloads.")
+            return
+        }
+        #expect(newPackets.map(\.id) == [3])
+        #expect(updatedPackets.map(\.id) == [1])
+        #expect(service.consume(coalesced))
+        #expect(service.currentSnapshot(for: .domains).rows.first?.domain == "api.example")
+        #expect(Self.isNone(coordinator.drainCompleted(didConsume: true)))
+        #expect(!coordinator.isDrainInFlight)
+    }
+
+    @Test func overloadPausesWithoutRebuildLoopUntilManualReplacementResumes() throws {
+        let service = EndpointStatisticsService()
+        var coordinator = EndpointStatisticsUpdateDrainCoordinator(maximumPendingPacketCount: 2)
+        let baseline = try Self.drainUpdate(from: coordinator.enqueue(Self.update(
+            revision: 1,
+            totalCount: 1,
+            kind: .replace([Self.packet(id: 1)])
+        )))
+        #expect(service.consume(baseline))
+        let oversizedPackets = (2...10_001).map { Self.packet(id: UInt64($0)) }
+
+        #expect(Self.isPaused(coordinator.enqueue(Self.update(
+            revision: 2,
+            totalCount: 10_001,
+            kind: .append(oversizedPackets)
+        ))))
+        #expect(coordinator.retainedPendingPacketCount == 0)
+        #expect(coordinator.isPaused)
+        #expect(Self.isPaused(coordinator.drainCompleted(didConsume: true)))
+
+        for revision in 3...1_002 {
+            #expect(Self.isNone(coordinator.enqueue(Self.update(
+                revision: UInt64(revision),
+                totalCount: 10_000 + revision - 1,
+                kind: .append([Self.packet(id: UInt64(20_000 + revision))])
+            ))))
+        }
+        #expect(coordinator.retainedPendingPacketCount == 0)
+        #expect(service.debugSnapshot().fullRebuildCount == 1)
+
+        let droppedPackets = (3...1_002).map { revision in
+            Self.packet(id: UInt64(20_000 + revision))
+        }
+        let latestPackets = [Self.packet(id: 1)] + oversizedPackets + droppedPackets
+        let replacement = Self.update(
+            revision: 1_002,
+            totalCount: latestPackets.count,
+            kind: .replace(latestPackets)
+        )
+        let resumedUpdate = try Self.drainUpdate(from: coordinator.resume(withReplacement: replacement))
+        #expect(service.consume(resumedUpdate))
+        #expect(Self.isNone(coordinator.drainCompleted(didConsume: true)))
+        #expect(service.debugSnapshot().fullRebuildCount == 2)
+        #expect(service.currentSnapshot(for: .ipv4).footerTotals.packets == 11_001)
+        #expect(!coordinator.isPaused)
+        let nextAppend = try Self.drainUpdate(from: coordinator.enqueue(Self.update(
+            revision: 1_003,
+            totalCount: 11_002,
+            kind: .append([Self.packet(id: 30_000)])
+        )))
+        #expect(nextAppend.totalPacketCount == 11_002)
+        #expect(service.consume(nextAppend))
+        #expect(Self.isNone(coordinator.drainCompleted(didConsume: true)))
+        #expect(service.currentSnapshot(for: .ipv4).footerTotals.packets == 11_002)
+        #expect(!coordinator.isDrainInFlight)
+        #expect(coordinator.retainedPendingPacketCount == 0)
+    }
+
+    @Test func rejectedDrainDropsPendingWorkAndPauses() throws {
+        var coordinator = EndpointStatisticsUpdateDrainCoordinator(maximumPendingPacketCount: 10)
+        _ = try Self.drainUpdate(from: coordinator.enqueue(Self.update(
+            revision: 1,
+            totalCount: 1,
+            kind: .replace([Self.packet(id: 1)])
+        )))
+        #expect(Self.isNone(coordinator.enqueue(Self.update(
+            revision: 2,
+            totalCount: 2,
+            kind: .append([Self.packet(id: 2)])
+        ))))
+
+        #expect(Self.isPaused(coordinator.drainCompleted(didConsume: false)))
+        #expect(!coordinator.isDrainInFlight)
+        #expect(coordinator.isPaused)
+        #expect(coordinator.retainedPendingPacketCount == 0)
+    }
+}
+
+private extension EndpointStatisticsUpdateDrainCoordinatorTests {
+    static func update(
+        revision: UInt64,
+        totalCount: Int,
+        kind: EndpointStatisticsIngestUpdate.Kind
+    ) -> EndpointStatisticsIngestUpdate {
+        EndpointStatisticsIngestUpdate(
+            packetRevision: revision,
+            packetLineageRevision: 1,
+            totalPacketCount: totalCount,
+            kind: kind
+        )
+    }
+
+    static func drainUpdate(
+        from action: EndpointStatisticsUpdateDrainCoordinator.Action
+    ) throws -> EndpointStatisticsIngestUpdate {
+        guard case .drain(let update) = action else {
+            Issue.record("Expected a drain action.")
+            throw CoordinatorTestError.missingDrain
+        }
+        return update
+    }
+
+    static func isNone(_ action: EndpointStatisticsUpdateDrainCoordinator.Action) -> Bool {
+        if case .none = action {
+            return true
+        }
+        return false
+    }
+
+    static func isPaused(_ action: EndpointStatisticsUpdateDrainCoordinator.Action) -> Bool {
+        if case .paused = action {
+            return true
+        }
+        return false
+    }
+
+    static func packet(id: UInt64, domain: String? = nil) -> PacketSummary {
+        PacketSummary(
+            id: id,
+            packetNumber: id,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(id)),
+            source: .live,
+            interfaceID: "en0",
+            transportHint: .tcp,
+            endpoints: PacketEndpoints(
+                source: PacketEndpoint(address: "10.0.0.2", port: 51_000),
+                destination: PacketEndpoint(address: "93.184.216.34", port: 443)
+            ),
+            originalLength: 128,
+            capturedLength: 128,
+            direction: .outbound,
+            infoSummary: "Packet \(id)",
+            layers: [PacketLayer(name: "IPv4"), PacketLayer(name: "TCP")],
+            decodeStatus: PacketDecodeStatus(kind: .complete),
+            captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
+            sniDomainName: domain
+        )
+    }
+
+    enum CoordinatorTestError: Error {
+        case missingDrain
+    }
+}

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1853,8 +1853,8 @@ struct NetworkInspectorViewModelTests {
         controller.loadViewIfNeeded()
         controller.render(snapshot: snapshot)
 
-        let labels = allSubviews(ofType: NSTextField.self, in: controller.view).map(\.stringValue)
-        #expect(labels.contains("No traffic captured yet."))
+        #expect(controller.isSwiftUIHostedForTesting)
+        #expect(controller.showsNoTrafficStateForTesting)
         #expect(allSubviews(ofType: NSProgressIndicator.self, in: controller.view).isEmpty)
     }
 

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1819,27 +1819,11 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.isInspectorVisible)
     }
 
-    @Test func overviewEndpointActionForcesTheExistingWindowToAllPackets() throws {
-        let defaults = isolatedDefaults()
-        let controller = EndpointStatisticsWindowController(
-            configuration: AppConfiguration(defaults: defaults),
-            packetProvider: { _ in [] },
-            showRelatedPackets: { _ in }
-        )
-        defer { controller.close() }
-        let displayedOnlyCheckbox = try #require(
-            controller.window?.toolbar?.items.compactMap { $0.view as? NSButton }.first {
-                $0.title == "Displayed packets only"
-            }
-        )
-        displayedOnlyCheckbox.state = .on
-
-        controller.present(title: "Endpoints", forceAllPackets: true)
-
-        #expect(displayedOnlyCheckbox.state == .off)
+    @Test func endpointStatisticsUsesTheLargerDefaultContentSize() {
+        #expect(EndpointStatisticsWindowController.defaultContentSize == NSSize(width: 1_440, height: 820))
     }
 
-    @Test func endpointStatisticsUsesTheWindowToolbarForCommonControls() throws {
+    @Test func endpointStatisticsToolbarOnlyShowsEndpointTypesAndSearch() throws {
         let controller = EndpointStatisticsWindowController(
             configuration: AppConfiguration(defaults: isolatedDefaults()),
             packetProvider: { _ in [] },
@@ -1848,19 +1832,22 @@ struct NetworkInspectorViewModelTests {
         defer { controller.close() }
         let toolbar = try #require(controller.window?.toolbar)
         let identifiers = toolbar.items.map(\.itemIdentifier.rawValue)
+        let endpointIdentifiers = identifiers.filter { $0.hasPrefix("TCPViewer.EndpointStatistics") }
 
-        #expect(identifiers.contains("TCPViewer.EndpointStatistics.endpointTypes"))
-        #expect(identifiers.contains("TCPViewer.EndpointStatistics.displayedPackets"))
-        #expect(identifiers.contains("TCPViewer.EndpointStatistics.showPackets"))
-        #expect(identifiers.contains("TCPViewer.EndpointStatistics.copy"))
-        #expect(identifiers.contains("TCPViewer.EndpointStatistics.search"))
+        #expect(endpointIdentifiers == [
+            "TCPViewer.EndpointStatistics.endpointTypes",
+            "TCPViewer.EndpointStatistics.search",
+        ])
+        #expect(toolbar.centeredItemIdentifiers == [
+            NSToolbarItem.Identifier("TCPViewer.EndpointStatistics.endpointTypes"),
+        ])
 
         let endpointTypes = try #require(
             toolbar.items.compactMap { $0.view as? NSSegmentedControl }.first
         )
         #expect(endpointTypes.segmentCount == EndpointStatisticsGroup.allCases.count)
         #expect(toolbar.items.contains { $0 is NSSearchToolbarItem })
-        #expect(toolbar.items.contains { $0 is NSMenuToolbarItem })
+        #expect(!toolbar.items.contains { $0 is NSMenuToolbarItem })
     }
 
     @Test func emptyOverviewShowsNoTrafficStateWithoutACalculatingSpinner() {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -15,6 +15,56 @@ import PcapPlusPlusCore
 @MainActor
 struct NetworkInspectorViewModelTests {
 
+    @Test func overviewPacketActionsPreserveNormalFiltersAndClearEndpointDrillDown() async {
+        let client = PacketClient(
+            pid: 123,
+            name: "Browser",
+            displayName: "Browser",
+            executablePath: "/Applications/Browser.app/Contents/MacOS/Browser",
+            bundleIdentifier: "com.example.browser",
+            bundlePath: "/Applications/Browser.app"
+        )
+        let packet = makePacket(
+            packetNumber: 1,
+            source: .offline,
+            transportHint: .tcp,
+            sniDomainName: "example.com",
+            client: client,
+            direction: .outbound
+        )
+        let viewModel = makeOfflineViewModel(packets: [packet])
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/overview-actions.pcapng"))
+        await waitUntil { viewModel.snapshot.totalPacketCount == 1 }
+        viewModel.updateDisplayFilterText("protocol:tcp")
+        viewModel.toggleQuickFilter(.tcp)
+        viewModel.updateSourceListFilterText("hidden")
+        viewModel.showRelatedPackets(forEndpoint: EndpointStatisticsRowID(group: .tcp, key: "10.0.0.1:1234"))
+
+        viewModel.selectWorkspaceMode(.overview)
+        #expect(viewModel.snapshot.workspaceMode == .overview)
+        #expect(viewModel.snapshot.endpointStatisticsFilterLabel != nil)
+
+        viewModel.showPacketsFromOverview()
+        #expect(viewModel.snapshot.workspaceMode == .packets)
+        #expect(viewModel.snapshot.selectedSourceListSelection == .allPackets)
+        #expect(viewModel.snapshot.endpointStatisticsFilterLabel == nil)
+        #expect(viewModel.snapshot.displayFilterText == "protocol:tcp")
+        #expect(viewModel.snapshot.quickFilterSelection.contains(.tcp))
+
+        viewModel.updateSourceListFilterText("hidden")
+        viewModel.showRelatedPackets(forEndpoint: EndpointStatisticsRowID(group: .tcp, key: "10.0.0.1:1234"))
+        viewModel.selectWorkspaceMode(.overview)
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.browser")
+        viewModel.showSourceListSelectionFromOverview(.app(appKey))
+
+        #expect(viewModel.snapshot.workspaceMode == .packets)
+        #expect(viewModel.snapshot.selectedSourceListSelection == .app(appKey))
+        #expect(viewModel.snapshot.sourceListFilterText.isEmpty)
+        #expect(viewModel.snapshot.endpointStatisticsFilterLabel == nil)
+        #expect(viewModel.snapshot.displayFilterText == "protocol:tcp")
+        #expect(viewModel.snapshot.quickFilterSelection.contains(.tcp))
+    }
+
     @Test func liveCaptureBuildsPacketRowsSelectionAndFilters() async {
         let packet = makePacket(
             packetNumber: 1,
@@ -1732,6 +1782,80 @@ struct NetworkInspectorViewModelTests {
 
         #expect(hiddenReloadedViewModel.snapshot.inspectorPlacement == .bottom)
         #expect(!hiddenReloadedViewModel.snapshot.isInspectorVisible)
+    }
+
+    @Test func overviewReplacesPacketWorkspaceAndRestoresInspectorPreference() async {
+        let defaults = isolatedDefaults()
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")]
+            )),
+            userDefaults: defaults
+        )
+        let controller = TCPViewerRootViewController(
+            viewModel: viewModel,
+            configuration: AppConfiguration(defaults: defaults)
+        )
+        let window = NSWindow(contentViewController: controller)
+        defer { window.close() }
+        controller.loadViewIfNeeded()
+
+        viewModel.selectWorkspaceMode(.overview)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(viewModel.snapshot.isInspectorVisible)
+        #expect(controller.isOverviewWorkspaceVisibleForTesting)
+        #expect(!controller.isPacketWorkspaceVisibleForTesting)
+        #expect(controller.isInspectorCollapsedForTesting)
+        #expect(!controller.isMainEmptyStateVisibleForTesting)
+
+        viewModel.showPacketsFromOverview()
+        await waitUntil {
+            controller.isPacketWorkspaceVisibleForTesting &&
+                !controller.isOverviewWorkspaceVisibleForTesting &&
+                !controller.isInspectorCollapsedForTesting
+        }
+
+        #expect(viewModel.snapshot.isInspectorVisible)
+    }
+
+    @Test func overviewEndpointActionForcesTheExistingWindowToAllPackets() throws {
+        let defaults = isolatedDefaults()
+        let controller = EndpointStatisticsWindowController(
+            configuration: AppConfiguration(defaults: defaults),
+            packetProvider: { _ in [] },
+            showRelatedPackets: { _ in }
+        )
+        defer { controller.close() }
+        let contentView = try #require(controller.window?.contentViewController?.view)
+        let displayedOnlyCheckbox = try #require(
+            allSubviews(ofType: NSButton.self, in: contentView).first {
+                $0.title == "Displayed packets only"
+            }
+        )
+        displayedOnlyCheckbox.state = .on
+
+        controller.present(title: "Endpoints", forceAllPackets: true)
+
+        #expect(displayedOnlyCheckbox.state == .off)
+    }
+
+    @Test func emptyOverviewShowsNoTrafficStateWithoutACalculatingSpinner() {
+        var snapshot = makeInspectorSnapshot(
+            packets: [],
+            selectedPacketID: nil,
+            generation: 0,
+            updatePlan: .none
+        )
+        snapshot.workspaceMode = .overview
+        let controller = CaptureOverviewViewController(latestIngestStateProvider: { .empty })
+
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: snapshot)
+
+        let labels = allSubviews(ofType: NSTextField.self, in: controller.view).map(\.stringValue)
+        #expect(labels.contains("No traffic captured yet."))
+        #expect(allSubviews(ofType: NSProgressIndicator.self, in: controller.view).isEmpty)
     }
 
     @Test func bottomInspectorPlacementLaysOutInspectorBelowWorkspace() async throws {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1827,9 +1827,8 @@ struct NetworkInspectorViewModelTests {
             showRelatedPackets: { _ in }
         )
         defer { controller.close() }
-        let contentView = try #require(controller.window?.contentViewController?.view)
         let displayedOnlyCheckbox = try #require(
-            allSubviews(ofType: NSButton.self, in: contentView).first {
+            controller.window?.toolbar?.items.compactMap { $0.view as? NSButton }.first {
                 $0.title == "Displayed packets only"
             }
         )
@@ -1838,6 +1837,30 @@ struct NetworkInspectorViewModelTests {
         controller.present(title: "Endpoints", forceAllPackets: true)
 
         #expect(displayedOnlyCheckbox.state == .off)
+    }
+
+    @Test func endpointStatisticsUsesTheWindowToolbarForCommonControls() throws {
+        let controller = EndpointStatisticsWindowController(
+            configuration: AppConfiguration(defaults: isolatedDefaults()),
+            packetProvider: { _ in [] },
+            showRelatedPackets: { _ in }
+        )
+        defer { controller.close() }
+        let toolbar = try #require(controller.window?.toolbar)
+        let identifiers = toolbar.items.map(\.itemIdentifier.rawValue)
+
+        #expect(identifiers.contains("TCPViewer.EndpointStatistics.endpointTypes"))
+        #expect(identifiers.contains("TCPViewer.EndpointStatistics.displayedPackets"))
+        #expect(identifiers.contains("TCPViewer.EndpointStatistics.showPackets"))
+        #expect(identifiers.contains("TCPViewer.EndpointStatistics.copy"))
+        #expect(identifiers.contains("TCPViewer.EndpointStatistics.search"))
+
+        let endpointTypes = try #require(
+            toolbar.items.compactMap { $0.view as? NSSegmentedControl }.first
+        )
+        #expect(endpointTypes.segmentCount == EndpointStatisticsGroup.allCases.count)
+        #expect(toolbar.items.contains { $0 is NSSearchToolbarItem })
+        #expect(toolbar.items.contains { $0 is NSMenuToolbarItem })
     }
 
     @Test func emptyOverviewShowsNoTrafficStateWithoutACalculatingSpinner() {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1846,7 +1846,8 @@ struct NetworkInspectorViewModelTests {
             toolbar.items.compactMap { $0.view as? NSSegmentedControl }.first
         )
         #expect(endpointTypes.segmentCount == EndpointStatisticsGroup.allCases.count)
-        #expect(toolbar.items.contains { $0 is NSSearchToolbarItem })
+        let searchItem = try #require(toolbar.items.compactMap { $0 as? NSSearchToolbarItem }.first)
+        #expect(searchItem.searchField.placeholderString == "Search endpoints (⌘F)")
         #expect(!toolbar.items.contains { $0 is NSMenuToolbarItem })
     }
 

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -1960,6 +1960,10 @@ struct NetworkInspectorViewModelTests {
         #expect(controller.isMainEmptyStateVisibleForTesting)
         #expect(controller.isContentSplitViewHiddenForTesting)
 
+        controller.simulateInitialSplitVisibilityRestoreForTesting()
+        #expect(controller.isMainEmptyStateVisibleForTesting)
+        #expect(controller.isContentSplitViewHiddenForTesting)
+
         await viewModel.openDocument(at: document.currentURL())
         await waitUntil {
             viewModel.snapshot.totalPacketCount == 1 &&

--- a/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketSourceListServiceTests.swift
@@ -17,10 +17,13 @@ struct PacketSourceListServiceTests {
         let service = PacketSourceListService()
         let snapshot = service.snapshot(for: .empty)
 
-        #expect(snapshot.roots.map(\.title) == ["Favorites", "All"])
-        #expect(snapshot.roots[0].children.map(\.title) == ["Pinned", "Saved"])
+        #expect(snapshot.roots.map(\.title) == ["Capture", "Favorites", "All"])
+        #expect(snapshot.roots[0].children.map(\.title) == ["Overview"])
+        #expect(snapshot.roots[0].children[0].workspaceMode == .overview)
+        #expect(snapshot.roots[0].children[0].count == nil)
+        #expect(snapshot.roots[1].children.map(\.title) == ["Pinned", "Saved"])
         #expect(snapshot.firstItem { $0.id == PacketSourceListTreeBuilder.filesGroupID } == nil)
-        #expect(snapshot.roots[1].children.map(\.title) == ["Apps", "Domains"])
+        #expect(snapshot.roots[2].children.map(\.title) == ["Apps", "Domains"])
         #expect(snapshot.item(for: .apps)?.children.isEmpty == true)
         #expect(snapshot.item(for: .domains)?.children.isEmpty == true)
     }
@@ -705,9 +708,10 @@ struct PacketSourceListServiceTests {
             .snapshot(for: state)
             .filtered(matching: "chrome")
 
-        #expect(filtered.roots.map(\.title) == ["All"])
-        #expect(filtered.roots.first?.children.map(\.title) == ["Apps"])
-        #expect(filtered.roots.first?.children.first?.children.map(\.title) == ["Google Chrome"])
+        #expect(filtered.roots.map(\.title) == ["Capture", "All"])
+        #expect(filtered.roots[0].children.map(\.title) == ["Overview"])
+        #expect(filtered.roots[1].children.map(\.title) == ["Apps"])
+        #expect(filtered.roots[1].children.first?.children.map(\.title) == ["Google Chrome"])
     }
 
     private func makePacket(

--- a/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketTableMenuLogicTests.swift
@@ -135,6 +135,33 @@ struct PacketTableMenuLogicTests {
         #expect(row.text(for: .comment) == "First line Second line")
     }
 
+    @Test func dnsSummaryShowsOnlyTheQueryAndParsedAnswer() {
+        let query = PacketTableRow(packet: makePacket(
+            packetNumber: 1,
+            infoSummary: "Standard query 0x1234 A api.example.com",
+            transportHint: .dns
+        ))
+        let response = PacketTableRow(packet: makePacket(
+            packetNumber: 2,
+            infoSummary: "Standard query response 0x1234 A api.example.com A 203.0.113.8",
+            transportHint: .dns,
+            dnsResolutions: [DNSResolutionObservation(
+                domainName: "api.example.com",
+                ipAddress: "203.0.113.8",
+                timeToLive: 60
+            )]
+        ))
+        let uncommon = PacketTableRow(packet: makePacket(
+            packetNumber: 3,
+            infoSummary: "DNS retransmission",
+            transportHint: .dns
+        ))
+
+        #expect(query.summaryText == "A? api.example.com")
+        #expect(response.summaryText == "A api.example.com → 203.0.113.8")
+        #expect(uncommon.summaryText == "DNS retransmission")
+    }
+
     @Test func copyFormatterSupportsRowsAsFormatsForMultipleSelections() throws {
         let rows = [
             PacketTableRow(packet: makePacket(packetNumber: 1, infoSummary: "Hello, world | alpha")),
@@ -518,14 +545,16 @@ struct PacketTableMenuLogicTests {
         sniDomainName: String? = nil,
         client: PacketClient? = nil,
         customComment: String? = nil,
-        streamID: UInt32? = nil
+        streamID: UInt32? = nil,
+        transportHint: TransportProtocolHint = .tcp,
+        dnsResolutions: [DNSResolutionObservation]? = nil
     ) -> PacketSummary {
         PacketSummary(
             packetNumber: packetNumber,
             timestamp: Date(timeIntervalSince1970: TimeInterval(packetNumber)),
             source: .live,
             interfaceID: "en0",
-            transportHint: .tcp,
+            transportHint: transportHint,
             endpoints: PacketEndpoints(
                 source: PacketEndpoint(address: "10.0.0.1", port: 1234),
                 destination: PacketEndpoint(address: "10.0.0.2", port: 443)
@@ -539,6 +568,7 @@ struct PacketTableMenuLogicTests {
             decodeStatus: PacketDecodeStatus(kind: .complete),
             captureMetadata: PacketCaptureMetadata(linkType: .ethernet, isTruncated: false),
             sniDomainName: sniDomainName,
+            dnsResolutions: dnsResolutions,
             client: client,
             customComment: customComment
         )

--- a/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SavedPacketServiceTests.swift
@@ -106,6 +106,34 @@ struct SavedPacketServiceTests {
         #expect(reloaded.records()[1].packet.customComment == nil)
     }
 
+    @Test func chunkedPacketLookupBuildsTheSavedIndexOnceUntilRecordsChange() {
+        let service = SavedPacketService(storageURL: temporaryDirectory().appendingPathComponent("Saved.json"))
+        let records = (1...4_097).map { value in
+            SavedPacketRecord(
+                id: "saved-\(value)",
+                savedAt: Date(timeIntervalSince1970: TimeInterval(value)),
+                backingIdentity: "capture",
+                packet: makePacket(packetNumber: UInt64(value))
+            )
+        }
+        service.useDocumentRecords(records)
+
+        let packetIDs = records.map { $0.packet.id }
+        let first = service.packets(withIDs: Array(packetIDs[0..<2_048]))
+        let second = service.packets(withIDs: Array(packetIDs[2_048..<4_096]))
+        let third = service.packets(withIDs: Array(packetIDs[4_096...]))
+
+        #expect(first.count == 2_048)
+        #expect(second.count == 2_048)
+        #expect(third.count == 1)
+        #expect(third.first?.id == packetIDs.last)
+        #expect(service.packetLookupIndexBuildCount == 1)
+
+        service.useDocumentRecords(Array(records.prefix(1)))
+        #expect(service.packet(withID: packetIDs[0])?.id == packetIDs[0])
+        #expect(service.packetLookupIndexBuildCount == 2)
+    }
+
     private func temporaryDirectory() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -150,6 +150,42 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
+    @Test func captureOverviewIsFirstAlwaysExpandedAndHasNoPacketContextActions() async throws {
+        let controller = SidebarViewController()
+        let selectionRecorder = SidebarSelectionRecorder()
+        controller.delegate = selectionRecorder
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: PacketSourceListSnapshot.empty.filtered(matching: "no-match"),
+            selectedSelection: .allPackets,
+            packetMutation: .none,
+            filterText: "no-match",
+            workspaceMode: .overview
+        ))
+
+        let outlineView = try #require(findOutlineScrollView(in: controller.view)?.documentView as? NSOutlineView)
+        let captureRow = try #require(row(withItemID: PacketSourceListTreeBuilder.captureGroupID, in: outlineView))
+        let overviewRow = try #require(row(withItemID: PacketSourceListTreeBuilder.overviewItemID, in: outlineView))
+        let captureItem = try #require(outlineView.item(atRow: captureRow))
+        let menu = try #require(outlineView.menu)
+
+        #expect(captureRow == 0)
+        #expect(outlineView.isItemExpanded(captureItem))
+        #expect(!controller.outlineView(outlineView, shouldCollapseItem: captureItem))
+        #expect(outlineView.selectedRow == overviewRow)
+
+        await Task.yield()
+        controller.outlineViewSelectionDidChange(Notification(
+            name: NSOutlineView.selectionDidChangeNotification,
+            object: outlineView
+        ))
+        controller.menuNeedsUpdate(menu)
+
+        #expect(selectionRecorder.selectedWorkspaceModes == [.overview])
+        #expect(menu.items.isEmpty)
+    }
+
+    @MainActor
     @Test func sidebarContextMenuPlacesPinFirstAndShowInFinderAboveDelete() throws {
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
         let controller = SidebarViewController()
@@ -509,7 +545,9 @@ struct SidebarOutlineReloadPolicyTests {
     private func makeSnapshot(
         sourceListSnapshot: PacketSourceListSnapshot,
         selectedSelection: PacketSourceListSelection,
-        packetMutation: PacketIngestMutation
+        packetMutation: PacketIngestMutation,
+        filterText: String = "",
+        workspaceMode: NetworkInspectorWorkspaceMode = .packets
     ) -> NetworkInspectorSnapshot {
         var base = TCPViewerWindowSnapshot.foundation
         base.packetIngestState.lastMutation = packetMutation
@@ -527,8 +565,8 @@ struct SidebarOutlineReloadPolicyTests {
             selectedSidebar: .liveCapture,
             selectedSourceListSelection: selectedSelection,
             sourceListSnapshot: sourceListSnapshot,
-            sourceListFilterText: "",
-            workspaceMode: .packets,
+            sourceListFilterText: filterText,
+            workspaceMode: workspaceMode,
             inspectorTab: .summary,
             isInspectorVisible: true,
             displayFilterText: "",
@@ -591,10 +629,18 @@ struct SidebarOutlineReloadPolicyTests {
 private final class SidebarSelectionRecorder: SidebarViewControllerDelegate {
     var selectedSelection: PacketSourceListSelection?
     var selectedSelections: [PacketSourceListSelection?] = []
+    var selectedWorkspaceModes: [NetworkInspectorWorkspaceMode] = []
 
     func sidebarViewController(_ controller: SidebarViewController, didSelect selection: PacketSourceListSelection?) {
         selectedSelection = selection
         selectedSelections.append(selection)
+    }
+
+    func sidebarViewController(
+        _ controller: SidebarViewController,
+        didSelectWorkspaceMode mode: NetworkInspectorWorkspaceMode
+    ) {
+        selectedWorkspaceModes.append(mode)
     }
 
     func sidebarViewController(_ controller: SidebarViewController, didUpdateFilterText text: String) {}

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -150,7 +150,7 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
-    @Test func captureOverviewIsFirstAlwaysExpandedAndHasNoPacketContextActions() async throws {
+    @Test func captureOverviewIsFirstInitiallyExpandedAndHasNoPacketContextActions() async throws {
         let controller = SidebarViewController()
         let selectionRecorder = SidebarSelectionRecorder()
         controller.delegate = selectionRecorder
@@ -171,7 +171,6 @@ struct SidebarOutlineReloadPolicyTests {
 
         #expect(captureRow == 0)
         #expect(outlineView.isItemExpanded(captureItem))
-        #expect(!controller.outlineView(outlineView, shouldCollapseItem: captureItem))
         #expect(outlineView.selectedRow == overviewRow)
 
         await Task.yield()
@@ -183,6 +182,34 @@ struct SidebarOutlineReloadPolicyTests {
 
         #expect(selectionRecorder.selectedWorkspaceModes == [.overview])
         #expect(menu.items.isEmpty)
+    }
+
+    @MainActor
+    @Test func collapsedCaptureGroupStaysCollapsedAfterSidebarRefresh() throws {
+        let controller = SidebarViewController()
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: .empty,
+            selectedSelection: .allPackets,
+            packetMutation: .none
+        ))
+
+        let outlineView = try #require(findOutlineScrollView(in: controller.view)?.documentView as? NSOutlineView)
+        let captureRow = try #require(row(withItemID: PacketSourceListTreeBuilder.captureGroupID, in: outlineView))
+        let captureItem = try #require(outlineView.item(atRow: captureRow))
+        outlineView.collapseItem(captureItem)
+        #expect(!outlineView.isItemExpanded(captureItem))
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithApp(),
+            selectedSelection: .allPackets,
+            packetMutation: .replace
+        ))
+
+        let refreshedCaptureRow = try #require(row(withItemID: PacketSourceListTreeBuilder.captureGroupID, in: outlineView))
+        let refreshedCaptureItem = try #require(outlineView.item(atRow: refreshedCaptureRow))
+        #expect(!outlineView.isItemExpanded(refreshedCaptureItem))
+        #expect(row(withItemID: PacketSourceListTreeBuilder.overviewItemID, in: outlineView) == nil)
     }
 
     @MainActor

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -213,6 +213,38 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
+    @Test func repeatedStartupRendersKeepDefaultGroupsExpanded() throws {
+        let controller = SidebarViewController()
+        controller.loadViewIfNeeded()
+        let startupSnapshot = makeSnapshot(
+            sourceListSnapshot: .empty,
+            selectedSelection: .allPackets,
+            packetMutation: .none
+        )
+
+        controller.render(snapshot: startupSnapshot)
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithApp(),
+            selectedSelection: .allPackets,
+            packetMutation: .replace
+        ))
+
+        let outlineView = try #require(findOutlineScrollView(in: controller.view)?.documentView as? NSOutlineView)
+        for itemID in [
+            PacketSourceListTreeBuilder.captureGroupID,
+            PacketSourceListTreeBuilder.favoritesGroupID,
+            PacketSourceListTreeBuilder.allGroupID,
+            PacketSourceListTreeBuilder.pinnedFolderID,
+            PacketSourceListTreeBuilder.appsFolderID,
+            PacketSourceListTreeBuilder.domainsFolderID,
+        ] {
+            let itemRow = try #require(row(withItemID: itemID, in: outlineView))
+            let item = try #require(outlineView.item(atRow: itemRow))
+            #expect(outlineView.isItemExpanded(item))
+        }
+    }
+
+    @MainActor
     @Test func sidebarContextMenuPlacesPinFirstAndShowInFinderAboveDelete() throws {
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
         let controller = SidebarViewController()

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -245,6 +245,39 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
+    @Test func revealingEndpointAppExpandsAncestorsAndSelectsItsRow() throws {
+        let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
+        let controller = SidebarViewController()
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithApp(),
+            selectedSelection: .saved,
+            packetMutation: .none
+        ))
+
+        let outlineView = try #require(findOutlineScrollView(in: controller.view)?.documentView as? NSOutlineView)
+        let allRow = try #require(row(withItemID: PacketSourceListTreeBuilder.allGroupID, in: outlineView))
+        let allItem = try #require(outlineView.item(atRow: allRow))
+        outlineView.collapseItem(allItem)
+
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithApp(),
+            selectedSelection: .app(appKey),
+            packetMutation: .replace
+        ))
+        controller.revealSourceListSelection(.app(appKey))
+
+        let appRow = try #require(row(withItemID: "app:\(appKey.rawValue)", in: outlineView))
+        let refreshedAllRow = try #require(row(withItemID: PacketSourceListTreeBuilder.allGroupID, in: outlineView))
+        let refreshedAllItem = try #require(outlineView.item(atRow: refreshedAllRow))
+        let appsRow = try #require(row(withItemID: PacketSourceListTreeBuilder.appsFolderID, in: outlineView))
+        let appsItem = try #require(outlineView.item(atRow: appsRow))
+        #expect(outlineView.isItemExpanded(refreshedAllItem))
+        #expect(outlineView.isItemExpanded(appsItem))
+        #expect(outlineView.selectedRow == appRow)
+    }
+
+    @MainActor
     @Test func sidebarContextMenuPlacesPinFirstAndShowInFinderAboveDelete() throws {
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
         let controller = SidebarViewController()

--- a/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/SidebarOutlineReloadPolicyTests.swift
@@ -245,6 +245,45 @@ struct SidebarOutlineReloadPolicyTests {
     }
 
     @MainActor
+    @Test func firstWindowAppearanceRestoresDefaultGroupsAfterAppKitCollapsesThem() throws {
+        let controller = SidebarViewController()
+        controller.loadViewIfNeeded()
+        controller.render(snapshot: makeSnapshot(
+            sourceListSnapshot: snapshotWithApp(),
+            selectedSelection: .allPackets,
+            packetMutation: .none
+        ))
+
+        let outlineView = try #require(findOutlineScrollView(in: controller.view)?.documentView as? NSOutlineView)
+        for itemID in [
+            PacketSourceListTreeBuilder.captureGroupID,
+            PacketSourceListTreeBuilder.favoritesGroupID,
+            PacketSourceListTreeBuilder.allGroupID,
+        ] {
+            let itemRow = try #require(row(withItemID: itemID, in: outlineView))
+            outlineView.collapseItem(outlineView.item(atRow: itemRow))
+        }
+
+        let window = NSWindow(contentViewController: controller)
+        window.makeKeyAndOrderFront(nil)
+        defer { window.close() }
+        controller.viewDidAppear()
+
+        for itemID in [
+            PacketSourceListTreeBuilder.captureGroupID,
+            PacketSourceListTreeBuilder.favoritesGroupID,
+            PacketSourceListTreeBuilder.allGroupID,
+            PacketSourceListTreeBuilder.pinnedFolderID,
+            PacketSourceListTreeBuilder.appsFolderID,
+            PacketSourceListTreeBuilder.domainsFolderID,
+        ] {
+            let itemRow = try #require(row(withItemID: itemID, in: outlineView))
+            let item = try #require(outlineView.item(atRow: itemRow))
+            #expect(outlineView.isItemExpanded(item))
+        }
+    }
+
+    @MainActor
     @Test func revealingEndpointAppExpandsAncestorsAndSelectsItsRow() throws {
         let appKey = PacketSourceClientKey(rawValue: "bundleIdentifier:com.example.App")
         let controller = SidebarViewController()

--- a/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
@@ -88,6 +88,7 @@ struct TCPViewSessionFormatTests {
             wiresharkExpression: "tls.handshake.extensions_server_name == \"example.com\"",
             selectedPacketID: packet.id,
             selectedSourceListSelection: selectedSource,
+            workspaceMode: .overview,
             tableColumnLayout: layout
         )
 
@@ -97,6 +98,7 @@ struct TCPViewSessionFormatTests {
         #expect(decoded.importedCaptureFiles == [importedFile])
         #expect(decoded.importedPacketReferenceByID[packet.id]?.originalPacketID == 1)
         #expect(decoded.selectedSourceListSelection?.selection() == selectedSource)
+        #expect(decoded.workspaceMode == NetworkInspectorWorkspaceMode.overview.rawValue)
         #expect(decoded.importedFileProvenance != nil)
         #expect(decoded.filterMode == .wireshark)
         #expect(decoded.wiresharkExpression == "tls.handshake.extensions_server_name == \"example.com\"")
@@ -657,6 +659,7 @@ struct TCPViewSessionFormatTests {
         wiresharkExpression: String? = nil,
         selectedPacketID: PacketSummary.ID? = nil,
         selectedSourceListSelection: PacketSourceListSelection = .allPackets,
+        workspaceMode: NetworkInspectorWorkspaceMode = .packets,
         tableColumnLayout: PacketTableColumnLayout? = nil
     ) -> TCPViewSessionExportSnapshot {
         TCPViewSessionExportSnapshot(
@@ -674,7 +677,7 @@ struct TCPViewSessionFormatTests {
             sourceListFilterText: "example",
             selectedPacketID: selectedPacketID,
             selectedSourceListSelection: selectedSourceListSelection,
-            workspaceMode: .packets,
+            workspaceMode: workspaceMode,
             inspectorTab: .detail,
             inspectorPlacement: .bottom,
             isInspectorVisible: true,


### PR DESCRIPTION
## Summary

- Add a Statistics > Endpoints menu entry
- Support filtering packet views by a selected endpoint
- Show the active endpoint filter in the workspace
- Cache saved-packet lookups for statistics consumers
- Preserve packet selection and filter state during asynchronous filtering

## Testing

Not run (not requested)