### PR TITLE
Reject unknown release arguments

### DIFF
--- a/scripts/nodejs/index.js
+++ b/scripts/nodejs/index.js
@@ -29,6 +29,9 @@ function parseArgs(argv) {
       args.homebrewInstallTested = true;
     } else if (arg === "--homebrew-only") {
       args.homebrewOnly = true;
+    } else {
+      const argumentName = arg.split("=", 1)[0];
+      throw new Error(`Unknown release argument: ${argumentName}`);
     }
   }
   return args;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1671,6 +1671,9 @@ function parseArgs(argv) {
       args.homebrewInstallTested = true;
     } else if (arg === "--homebrew-only") {
       args.homebrewOnly = true;
+    } else {
+      const argumentName = arg.split("=", 1)[0];
+      throw new Error(`Unknown release argument: ${argumentName}`);
     }
   }
   return args;

--- a/tests/release-args.test.mjs
+++ b/tests/release-args.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const releaseEntrypoints = [
+  "scripts/release.mjs",
+  "scripts/nodejs/index.js"
+];
+
+test("release entrypoints reject unknown arguments", async (t) => {
+  for (const entrypoint of releaseEntrypoints) {
+    await t.test(entrypoint, () => {
+      const result = spawnSync(
+        process.execPath,
+        [entrypoint, "--definitely-unsupported=private-value", "--type=invalid"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8"
+        }
+      );
+
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /Unknown release argument: --definitely-unsupported/);
+      assert.doesNotMatch(result.stderr, /private-value/);
+      assert.doesNotMatch(result.stderr, /Release type must be/);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- reject unsupported arguments in both release entry points before loading release configuration or performing side effects
- report only the option name for `--flag=value` inputs so accidental values are not copied into diagnostics
- add regression coverage for the direct release script and compatibility launcher

## Problem

Both release argument parsers silently ignored unknown options. A misspelled release flag could therefore change the requested behavior without a clear error; for example, a typo in `--bump-homebrew` during a non-interactive run would be discarded and the Homebrew update would be skipped.

## Root cause

Each parser handled recognized arguments but had no final rejection branch. Unmatched arguments fell through the loop.

## Fix

Fail immediately when an argument does not match the supported option set. For options written as `--name=value`, the error includes `--name` but omits the value. Valid release options and defaults are unchanged.

## Security considerations

Release commands run with signing, publishing, and repository credentials. Failing before configuration loading and external operations keeps malformed invocations on a side-effect-free path. Redacting the value portion of unknown options avoids reflecting a potentially sensitive accidental value into logs.

## Validation

- `node --test tests/release-args.test.mjs` (3 passed)
- `npm test` (24 passed)
- `npm --prefix scripts/nodejs test` (passed)
- `node --check scripts/release.mjs` (passed)
- `node --check tests/release-args.test.mjs` (passed)
- `git diff --check upstream/main...HEAD` (passed)

The macOS application build and Xcode test suites were not run because this change only affects the Node release entry points and their tests.

## Compatibility

Recognized command-line options retain their existing behavior. Previously ignored invalid options now exit with status 1 and an actionable error. There are no application, SDK, capture-format, or persisted-state changes.

## AI assistance

OpenAI Codex assisted with repository inspection, implementation, and test preparation. I reviewed the diff and test results and take responsibility for the change.