### PR TITLE
Persist utility window positions and associate the helper daemon

### DIFF
--- a/NetworkHelperLaunchDaemons/com.proxyman.tcpviewer.helpertool.plist
+++ b/NetworkHelperLaunchDaemons/com.proxyman.tcpviewer.helpertool.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>Label</key>
 	<string>com.proxyman.tcpviewer.helpertool</string>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.proxyman.tcpviewer</string>
+	</array>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>

--- a/TCPViewer/App/About/TCPViewerAboutWindowController.swift
+++ b/TCPViewer/App/About/TCPViewerAboutWindowController.swift
@@ -9,6 +9,8 @@ import AppKit
 import SwiftUI
 
 final class TCPViewerAboutWindowController: NSWindowController {
+    private static let frameAutosaveName = "TCPViewer.AboutWindow"
+
     init(info: TCPViewerAboutInfo = .current) {
         let hostingController = NSHostingController(rootView: TCPViewerAboutView(info: info))
         let window = NSWindow(contentViewController: hostingController)
@@ -32,6 +34,7 @@ final class TCPViewerAboutWindowController: NSWindowController {
         window.standardWindowButton(.closeButton)?.isEnabled = true
 
         super.init(window: window)
+        TCPViewerUI.restoreWindowFrameOrCenter(window, autosaveName: Self.frameAutosaveName)
     }
 
     @available(*, unavailable)

--- a/TCPViewer/App/Settings/TCPViewerSettingsWindowController.swift
+++ b/TCPViewer/App/Settings/TCPViewerSettingsWindowController.swift
@@ -9,6 +9,8 @@ import AppKit
 import SwiftUI
 
 final class TCPViewerSettingsWindowController: NSWindowController {
+    private static let frameAutosaveName = "TCPViewer.SettingsWindow"
+
     private let tabViewController = TCPViewerSettingsTabViewController()
     private var tabChromeHeight: CGFloat = 112
 
@@ -68,6 +70,8 @@ final class TCPViewerSettingsWindowController: NSWindowController {
         tabViewController.onSelectionChanged = { [weak self] in
             self?.resizeWindowToSelectedTab()
         }
+        resizeWindowToSelectedTab()
+        TCPViewerUI.restoreWindowFrameOrCenter(window, autosaveName: Self.frameAutosaveName)
         resizeWindowToSelectedTab()
     }
 

--- a/TCPViewer/Core/AppKitUIUtilities.swift
+++ b/TCPViewer/Core/AppKitUIUtilities.swift
@@ -123,6 +123,14 @@ enum TCPViewerUI {
             view.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -insets.bottom),
         ])
     }
+
+    // Fixed-size windows need a forced restore before AppKit can autosave later moves.
+    static func restoreWindowFrameOrCenter(_ window: NSWindow, autosaveName: String) {
+        if !window.setFrameUsingName(autosaveName, force: true) {
+            window.center()
+        }
+        window.setFrameAutosaveName(autosaveName)
+    }
 }
 
 extension NSEdgeInsets {

--- a/TCPViewerTests/App/TCPViewerUIWindowPositioningTests.swift
+++ b/TCPViewerTests/App/TCPViewerUIWindowPositioningTests.swift
@@ -1,0 +1,70 @@
+//
+//  TCPViewerUIWindowPositioningTests.swift
+//  TCPViewer
+//
+//  Created by Proxyman LLC on 2/9/26.
+//
+
+import AppKit
+import Testing
+@testable import TCPViewer
+
+@MainActor
+struct TCPViewerUIWindowPositioningTests {
+    @Test func centersWindowWhenNoSavedFrameExists() {
+        let window = WindowPositioningSpy(restoresSavedFrame: false)
+
+        TCPViewerUI.restoreWindowFrameOrCenter(window, autosaveName: "Test.Window")
+
+        #expect(window.restoredFrameName == "Test.Window")
+        #expect(window.forcedFrameRestore)
+        #expect(window.centerCallCount == 1)
+        #expect(window.registeredAutosaveName == "Test.Window")
+    }
+
+    @Test func keepsRestoredPositionWhenSavedFrameExists() {
+        let window = WindowPositioningSpy(restoresSavedFrame: true)
+
+        TCPViewerUI.restoreWindowFrameOrCenter(window, autosaveName: "Test.Window")
+
+        #expect(window.restoredFrameName == "Test.Window")
+        #expect(window.forcedFrameRestore)
+        #expect(window.centerCallCount == 0)
+        #expect(window.registeredAutosaveName == "Test.Window")
+    }
+}
+
+@MainActor
+private final class WindowPositioningSpy: NSWindow {
+    private let restoresSavedFrame: Bool
+
+    private(set) var restoredFrameName: String?
+    private(set) var forcedFrameRestore = false
+    private(set) var centerCallCount = 0
+    private(set) var registeredAutosaveName: String?
+
+    init(restoresSavedFrame: Bool) {
+        self.restoresSavedFrame = restoresSavedFrame
+        super.init(
+            contentRect: .zero,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    override func setFrameUsingName(_ name: NSWindow.FrameAutosaveName, force: Bool) -> Bool {
+        restoredFrameName = name
+        forcedFrameRestore = force
+        return restoresSavedFrame
+    }
+
+    override func center() {
+        centerCallCount += 1
+    }
+
+    override func setFrameAutosaveName(_ name: NSWindow.FrameAutosaveName) -> Bool {
+        registeredAutosaveName = name
+        return true
+    }
+}

--- a/TCPViewerTests/Features/NetworkHelper/TCPViewerNetworkHelperToolManagerTests.swift
+++ b/TCPViewerTests/Features/NetworkHelper/TCPViewerNetworkHelperToolManagerTests.swift
@@ -194,6 +194,18 @@ struct TCPViewerNetworkHelperToolManagerTests {
         #expect(TCPViewerNetworkHelperConstants.displayName == "TCP Viewer Network Helper Tool")
     }
 
+    @Test func bundledLaunchDaemonIsAssociatedWithTCPViewerApp() throws {
+        let plistURL = Bundle.main.bundleURL.appendingPathComponent(
+            TCPViewerNetworkHelperConstants.bundledLaunchDaemonPlistRelativePath
+        )
+        let data = try Data(contentsOf: plistURL)
+        let plist = try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        #expect(plist["AssociatedBundleIdentifiers"] as? [String] == ["com.proxyman.tcpviewer"])
+    }
+
     @Test func smJobBlessStatusReportsNotFoundWhenBundledPayloadIsMissing() throws {
         let fixture = try makeBlessFixture()
         defer { try? FileManager.default.removeItem(at: fixture.rootURL) }


### PR DESCRIPTION
## Summary

- Restore and autosave About and Settings window positions.
- Center windows when no saved frame exists.
- Associate the network helper launch daemon with TCPViewer.

## Testing

- Added Swift Testing coverage for window positioning and launch daemon association.
- Not run (not requested).