### PR TITLE
Separate decode-issue filtering from protocol selection

### DIFF
--- a/TCPViewer/Features/NetworkInspector/Models/PacketQuickFilterModels.swift
+++ b/TCPViewer/Features/NetworkInspector/Models/PacketQuickFilterModels.swift
@@ -18,6 +18,7 @@ enum PacketQuickFilterID: String, CaseIterable, Codable, Identifiable, Sendable,
     case websocket
     case clientHello
     case serverHello
+    // Keep the stored identifier so existing capture sessions retain their decode-issue selection.
     case errors
 
     var id: String { rawValue }
@@ -43,14 +44,14 @@ enum PacketQuickFilterID: String, CaseIterable, Codable, Identifiable, Sendable,
         case .serverHello:
             "Server Hello"
         case .errors:
-            "Errors"
+            "Decode issues"
         }
     }
 
     var toolTip: String {
         switch self {
         case .all:
-            "Show all packets"
+            "Show all protocols, keeping the troubleshooting selection"
         case .tcp:
             "Show packets that include TCP, including HTTP, TLS, and WebSocket over TCP"
         case .udp:
@@ -112,6 +113,10 @@ struct PacketQuickFilterSelection: Codable, Equatable, Sendable, Hashable {
         PacketQuickFilterID.allCases.filter { $0 != .all && selectedIDs.contains($0) }
     }
 
+    var activeProtocolIDs: [PacketQuickFilterID] {
+        activeIDs.filter { $0 != .errors }
+    }
+
     var activeLabels: [String] {
         activeIDs.map(\.title)
     }
@@ -121,12 +126,13 @@ struct PacketQuickFilterSelection: Codable, Equatable, Sendable, Hashable {
     }
 
     func contains(_ id: PacketQuickFilterID) -> Bool {
-        selectedIDs.contains(id)
+        id == .all ? activeProtocolIDs.isEmpty : selectedIDs.contains(id)
     }
 
+    // All clears only the protocol group; troubleshooting stays active until explicitly cleared.
     func toggled(_ id: PacketQuickFilterID) -> PacketQuickFilterSelection {
         guard id != .all else {
-            return .all
+            return PacketQuickFilterSelection(selectedIDs: selectedIDs.intersection([.errors]))
         }
 
         var nextIDs = Set(activeIDs)
@@ -169,14 +175,15 @@ final class PacketQuickFilterService {
         self.selection = selection
     }
 
+    // Match any selected protocol, then require the independent troubleshooting condition.
     func matches(_ packet: PacketSummary, selection: PacketQuickFilterSelection? = nil) -> Bool {
         let selection = selection ?? self.selection
-        guard selection.isActive else {
-            return true
+        if selection.contains(.errors), !matches(packet, filterID: .errors) {
+            return false
         }
 
-        // Quick filters are OR-ed, so a packet can match any active filter chip.
-        return selection.activeIDs.contains { matches(packet, filterID: $0) }
+        let protocolIDs = selection.activeProtocolIDs
+        return protocolIDs.isEmpty || protocolIDs.contains { matches(packet, filterID: $0) }
     }
 
     private func matches(_ packet: PacketSummary, filterID: PacketQuickFilterID) -> Bool {

--- a/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
+++ b/TCPViewer/Features/NetworkInspector/Views/PacketQuickFilterViewController.swift
@@ -76,6 +76,8 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     weak var delegate: PacketQuickFilterViewControllerDelegate?
 
     private let stackView = NSStackView()
+    private let troubleshootingSeparator = NSBox()
+    private let troubleshootingButton = NSPopUpButton(frame: .zero, pullsDown: true)
     private let customSeparator = NSBox()
     private let resetSeparator = NSBox()
     private let bottomSeparator = NSBox()
@@ -86,6 +88,7 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
     private var customItemsByID: [PacketCustomFilter.ID: PacketCustomFilterItem] = [:]
     private var renderedQuickFilterIDs: [PacketQuickFilterID] = []
     private var renderedCustomFilterSignatures: [PacketCustomFilterButtonSignature] = []
+    private var isDecodeIssuesEnabled = false
 
     override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -124,6 +127,7 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
             }
             render(button: button, title: item.title, toolTip: item.id.toolTip, isSelected: item.isSelected)
         }
+        renderTroubleshooting(isEnabled: snapshot.quickFilterSelection.contains(.errors))
         for item in snapshot.customFilterItems {
             guard let button = customButtons[item.id] else {
                 continue
@@ -159,6 +163,10 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
         customSeparator.boxType = .separator
         customSeparator.translatesAutoresizingMaskIntoConstraints = false
 
+        troubleshootingSeparator.boxType = .separator
+        troubleshootingSeparator.translatesAutoresizingMaskIntoConstraints = false
+        configureTroubleshooting()
+
         bottomSeparator.boxType = .separator
         bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
 
@@ -181,6 +189,8 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
             stackView.topAnchor.constraint(equalTo: view.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomSeparator.topAnchor),
             customSeparator.heightAnchor.constraint(equalToConstant: 18),
+            troubleshootingSeparator.heightAnchor.constraint(equalToConstant: 18),
+            troubleshootingButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             resetSeparator.heightAnchor.constraint(equalToConstant: 18),
             resetButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             bottomSeparator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -209,7 +219,7 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
         renderedQuickFilterIDs = nextQuickFilterIDs
         renderedCustomFilterSignatures = nextCustomFilterSignatures
 
-        for item in items {
+        for item in items where item.id != .errors {
             let button = PacketQuickFilterButton(filterID: item.id, target: self, action: #selector(toggleFilter(_:)))
             configure(button: button, isToggle: true)
             buttons[item.id] = button
@@ -217,6 +227,9 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
             button.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight).isActive = true
             button.widthAnchor.constraint(greaterThanOrEqualToConstant: measuredWidth(for: item.title)).isActive = true
         }
+
+        stackView.addArrangedSubview(troubleshootingSeparator)
+        stackView.addArrangedSubview(troubleshootingButton)
 
         if !customItems.isEmpty {
             stackView.addArrangedSubview(customSeparator)
@@ -240,6 +253,53 @@ final class PacketQuickFilterViewController: NSTitlebarAccessoryViewController {
 
         stackView.addArrangedSubview(resetSeparator)
         stackView.addArrangedSubview(resetButton)
+    }
+
+    // Keep troubleshooting in a separate menu so it narrows the protocol chips instead of joining them.
+    private func configureTroubleshooting() {
+        configure(button: troubleshootingButton, isToggle: false)
+        troubleshootingButton.addItem(withTitle: "Troubleshooting")
+        let menu = troubleshootingButton.menu
+        menu?.autoenablesItems = false
+        for (index, title) in ["Off", PacketQuickFilterID.errors.title].enumerated() {
+            let item = NSMenuItem(title: title, action: #selector(selectTroubleshooting(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = index
+            item.toolTip = index == 0
+                ? "Show selected protocols without troubleshooting restrictions"
+                : PacketQuickFilterID.errors.toolTip
+            menu?.addItem(item)
+        }
+        troubleshootingButton.setAccessibilityLabel("Troubleshooting")
+        troubleshootingButton.widthAnchor.constraint(
+            greaterThanOrEqualToConstant: measuredWidth(for: "Troubleshooting") + 16
+        ).isActive = true
+    }
+
+    // Show the active condition on the control and expose its checked state in the menu.
+    private func renderTroubleshooting(isEnabled: Bool) {
+        isDecodeIssuesEnabled = isEnabled
+        let title = isEnabled ? PacketQuickFilterID.errors.title : "Troubleshooting"
+        troubleshootingButton.item(at: 0)?.title = title
+        troubleshootingButton.item(at: 1)?.state = isEnabled ? .off : .on
+        troubleshootingButton.item(at: 2)?.state = isEnabled ? .on : .off
+        render(
+            button: troubleshootingButton,
+            title: title,
+            toolTip: isEnabled
+                ? "Show only partial, malformed, unsupported, or truncated packets within the selected protocols"
+                : "Narrow the selected protocols to packets with decode issues",
+            isSelected: isEnabled
+        )
+        troubleshootingButton.setAccessibilityValue(isEnabled ? PacketQuickFilterID.errors.title : "Off")
+    }
+
+    // Selecting the already checked item leaves the current filter unchanged.
+    @objc private func selectTroubleshooting(_ sender: NSMenuItem) {
+        guard (sender.tag == 1) != isDecodeIssuesEnabled else {
+            return
+        }
+        delegate?.packetQuickFilterViewController(self, didToggle: .errors)
     }
 
     private func configure(button: NSButton, isToggle: Bool) {

--- a/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/NetworkInspectorViewModelTests.swift
@@ -3727,6 +3727,79 @@ struct NetworkInspectorViewModelTests {
         #expect(viewModel.snapshot.quickFilterSelection.selectedIDs == [.all])
     }
 
+    // Troubleshooting remains an intersection with protocol, app, and structured filters.
+    @Test func decodeIssuesCombineWithProtocolAndSourceFilters() async {
+        let client = makeClient(displayName: "Example", bundleIdentifier: "com.example.app")
+        let packets = [
+            makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, destinationPort: 443, streamID: nil, client: client),
+            makePacket(packetNumber: 2, source: .offline, transportHint: .tcp, destinationPort: 443, streamID: nil,
+                       decodeStatus: PacketDecodeStatus(kind: .partial), client: client),
+            makePacket(packetNumber: 3, source: .offline, transportHint: .udp, destinationPort: 443, streamID: nil,
+                       decodeStatus: PacketDecodeStatus(kind: .malformed), client: client),
+            makePacket(packetNumber: 4, source: .offline, transportHint: .tcp, destinationPort: 443, streamID: nil,
+                       decodeStatus: PacketDecodeStatus(kind: .partial)),
+            makePacket(packetNumber: 5, source: .offline, transportHint: .tcp, destinationPort: 80, streamID: nil,
+                       decodeStatus: PacketDecodeStatus(kind: .partial), client: client),
+        ]
+        let viewModel = makeOfflineViewModel(packets: packets)
+
+        await viewModel.openDocument(at: URL(fileURLWithPath: "/tmp/decode-issues-combined.pcapng"))
+        await waitUntil { viewModel.snapshot.packetRows.count == packets.count }
+
+        viewModel.selectSourceList(.apps)
+        viewModel.updateDisplayFilterText("port:443")
+        viewModel.toggleQuickFilter(.tcp)
+        viewModel.toggleQuickFilter(.errors)
+
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[1].id])
+        #expect(viewModel.snapshot.activeFilterBarLabels == ["TCP", "Decode issues"])
+        #expect(viewModel.snapshot.selectedPacket?.id == packets[1].id)
+
+        viewModel.toggleQuickFilter(.all)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[1].id, packets[2].id])
+        #expect(viewModel.snapshot.quickFilterItems.first { $0.id == .all }?.isSelected == true)
+        #expect(viewModel.snapshot.quickFilterSelection.contains(.errors))
+
+        viewModel.resetQuickFilters()
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [packets[0].id, packets[1].id, packets[2].id])
+        #expect(!viewModel.snapshot.isQuickFilterResetVisible)
+    }
+
+    // Live appends must use the same protocol-and-issue predicate as the initial table build.
+    @Test func decodeIssuesFilterLiveAppendsWithinSelectedProtocols() async {
+        let healthyTCP = makePacket(packetNumber: 1, source: .live, transportHint: .tcp, streamID: nil)
+        let partialTCP = makePacket(packetNumber: 2, source: .live, transportHint: .tcp, streamID: nil,
+                                    decodeStatus: PacketDecodeStatus(kind: .partial))
+        let malformedUDP = makePacket(packetNumber: 3, source: .live, transportHint: .udp, streamID: nil,
+                                      decodeStatus: PacketDecodeStatus(kind: .malformed))
+        let laterTCP = makePacket(packetNumber: 4, source: .live, transportHint: .tcp, streamID: nil,
+                                  decodeStatus: PacketDecodeStatus(kind: .malformed))
+        let liveSession = InspectorFakeLiveSession()
+        let viewModel = NetworkInspectorViewModel(
+            services: TCPViewerServiceRegistry(core: InspectorFakeCore(
+                interfaces: [makeInterface(id: "en0", displayName: "Wi-Fi")],
+                liveSession: liveSession
+            )),
+            userDefaults: isolatedDefaults()
+        )
+
+        await viewModel.performInitialLoadIfNeeded()
+        viewModel.toggleQuickFilter(.tcp)
+        viewModel.toggleQuickFilter(.errors)
+        await viewModel.toggleLiveCapture()
+        liveSession.send(.liveStateChanged(phase: .running, message: "Capture running."))
+        liveSession.send(.packetBatch([healthyTCP, partialTCP, malformedUDP], disposition: .append))
+        await waitUntil { viewModel.snapshot.totalPacketCount == 3 }
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [partialTCP.id])
+
+        liveSession.send(.packetBatch([laterTCP], disposition: .append))
+        await waitUntil { viewModel.snapshot.totalPacketCount == 4 }
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [partialTCP.id, laterTCP.id])
+
+        viewModel.toggleQuickFilter(.errors)
+        #expect(viewModel.snapshot.packetRows.map(\.id) == [healthyTCP.id, partialTCP.id, laterTCP.id])
+    }
+
     @Test func quickFilterResetRestoresAllRowsWhenOnlyQuickFiltersAreActive() async {
         let packets = [
             makePacket(packetNumber: 1, source: .offline, transportHint: .tcp, streamID: nil, layerNames: ["Ethernet", "TCP"]),

--- a/TCPViewerTests/Features/NetworkInspector/PacketQuickFilterServiceTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/PacketQuickFilterServiceTests.swift
@@ -45,6 +45,66 @@ struct PacketQuickFilterServiceTests {
         #expect(!service.matches(arpPacket))
     }
 
+    // Decode issues narrow the protocol union instead of admitting unrelated or healthy packets.
+    @Test func decodeIssuesIntersectSelectedProtocols() {
+        let service = PacketQuickFilterService(selection: PacketQuickFilterSelection(selectedIDs: [.tcp, .udp, .errors]))
+        let packets = [
+            makePacket(packetNumber: 1, transportHint: .tcp, layers: ["TCP"]),
+            makePacket(packetNumber: 2, transportHint: .udp, layers: ["UDP"]),
+            makePacket(packetNumber: 3, transportHint: .tcp, layers: ["TCP"], decodeStatus: PacketDecodeStatus(kind: .partial)),
+            makePacket(packetNumber: 4, transportHint: .udp, layers: ["UDP"], decodeStatus: PacketDecodeStatus(kind: .malformed)),
+            makePacket(packetNumber: 5, transportHint: .arp, layers: ["ARP"], decodeStatus: PacketDecodeStatus(kind: .unsupported)),
+            makePacket(packetNumber: 6, transportHint: .tcp, layers: ["TCP"], isTruncated: true),
+        ]
+
+        #expect(packets.filter { service.matches($0) }.map(\.packetNumber) == [3, 4, 6])
+
+        service.toggle(.udp)
+        #expect(packets.filter { service.matches($0) }.map(\.packetNumber) == [3, 6])
+
+        service.toggle(.errors)
+        #expect(packets.filter { service.matches($0) }.map(\.packetNumber) == [1, 3, 6])
+    }
+
+    // All changes only protocols, while Reset Filters clears both independent selections.
+    @Test func allProtocolsPreservesDecodeIssuesUntilReset() {
+        let service = PacketQuickFilterService(selection: PacketQuickFilterSelection(selectedIDs: [.tcp, .errors]))
+        let issue = makePacket(packetNumber: 1, transportHint: .arp, layers: ["ARP"], decodeStatus: PacketDecodeStatus(kind: .unsupported))
+        let healthy = makePacket(packetNumber: 2, transportHint: .tcp, layers: ["TCP"])
+
+        service.toggle(.all)
+
+        #expect(service.selection.contains(.errors))
+        #expect(service.items().first { $0.id == .all }?.isSelected == true)
+        #expect(service.selection.isActive)
+        #expect(service.matches(issue))
+        #expect(!service.matches(healthy))
+
+        service.toggle(.tcp)
+        #expect(!service.selection.contains(.all))
+        service.toggle(.tcp)
+        #expect(service.selection.contains(.all))
+        #expect(service.selection.contains(.errors))
+
+        service.reset()
+        #expect(service.selection == .all)
+        #expect(!service.selection.isActive)
+        #expect(service.matches(healthy))
+    }
+
+    // Existing session files retain their saved troubleshooting selection after the label changes.
+    @Test func legacyErrorsSelectionSurvivesCodingAndUsesIntersection() throws {
+        let data = Data(#"{"selectedIDs":["tcp","errors"]}"#.utf8)
+        let selection = try JSONDecoder().decode(PacketQuickFilterSelection.self, from: data)
+        let restored = try JSONDecoder().decode(PacketQuickFilterSelection.self, from: JSONEncoder().encode(selection))
+        let service = PacketQuickFilterService(selection: restored)
+
+        #expect(restored == selection)
+        #expect(restored.activeLabels == ["TCP", "Decode issues"])
+        #expect(!service.matches(makePacket(packetNumber: 1, transportHint: .tcp, layers: ["TCP"])))
+        #expect(service.matches(makePacket(packetNumber: 2, transportHint: .tcp, layers: ["TCP"], isTruncated: true)))
+    }
+
     @Test func quickFilterPredicatesMatchRepresentativePackets() {
         let service = PacketQuickFilterService()
         let httpOverTCP = makePacket(packetNumber: 1, transportHint: .http1, layers: ["Ethernet", "TCP", "HTTP Request"])

--- a/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
+++ b/TCPViewerTests/Features/NetworkInspector/TCPViewSessionFormatTests.swift
@@ -82,7 +82,7 @@ struct TCPViewSessionFormatTests {
             pins: [pin],
             savedPackets: [savedRecord],
             customFilters: [customFilter],
-            quickFilterSelection: PacketQuickFilterSelection(selectedIDs: [.tcp, .dns]),
+            quickFilterSelection: PacketQuickFilterSelection(selectedIDs: [.tcp, .dns, .errors]),
             structuredFilterGroup: structuredGroup,
             filterMode: .wireshark,
             wiresharkExpression: "tls.handshake.extensions_server_name == \"example.com\"",


### PR DESCRIPTION
## Summary

- Add a dedicated Troubleshooting menu for decode-issue filtering.
- Keep the existing `errors` identifier for session compatibility while renaming it to Decode issues.
- Make All preserve the active troubleshooting condition and apply it as an intersection with protocol filters.
- Add coverage for combined filters, live capture appends, reset behavior, and legacy session decoding.

## Testing

- Not run (not requested)